### PR TITLE
feat: make chat sidebar collapsible on desktop

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -130,19 +130,23 @@ This document outlines the phased implementation strategy for the AI Agent Text 
 
 **Goal:** Provide the agent with reference material via workspace documents.
 
-### Phase 10a: Docs UI
-- [ ] Add `SupportingDocsContext` with `localStorage` persistence.
-- [ ] Build `ReferenceTab` (doc list, inline editor, auto-save) and add it to the sidebar.
-- **Working State:** The user can create, edit, and delete reference documents in the sidebar. Documents survive a page reload.
+### Phase 10a: Docs UI ✅
+
+- [x] Add `SupportingDocsContext` with `localStorage` persistence.
+- [x] Build `ReferenceTab` (doc list, inline editor, auto-save) as a collapsible left drawer.
+- **Working State:** The user can create, edit, and delete reference documents in a collapsible left panel. Documents survive a page reload.
 
 ### Phase 10b: Basic read tools
+
 - [ ] Implement `list_supporting_docs` and `read_supporting_doc` in the tool registry.
 - **Working State:** The agent can list and read documents directly.
 
 ### Phase 10c: Single-doc query
+
 - [ ] Implement `query_supporting_doc`: delegates to a short-lived sub-agent that reads one doc and returns a focused summary.
 - **Working State:** The agent can ask a focused question about a specific document without the full content entering its context.
 
 ### Phase 10d: Multi-doc synthesis
+
 - [ ] Implement `query_supporting_docs`: calls `query_supporting_doc` for each doc, then passes the summaries to a synthesizer sub-agent.
 - **Working State:** The agent can query across the entire workspace in a single tool call and receive a synthesized answer.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -130,7 +130,19 @@ This document outlines the phased implementation strategy for the AI Agent Text 
 
 **Goal:** Provide the agent with reference material via workspace documents.
 
-- [ ] Extend global state to manage a list of supporting markdown documents (title + content) synced with `localStorage`.
-- [ ] Build a UI (e.g., a "Reference" tab in the sidebar) for the user to create, edit, and delete these documents.
+### Phase 10a: Docs UI
+- [ ] Add `SupportingDocsContext` with `localStorage` persistence.
+- [ ] Build `ReferenceTab` (doc list, inline editor, auto-save) and add it to the sidebar.
+- **Working State:** The user can create, edit, and delete reference documents in the sidebar. Documents survive a page reload.
+
+### Phase 10b: Basic read tools
 - [ ] Implement `list_supporting_docs` and `read_supporting_doc` in the tool registry.
-- **Working State:** The user can manage reference notes. The agent can be asked to "check my notes on character X" and successfully use the tools to retrieve the information before making edits to the main text.
+- **Working State:** The agent can list and read documents directly.
+
+### Phase 10c: Single-doc query
+- [ ] Implement `query_supporting_doc`: delegates to a short-lived sub-agent that reads one doc and returns a focused summary.
+- **Working State:** The agent can ask a focused question about a specific document without the full content entering its context.
+
+### Phase 10d: Multi-doc synthesis
+- [ ] Implement `query_supporting_docs`: calls `query_supporting_doc` for each doc, then passes the summaries to a synthesizer sub-agent.
+- **Working State:** The agent can query across the entire workspace in a single tool call and receive a synthesized answer.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -146,12 +146,13 @@ Phases 10b, 10c, and 10d have been superseded by the Workspaces feature (Phase 1
 
 **Goal:** Replace the single-document model with named, persistent multi-document workspaces. Users can create, open, and delete workspaces; within a workspace any document can be edited and all are available to the agent. See `WORKSPACES_PLAN.md` for full details.
 
-### Phase 11a: Data model & context
+### Phase 11a: Data model & context ✅
 
-- [ ] Define `WorkspaceMeta`, `WorkspaceDocument`, `WorkspaceData` types; create `WorkspacesContext` with per-workspace localStorage persistence.
-- [ ] Migrate `SupportingDocsContext` data into a default workspace; remove `SupportingDocsContext`.
-- [ ] Bind `EditorPanel` to the active workspace document (replaces `AppState.editorContent`).
+- [x] Define `WorkspaceMeta`, `WorkspaceDocument`, `WorkspaceData` types; create `WorkspacesContext` with per-workspace localStorage persistence.
+- [x] Migrate `SupportingDocsContext` data into a default workspace; remove `SupportingDocsContext`.
+- [x] Bind `EditorPanel` to the active workspace document (replaces `AppState.editorContent`).
 - **Working State:** The editor reads/writes the active workspace document. Documents survive reload. Existing supporting docs are migrated.
+- [x] Complete
 
 ### Phase 11b: Workspace picker
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -136,17 +136,36 @@ This document outlines the phased implementation strategy for the AI Agent Text 
 - [x] Build `ReferenceTab` (doc list, inline editor, auto-save) as a collapsible left drawer.
 - **Working State:** The user can create, edit, and delete reference documents in a collapsible left panel. Documents survive a page reload.
 
-### Phase 10b: Basic read tools
+### Phase 10b–10d: Superseded
 
-- [ ] Implement `list_supporting_docs` and `read_supporting_doc` in the tool registry.
-- **Working State:** The agent can list and read documents directly.
+Phases 10b, 10c, and 10d have been superseded by the Workspaces feature (Phase 11). See `WORKSPACES_PLAN.md`.
 
-### Phase 10c: Single-doc query
+---
 
-- [ ] Implement `query_supporting_doc`: delegates to a short-lived sub-agent that reads one doc and returns a focused summary.
-- **Working State:** The agent can ask a focused question about a specific document without the full content entering its context.
+## Phase 11: Workspaces
 
-### Phase 10d: Multi-doc synthesis
+**Goal:** Replace the single-document model with named, persistent multi-document workspaces. Users can create, open, and delete workspaces; within a workspace any document can be edited and all are available to the agent. See `WORKSPACES_PLAN.md` for full details.
 
-- [ ] Implement `query_supporting_docs`: calls `query_supporting_doc` for each doc, then passes the summaries to a synthesizer sub-agent.
-- **Working State:** The agent can query across the entire workspace in a single tool call and receive a synthesized answer.
+### Phase 11a: Data model & context
+
+- [ ] Define `WorkspaceMeta`, `WorkspaceDocument`, `WorkspaceData` types; create `WorkspacesContext` with per-workspace localStorage persistence.
+- [ ] Migrate `SupportingDocsContext` data into a default workspace; remove `SupportingDocsContext`.
+- [ ] Bind `EditorPanel` to the active workspace document (replaces `AppState.editorContent`).
+- **Working State:** The editor reads/writes the active workspace document. Documents survive reload. Existing supporting docs are migrated.
+
+### Phase 11b: Workspace picker
+
+- [ ] Build `WorkspacePicker`: list all workspaces with open/rename/delete; "New Workspace" button with name prompt.
+- [ ] Add "Switch Workspace" button in the editor header; show `WorkspacePicker` when no workspace is active.
+- **Working State:** Users can create named workspaces, switch between them, and delete them.
+
+### Phase 11c: Document navigator
+
+- [ ] Replace `ReferenceTab` with `WorkspacePanel`: doc list scoped to the active workspace, create/rename/delete, click to activate.
+- **Working State:** Users can manage multiple documents within a workspace and switch between them in the editor.
+
+### Phase 11d: Agent workspace tools
+
+- [ ] Implement `list_workspace_docs`, `read_workspace_doc`, `query_workspace_doc`, `query_workspace` in `WorkspaceTools.ts`.
+- [ ] Wire tools in `App.tsx`; update agent system prompt.
+- **Working State:** The agent can list, read, and query any document in the active workspace.

--- a/docs/PHASE_10_PLAN.md
+++ b/docs/PHASE_10_PLAN.md
@@ -1,0 +1,223 @@
+# Phase 10 Implementation Plan: Supporting Documents Workspace
+
+## Goal
+
+Give users a place to store reference notes (character sheets, style guides, outlines, research) and give the agent tools to query them without loading every document into the context window.
+
+---
+
+## Architecture overview
+
+```
+localStorage["supporting_docs"]  →  SupportingDocsContext
+│   list: [{ id, title, content }]
+│   exposes: docs, addDoc, updateDoc, deleteDoc
+│
+├── Sidebar "Reference" tab
+│   ├── DocList — title + delete button per entry
+│   ├── DocEditor — inline title + Monaco/textarea for editing content
+│   └── "New Document" button
+│
+└── Tool Registry
+    ├── list_supporting_docs   → returns [{id, title}] only
+    ├── read_supporting_doc    → returns full content of one doc by ID
+    ├── query_supporting_doc   → queries a single doc; sub-agent reads
+                                  the doc and returns a focused summary
+    └── query_supporting_docs  → calls query_supporting_doc for each doc,
+                                  then a synthesizer agent combines the
+                                  summaries into one answer
+```
+
+---
+
+## Key design decision: sub-agent delegation for doc queries
+
+The naive implementation would return all document content to the main agent. For a workspace with several large notes this floods the context with irrelevant material.
+
+There are two layers of sub-agent delegation:
+
+1. **`query_supporting_doc` (singular)** — given a doc ID and a query, spins up a sub-agent that reads the single document and returns a focused summary of what's relevant to the query.
+2. **`query_supporting_docs` (plural)** — calls `list_supporting_docs` to enumerate all docs, then calls `query_supporting_doc` for each one (collecting per-doc summaries), and finally passes all summaries to a synthesizer sub-agent that produces a single coherent answer.
+
+```
+Main agent
+  → calls query_supporting_docs(query="what are the traits of character X?")
+       │
+       ├─ calls list_supporting_docs()  →  [{id: "1", title: "Character Notes"}, ...]
+       │
+       ├─ calls query_supporting_doc(id="1", query="...")
+       │     └─ Doc sub-agent: reads doc, returns "Character X is brave and..."
+       │
+       ├─ calls query_supporting_doc(id="2", query="...")
+       │     └─ Doc sub-agent: reads doc, returns "No relevant info found."
+       │
+       └─ Synthesizer sub-agent
+              input: query + all per-doc summaries
+              returns: "Based on your notes, character X is..."
+  ← tool result: "Based on your notes, character X is..."
+```
+
+All sub-agents use `gemini-2.5-flash` — they are retrieval utilities, not creative engines.
+
+Sub-agent creation should be injected via a factory parameter so tests can mock it without hitting the real API.
+
+This mirrors the `delegate_to_skill` pattern from Phase 8, with sub-agents created dynamically by the tool rather than being user-defined.
+
+---
+
+## Data model
+
+```ts
+interface SupportingDoc {
+  id: string;        // crypto.randomUUID()
+  title: string;
+  content: string;   // raw markdown
+  updatedAt: number; // Date.now()
+}
+```
+
+Stored as `JSON.stringify(SupportingDoc[])` under the key `"supporting_docs"` in `localStorage`.
+
+---
+
+## Tool definitions
+
+### `list_supporting_docs`
+
+- **Input:** none
+- **Output:** `{ docs: Array<{ id: string; title: string }> }`
+- Returns titles only — no content.
+
+### `read_supporting_doc`
+
+- **Input:** `id: string`
+- **Output:** `{ title: string; content: string }` or `{ error: "Document not found" }`
+- Returns the full raw content of a single doc.
+
+### `query_supporting_doc`
+
+- **Input:** `id: string`, `query: string`
+- **Output:** `{ summary: string }` or `{ error: "Document not found" }`
+- Spins up a short-lived `AgentRunner` with the doc content and the query; returns a focused summary of what's relevant.
+
+### `query_supporting_docs`
+
+- **Input:** `query: string`
+- **Output:** `{ answer: string }` — synthesized across all docs
+- Calls `list_supporting_docs`, then `query_supporting_doc` for each doc, then passes the collected summaries to a synthesizer `AgentRunner` that returns a single coherent answer.
+
+---
+
+## UI: Reference tab
+
+The sidebar gains a third tab alongside Chat and Settings.
+
+```
+[ Chat ]  [ Settings ]  [ Reference ]
+                              │
+                    ┌─────────┴──────────┐
+                    │  + New Document    │
+                    ├────────────────────┤
+                    │ > Character Notes  │ ✕
+                    │   Style Guide      │ ✕
+                    │   Outline          │ ✕
+                    └────────────────────┘
+                    (click to expand inline editor)
+```
+
+Selecting a doc expands an inline editor showing the title (editable `<input>`) and content (Monaco editor in markdown mode). Changes are auto-saved to `localStorage` on debounce (500 ms).
+
+---
+
+## State management
+
+Add `SupportingDocsContext` (separate from `AppState`) following the same pattern as `ThemeProvider`:
+
+```ts
+// src/lib/SupportingDocsContext.tsx
+const SupportingDocsContext = createContext<SupportingDocsContextValue>(...)
+
+export function SupportingDocsProvider({ children }) {
+  const [docs, setDocs] = useState<SupportingDoc[]>(() =>
+    JSON.parse(localStorage.getItem("supporting_docs") ?? "[]")
+  );
+  // persist on change
+  useEffect(() => {
+    localStorage.setItem("supporting_docs", JSON.stringify(docs));
+  }, [docs]);
+  // addDoc, updateDoc, deleteDoc helpers ...
+}
+```
+
+Tools receive a snapshot of `docs` at call time via a ref passed from `App.tsx`, same pattern as `EditorTools.ts` receiving the Monaco editor ref.
+
+---
+
+## Subphases
+
+### Phase 10a: Docs UI
+
+**Goal:** Users can manage supporting documents in the sidebar. No agent tools yet.
+
+- Add `SupportingDoc` type and `SupportingDocsContext` with localStorage persistence.
+- Wrap the app with `SupportingDocsProvider` in `App.tsx`.
+- Build `ReferenceTab` component: doc list with add/delete, inline title + content editor, auto-save on debounce.
+- Add "Reference" tab to `ChatSidebar`.
+
+**Files:** `src/lib/SupportingDocsContext.tsx` (new), `src/components/ReferenceTab.tsx` (new), `src/components/ChatSidebar.tsx`, `src/App.tsx`
+
+**Tests:** `SupportingDocsContext` CRUD, localStorage persistence, empty initial state; `ReferenceTab` renders list, add/delete interactions, auto-save debounce.
+
+**Working state:** The user can create, edit, and delete reference documents in the "Reference" sidebar tab. Documents survive a page reload.
+
+---
+
+### Phase 10b: Basic read tools
+
+**Goal:** The agent can enumerate and read documents directly.
+
+- Register `list_supporting_docs` and `read_supporting_doc` in a new `SupportingDocTools.ts`.
+- Wire the tools in `App.tsx`, passing the docs ref.
+
+**Files:** `src/lib/SupportingDocTools.ts` (new), `src/App.tsx`
+
+**Tests:** `list_supporting_docs` returns titles only; `read_supporting_doc` returns content for a valid ID and error for unknown.
+
+**Working state:** The agent can be asked "what reference documents do I have?" or "read my style guide" and successfully use the tools.
+
+---
+
+### Phase 10c: Single-doc query
+
+**Goal:** The agent can ask a focused question about a specific document without the full content entering the main context.
+
+- Implement `query_supporting_doc` in `SupportingDocTools.ts`: looks up the doc, creates a short-lived `AgentRunner`, returns the focused summary.
+- Inject the `AgentRunner` factory as a parameter for testability.
+
+**Files:** `src/lib/SupportingDocTools.ts`
+
+**Tests:** `query_supporting_doc` creates a child `AgentRunner` with the doc content and query, returns its text response; error returned for unknown ID; factory injection allows mocking.
+
+**Working state:** The agent can be asked "what does my character sheet say about the antagonist?" and retrieve a concise summary without the raw doc appearing in its context.
+
+---
+
+### Phase 10d: Multi-doc synthesis
+
+**Goal:** The agent can query across the entire workspace in a single tool call.
+
+- Implement `query_supporting_docs` in `SupportingDocTools.ts`: calls `list_supporting_docs`, then `query_supporting_doc` for each doc, then feeds the summaries to a synthesizer `AgentRunner`.
+
+**Files:** `src/lib/SupportingDocTools.ts`
+
+**Tests:** `query_supporting_docs` calls `query_supporting_doc` for each doc, passes summaries to a synthesizer sub-agent, returns the final answer.
+
+**Working state:** The agent can be asked "check all my notes for anything relevant to character X" and return a synthesized answer drawn from every document in the workspace.
+
+---
+
+## Open questions
+
+1. **Streaming sub-agent answers** — The sub-agent response could stream back to `ChatSidebar` as a collapsible "Reading reference docs…" block, similar to how thinking chunks are displayed. Worth doing if the latency is noticeable.
+2. **Doc size limit** — Should we warn the user if a doc exceeds a token threshold (e.g. ~50 k chars) where even the sub-agent would struggle?
+3. **Parallelism in `query_supporting_docs`** — The per-doc `query_supporting_doc` calls could be issued in parallel rather than sequentially. Worth exploring if latency on large workspaces is noticeable.

--- a/docs/PHASE_10_PLAN.md
+++ b/docs/PHASE_10_PLAN.md
@@ -69,9 +69,9 @@ This mirrors the `delegate_to_skill` pattern from Phase 8, with sub-agents creat
 
 ```ts
 interface SupportingDoc {
-  id: string;        // crypto.randomUUID()
+  id: string; // crypto.randomUUID()
   title: string;
-  content: string;   // raw markdown
+  content: string; // raw markdown
   updatedAt: number; // Date.now()
 }
 ```

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -9,16 +9,25 @@ To provide a modern, AI-powered text editing experience where a browser-native A
 - **Monaco Editor Integration:** A high-performance text editor for a seamless writing experience.
 - **AI Agent (MAST):** A browser-native agent using the `mast-ai` library for low-latency, secure, and stateful interactions.
 - **Google Gen AI Integration:** Utilizing the latest `@google/genai` SDK. Users can choose their preferred underlying model from a list of current models (defaulting to Gemini 2.5 Flash).
-- **Editor-Aware Tools:** The agent will have access to tools that allow it to:
-  - **Read:** Retrieve the entire document content.
+- **Editor-Aware Tools:** The agent has access to tools that operate on the currently open document:
+  - **Read:** Retrieve the entire open document's content.
   - **Read Selection:** Retrieve only the text currently highlighted by the user for focused tasks.
-  - **Search:** Find specific words or phrases within the document without reading the whole file.
+  - **Search:** Find specific words or phrases within the open document without reading the whole file.
   - **Get Metadata:** Access document statistics like word count, character count, and current cursor position.
   - **Edit:** Suggest targeted, surgical edits (insertions, removals, or replacements) by providing a minimal snippet of the original text and the new text. Enforces strict length limits to prevent accidental full-document rewrites.
-  - **Write:** Propose replacing the entire document content (e.g., when drafting a new document or completing a full rewrite).
-  - **List Documents:** Retrieve a list of available supporting documents in the workspace.
-  - **Read Document:** Retrieve the content of a specific supporting document to use as reference.
-- **Supporting Documents:** Users can add multiple markdown documents to their workspace. These documents can hold project metadata, style guides, character bios, or general reference material to assist in the writing process.
+  - **Write:** Propose replacing the entire open document's content (e.g., when drafting a new document or completing a full rewrite).
+- **Workspaces:** The application organises documents into named, persistent workspaces. Each workspace is an independent collection of documents stored in the browser's local storage. Users can:
+  - **Create** a new workspace with a chosen name.
+  - **Open** an existing workspace; the last-active document is restored automatically.
+  - **Rename** a workspace at any time.
+  - **Delete** an entire workspace and all its documents.
+  - Switch between workspaces via a workspace picker screen, accessible from the editor header.
+- **Document Navigator:** Within a workspace, the left drawer lists all documents. Users can create, rename, delete, and switch between documents. The Monaco editor always shows the currently active document, and any document can become the active one.
+- **Workspace-Aware Agent Tools:** In addition to the editor tools, the agent can interact with all documents in the active workspace:
+  - **List Workspace Documents:** Returns the ID and title of every document in the workspace (no content).
+  - **Read Workspace Document:** Returns the full content of a specific document by ID.
+  - **Query Workspace Document:** Delegates to a short-lived sub-agent that reads one document and returns a focused summary relevant to a query, without loading the full content into the main context.
+  - **Query Workspace:** Queries all documents in the workspace and synthesizes the results into a single answer via a sub-agent.
 - **Approval Workflow:** By default, all modifications proposed by the agent (via `edit` or `write`) require explicit user approval. Tool execution pauses asynchronously until the user acts (Accept/Reject), ensuring the agent is notified of the outcome. Edits are displayed inline using a Google Docs-style aesthetic (red strikethrough for original, green monospace for new text) and automatically scroll into view. The user can optionally enable an "approve all" mode to automatically accept changes for faster editing.
 - **Interactive Sidebar:** A chat-based interface for interacting with the AI agent.
 - **Local Settings:** User preferences, credentials (like the Google AI Studio API key), and the selected AI model are securely saved in the browser's local storage to persist across sessions without requiring a backend.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -85,16 +85,16 @@ src/
 
 ```ts
 interface WorkspaceMeta {
-  id: string;        // crypto.randomUUID()
+  id: string; // crypto.randomUUID()
   name: string;
   createdAt: number; // Date.now()
   updatedAt: number; // Date.now()
 }
 
 interface WorkspaceDocument {
-  id: string;        // crypto.randomUUID()
+  id: string; // crypto.randomUUID()
   title: string;
-  content: string;   // raw text / markdown
+  content: string; // raw text / markdown
   updatedAt: number; // Date.now()
 }
 
@@ -106,11 +106,11 @@ interface WorkspaceData {
 
 `localStorage` layout:
 
-| Key                    | Value                                   |
-| ---------------------- | --------------------------------------- |
-| `workspaces_index`     | `JSON.stringify(WorkspaceMeta[])`       |
-| `workspace_{id}`       | `JSON.stringify(WorkspaceData)`         |
-| `active_workspace_id`  | ID of the currently open workspace      |
+| Key                   | Value                              |
+| --------------------- | ---------------------------------- |
+| `workspaces_index`    | `JSON.stringify(WorkspaceMeta[])`  |
+| `workspace_{id}`      | `JSON.stringify(WorkspaceData)`    |
+| `active_workspace_id` | ID of the currently open workspace |
 
 Workspaces are stored independently so listing workspaces does not require deserializing all document content. `WorkspaceData` is loaded on demand when a workspace is opened.
 
@@ -142,6 +142,7 @@ React context providing the full workspace API to the application:
 ### `WorkspacePicker.tsx`
 
 Full-screen view shown when `activeWorkspaceId` is `null`. Displays all workspaces with:
+
 - Open, Rename (inline edit), and Delete (with confirmation) actions per workspace.
 - **New Workspace** button: prompts for a name, creates the workspace, and opens it immediately.
 
@@ -150,6 +151,7 @@ Accessible from the editor header via a **Switch Workspace** button at any time.
 ### `WorkspacePanel.tsx`
 
 Left drawer content shown when a workspace is open. Displays:
+
 - The active workspace name (read-only label; rename goes via `WorkspacePicker`).
 - All documents in the active workspace: click to open, double-click to rename, delete button per document.
 - Active document is visually highlighted.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -4,8 +4,8 @@
 
 The application is a single-page React application bundled with Vite. It consists of three main architectural components:
 
-1. **The Editor (Monaco):** Handles text input, rendering, and provides an API for programmatic access.
-2. **The Agent (MAST):** Orchestrates the "think-act" loop. It uses a `ToolRegistry` to expose editor-specific functions to the AI. The architecture supports multi-agent orchestration; the primary `AgentRunner` can spin up specialized sub-`AgentRunners` based on user-defined skills.
+1. **The Editor (Monaco):** Handles text input, rendering, and provides an API for programmatic access. Bound to the active document of the active workspace.
+2. **The Agent (MAST):** Orchestrates the "think-act" loop. It uses a `ToolRegistry` to expose editor-specific and workspace-specific functions to the AI. The architecture supports multi-agent orchestration; the primary `AgentRunner` can spin up specialized sub-`AgentRunners` based on user-defined skills or for workspace document queries.
 3. **The Adapter (Google Gen AI):** A custom implementation of `LlmAdapter` that bridges `MAST` with the `@google/genai` SDK.
 
 ## Data Flow
@@ -15,7 +15,8 @@ The application is a single-page React application bundled with Vite. It consist
 3. The selected LLM (e.g., Gemini 2.5 Flash) decides whether to respond with text or call a tool.
 4. If a tool is called (e.g., `read`, `edit`, or `write`), the `ToolRegistry` executes the function. For modification tools (`edit`, `write`), the UI intercepts the action to present the suggestion to the user, unless "approve all" mode is enabled.
 5. The result of the tool execution (or the user's feedback/decision from a suggestion) is returned to the LLM, and the loop continues until a final response is generated.
-6. If the task requires specialized knowledge, the main agent can call a `delegate_to_skill` tool, invoking a sub-agent with specific instructions loaded from local storage. The sub-agent's results are returned to the main agent's context.
+6. If the task requires specialized knowledge, the main agent can call `delegate_to_skill`, invoking a sub-agent with specific instructions loaded from local storage. The sub-agent's results are returned to the main agent's context.
+7. For workspace document queries, `query_workspace_doc` and `query_workspace` spin up short-lived sub-`AgentRunners` that read document content and return focused summaries without loading the full content into the main agent's context.
 
 ## Technical Stack
 
@@ -62,17 +63,97 @@ src/
 │   ├── EditorPanel.tsx
 │   ├── ChatSidebar.tsx
 │   ├── SuggestionWidget.tsx
+│   ├── WorkspacePicker.tsx
+│   ├── WorkspacePanel.tsx
 │   └── SkillsManager.tsx
-├── tools/
-│   └── EditorTools.ts
-├── types/
-│   └── index.ts
+├── lib/
+│   ├── workspace.ts
+│   ├── WorkspacesContext.tsx
+│   ├── EditorTools.ts
+│   ├── WorkspaceTools.ts
+│   ├── skills.ts
+│   ├── store.tsx
+│   └── ThemeProvider.tsx
 ├── App.tsx
 ├── main.tsx
 └── App.css
 ```
 
+## Data Model
+
+### Workspace
+
+```ts
+interface WorkspaceMeta {
+  id: string;        // crypto.randomUUID()
+  name: string;
+  createdAt: number; // Date.now()
+  updatedAt: number; // Date.now()
+}
+
+interface WorkspaceDocument {
+  id: string;        // crypto.randomUUID()
+  title: string;
+  content: string;   // raw text / markdown
+  updatedAt: number; // Date.now()
+}
+
+interface WorkspaceData {
+  documents: WorkspaceDocument[];
+  activeDocumentId: string | null;
+}
+```
+
+`localStorage` layout:
+
+| Key                    | Value                                   |
+| ---------------------- | --------------------------------------- |
+| `workspaces_index`     | `JSON.stringify(WorkspaceMeta[])`       |
+| `workspace_{id}`       | `JSON.stringify(WorkspaceData)`         |
+| `active_workspace_id`  | ID of the currently open workspace      |
+
+Workspaces are stored independently so listing workspaces does not require deserializing all document content. `WorkspaceData` is loaded on demand when a workspace is opened.
+
+On first load, if `workspaces_index` does not exist, a migration runs: any `supporting_docs` data is imported into a default workspace named `"My Workspace"`, and `supporting_docs` is removed.
+
 ## Component Breakdown
+
+### `workspace.ts`
+
+Type definitions for `WorkspaceMeta`, `WorkspaceDocument`, and `WorkspaceData`.
+
+### `WorkspacesContext.tsx`
+
+React context providing the full workspace API to the application:
+
+- `index: WorkspaceMeta[]` — all workspace names and IDs.
+- `activeWorkspaceId: string | null`
+- `activeWorkspace: WorkspaceData | null` — loaded on demand.
+- `activeDocument: WorkspaceDocument | null` — derived from `activeWorkspace`.
+- `createWorkspace(name): WorkspaceMeta`
+- `openWorkspace(id)`
+- `renameWorkspace(id, newName)`
+- `deleteWorkspace(id)` — removes `workspace_{id}` and the index entry; if the deleted workspace was active, sets `activeWorkspaceId` to `null`.
+- `addDocument()`
+- `updateDocument(id, patch)` — debounced write to `localStorage`.
+- `deleteDocument(id)`
+- `setActiveDocumentId(id)` — persisted inside `workspace_{id}`.
+
+### `WorkspacePicker.tsx`
+
+Full-screen view shown when `activeWorkspaceId` is `null`. Displays all workspaces with:
+- Open, Rename (inline edit), and Delete (with confirmation) actions per workspace.
+- **New Workspace** button: prompts for a name, creates the workspace, and opens it immediately.
+
+Accessible from the editor header via a **Switch Workspace** button at any time.
+
+### `WorkspacePanel.tsx`
+
+Left drawer content shown when a workspace is open. Displays:
+- The active workspace name (read-only label; rename goes via `WorkspacePicker`).
+- All documents in the active workspace: click to open, double-click to rename, delete button per document.
+- Active document is visually highlighted.
+- **New Document** button: creates `"Untitled Document"` and activates it.
 
 ### `GoogleGenAIAdapter.ts`
 
@@ -85,38 +166,34 @@ Implements `LlmAdapter` interface:
 
 ### `EditorTools.ts`
 
-Registers tools with `ToolRegistry`:
+Registers tools that operate exclusively on the currently open document:
 
-- `read()`: `() => string`. Returns the complete current editor content.
-- `read_selection()`: `() => string`. Returns text currently selected.
+- `read()`: `() => string`. Returns the complete content of the open document.
+- `read_selection()`: `() => string`. Returns text currently selected in the editor.
 - `search(query: string)`: `({ query: string }) => { results: { line: number, text: string }[] }`.
 - `get_metadata()`: `() => { wordCount: number, lineCount: number, cursor: { line: number, column: number } }`.
-- `edit(originalText: string, replacementText: string)`: `({ originalText: string, replacementText: string }) => Promise<string>`. Proposes a targeted change. Contains hard size constraints (e.g., max 3000 chars) to enforce surgical edits; returns an instructional error if the agent attempts to rewrite too much. Uses a Promise to pause agent execution until the user resolves the change. The app applies a red strikethrough decoration to `originalText` and injects `replacementText` inline (green) via `after.content`.
-- `write(content: string)`: `({ content: string }) => Promise<string>`. Proposes full replacement, pausing execution until user approval.
-- `list_supporting_docs()`: `() => string[]`. Returns a list of names for available supporting markdown documents.
-- `read_supporting_doc(name: string)`: `({ name: string }) => string`. Returns the complete content of the requested supporting document.
-- `delegate_to_skill(skillName: string, task: string)`: `({ skillName: string, task: string }) => string`. Invokes sub-agent.
+- `edit(originalText, replacementText)`: Proposes a targeted change. Contains hard size constraints to enforce surgical edits. Uses a Promise to pause agent execution until the user resolves the change. Applies a red strikethrough decoration to `originalText` and injects `replacementText` inline (green) via `after.content`.
+- `write(content)`: Proposes full replacement of the open document, pausing execution until user approval.
+- `delegate_to_skill(skillName, task)`: Invokes a skill sub-agent.
 
-## Main Agent System Instructions
+`read`, `edit`, and `write` are intentionally symmetric — all three operate on the open document only. To access other documents, the agent uses `WorkspaceTools`.
 
-The primary agent should be configured with a system prompt that explains its role as an editor and its mandatory approval workflow.
-Example:
+### `WorkspaceTools.ts`
 
-> You are a senior editorial assistant. You help the user refine their text.
->
-> - Always use `read()` or `read_selection()` before suggesting changes.
-> - CRITICAL: Prefer small, surgical edits using `edit()`. Do not rewrite the entire document unless explicitly asked to.
-> - All edits MUST be proposed via `edit()` or `write()`. When called, execution will PAUSE until user approval. Do not assume the change was applied until you get a success confirmation.
-> - Do not assume you can change text without a tool call.
-> - You have access to specialized sub-agents. Use them for focused tasks like proofreading.
+Registers tools scoped to the active workspace. Receives a ref snapshot of `WorkspaceData` at call time (same pattern as `EditorTools` receiving the Monaco editor ref):
+
+- `list_workspace_docs()`: Returns `[{ id, title }]` — no content.
+- `read_workspace_doc(id)`: Returns `{ title, content }` or `{ error: "Document not found" }`.
+- `query_workspace_doc(id, query)`: Spins up a short-lived `AgentRunner` (`gemini-2.5-flash`) with the document content and query; returns `{ summary }`. The `AgentRunner` factory is injected as a parameter for testability.
+- `query_workspace(query)`: Calls `list_workspace_docs`, then `query_workspace_doc` for each document sequentially, then passes all summaries to a synthesizer `AgentRunner`; returns `{ answer }`.
 
 ### `EditorPanel.tsx`
 
-Wraps the Monaco Editor component and provides an imperative handle or context for tools to interact with the editor instance.
+Wraps the Monaco Editor. Reads initial content from `WorkspacesContext.activeDocument.content` and calls `updateDocument` on change (debounced 500 ms). Replaces the former `AppState.editorContent` / `setEditorContent` pattern.
 
 ### `ChatSidebar.tsx`
 
-Provides the chat interface and message history.
+Provides the streaming chat interface and message history.
 
 ### `SuggestionWidget.tsx`
 
@@ -125,18 +202,30 @@ Provides the chat interface and message history.
 
 ### `SkillsManager.tsx`
 
-A dialog or dedicated view for creating, editing, and deleting custom skills.
+A dialog for creating, editing, and deleting custom skills.
 
 ### `App.tsx`
 
 The main entry point:
 
-- Manages global state (e.g., API key, selected model, active suggestions, "approve all" toggle, user-defined skills, supporting documents).
-- Handles loading the API key, selected model, skills, and supporting documents from `localStorage` on initialization.
-- Includes UI components for managing both specialized skills and supporting markdown documents (creation, editing, deletion).
-- Dynamically constructs the `AgentConfig.systemInstructions` for the main `AgentRunner`. It appends only the `name` and `description` of each available skill into the main prompt, keeping it concise while ensuring the LLM knows when to use `delegate_to_skill` without needing to discover them first.
-- Renders the `MonacoEditor` and `ChatSidebar` components.
-- Initializes `AgentRunner` and `Conversation`.
+- Manages global state (API key, selected model, active suggestions, "approve all" toggle, skills).
+- Wires `EditorTools` and `WorkspaceTools` into the `ToolRegistry`, passing the Monaco editor ref and a snapshot ref of `WorkspacesContext.activeWorkspace.documents` respectively.
+- Dynamically constructs `AgentConfig.systemInstructions`: appends skill names/descriptions and workspace tool guidance.
+- Renders `WorkspacePicker` when no workspace is active, or the editor layout (`WorkspacePanel` + `EditorPanel` + `ChatSidebar`) when a workspace is open.
+- Handles responsive layout (desktop split-pane vs. mobile bottom-sheet).
+
+## Main Agent System Instructions
+
+The primary agent should be configured with a system prompt that explains its role as an editor and its mandatory approval workflow:
+
+> You are a senior editorial assistant. You help the user refine their text.
+>
+> - `read()`, `edit()`, and `write()` operate on the currently open document only.
+> - Always use `read()` or `read_selection()` before suggesting changes.
+> - CRITICAL: Prefer small, surgical edits using `edit()`. Do not rewrite the entire document unless explicitly asked to.
+> - All edits MUST be proposed via `edit()` or `write()`. Execution will PAUSE until user approval. Do not assume the change was applied until you receive a success confirmation.
+> - Use `list_workspace_docs`, `read_workspace_doc`, or `query_workspace_doc` / `query_workspace` to access other documents in the workspace.
+> - You have access to specialized sub-agents. Use them for focused tasks like proofreading.
 
 ## Security
 
@@ -153,6 +242,6 @@ The main entry point:
 - **Error Handling:**
   - Graceful handling of API rate limits and invalid tool calls.
   - Catch and display LLM errors (e.g., safety filters) in the chat UI.
-- **Styling:** Use Tailwind CSS for utility-first styling and `shadcn/ui` for complex components (e.g., Dialogs for Skills Manager, Tabs for Sidebar).
+- **Styling:** Use Tailwind CSS for utility-first styling and `shadcn/ui` for complex components (e.g., Dialogs for Skills Manager, workspace confirmation prompts).
 - **Dark Mode:** Use Tailwind CSS's class-based dark mode strategy (`darkMode: 'class'` in `tailwind.config`). A `ThemeProvider` wraps the app and toggles a `dark` class on the `<html>` element. The Monaco editor theme switches between `vs` (light) and `vs-dark` (dark) in sync. The selected theme is persisted in `localStorage`.
-- **Responsive Layout:** On screens narrower than the `md` breakpoint (768 px), the side-by-side editor/sidebar layout collapses into a tab-based view (Editor | Chat) using the existing `shadcn/ui` `Tabs` component. Touch targets (buttons, inputs) must be at minimum 44 × 44 px. The Monaco editor renders in a flex-fill container so it uses available height without overflow.
+- **Responsive Layout:** On screens narrower than the `md` breakpoint (768 px), the editor fills the screen and FABs open a bottom-sheet overlay for chat or the workspace panel. Touch targets must be at minimum 44 × 44 px. The Monaco editor renders in a flex-fill container so it uses available height without overflow.

--- a/docs/WORKSPACES_PLAN.md
+++ b/docs/WORKSPACES_PLAN.md
@@ -163,7 +163,7 @@ If `workspaces_index` already exists, skip migration entirely.
 
 ---
 
-### Phase 11c: Document navigator
+### ✅ Phase 11c: Document navigator
 
 **Goal:** The left drawer becomes a first-class document navigator for the active workspace.
 

--- a/docs/WORKSPACES_PLAN.md
+++ b/docs/WORKSPACES_PLAN.md
@@ -1,0 +1,230 @@
+# Workspaces Plan
+
+## Goal
+
+Replace the current single-document editor model with a **workspace** — a persistent, named collection of documents. The user can create, open, and delete workspaces. Within a workspace, any document can be opened in the Monaco editor, and every document is available to the agent (list, read, query). This renders the "supporting documents" concept (Phase 10) obsolete and supersedes Phases 10b–10d.
+
+---
+
+## Motivation
+
+The current design has two broken assumptions:
+
+| Current                       | Problem                                                    |
+| ----------------------------- | ---------------------------------------------------------- |
+| `AppState.editorContent`      | Ephemeral — lost on page reload. Only one document exists. |
+| `SupportingDocsContext` (10a) | Persistent, but second-class "reference" — not editable.  |
+
+A workspace collapses these into a single model: all documents are peers, any can be edited, all persist, and multiple independent workspaces can be created and switched between.
+
+---
+
+## Data model
+
+```ts
+interface WorkspaceDocument {
+  id: string;              // crypto.randomUUID()
+  title: string;
+  content: string;         // raw text / markdown
+  updatedAt: number;       // Date.now()
+}
+
+interface WorkspaceMeta {
+  id: string;              // crypto.randomUUID()
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface WorkspaceData {
+  documents: WorkspaceDocument[];
+  activeDocumentId: string | null;
+}
+```
+
+`localStorage` layout — workspaces are stored separately to keep the index small and avoid loading all document content on start:
+
+| Key                        | Value                                    |
+| -------------------------- | ---------------------------------------- |
+| `workspaces_index`         | `JSON.stringify(WorkspaceMeta[])`        |
+| `workspace_{id}`           | `JSON.stringify(WorkspaceData)`          |
+| `active_workspace_id`      | the ID of the currently open workspace   |
+
+---
+
+## Architecture
+
+```
+WorkspacesContext  (global)
+│   index: WorkspaceMeta[]           — all workspace names/IDs
+│   activeWorkspaceId: string | null
+│   activeWorkspace: WorkspaceData | null   (loaded on demand)
+│   activeDocument: WorkspaceDocument | null  (derived)
+│
+│   createWorkspace(name) → WorkspaceMeta
+│   openWorkspace(id)
+│   deleteWorkspace(id)
+│
+│   addDocument()
+│   updateDocument(id, patch)
+│   deleteDocument(id)
+│   setActiveDocumentId(id)
+│
+├── WorkspacePicker  (shown when no active workspace)
+│   ├── List of workspaces — name, last modified, open / delete
+│   └── "New Workspace" button → name prompt → creates and opens
+│
+├── Editor view  (shown when a workspace is active)
+│   ├── Header — workspace name + "Switch Workspace" button
+│   ├── Left drawer: WorkspacePanel
+│   │   ├── Document list — title, active indicator, rename, delete
+│   │   └── "New Document" button
+│   ├── EditorPanel — bound to activeDocument.content
+│   └── Right sidebar: ChatSidebar
+│
+└── Agent Tool Registry (scoped to activeWorkspace)
+    ├── list_workspace_docs   → [{ id, title }]
+    ├── read_workspace_doc    → { title, content } | { error }
+    ├── query_workspace_doc   → { summary } via sub-agent
+    └── query_workspace       → { answer }  synthesized via sub-agents
+```
+
+---
+
+## Migration from current state
+
+On first load after deployment (when `workspaces_index` does not exist):
+
+1. Create a default workspace named `"My Workspace"`.
+2. Read `localStorage["supporting_docs"]` (Phase 10a data); import each entry as a `WorkspaceDocument` in that workspace.
+3. Create one additional `WorkspaceDocument` titled `"Untitled Document"` with empty content, set as `activeDocumentId`.
+4. Delete `localStorage["supporting_docs"]`.
+5. Set `active_workspace_id` to the new workspace's ID so the user lands directly in the editor.
+
+If `workspaces_index` already exists, skip migration entirely.
+
+---
+
+## Subphases
+
+### Phase 11a: Data model & context
+
+**Goal:** Establish the multi-workspace data model. The app continues to work as before (single implicit workspace), but data is now persisted correctly.
+
+**Tasks:**
+- Define `WorkspaceMeta`, `WorkspaceDocument`, `WorkspaceData` types in `src/lib/workspace.ts`.
+- Create `WorkspacesContext` (`src/lib/WorkspacesContext.tsx`):
+  - Reads `workspaces_index` and `active_workspace_id` from localStorage on init.
+  - Loads `workspace_{id}` on demand when the active workspace changes.
+  - Exposes `createWorkspace`, `openWorkspace`, `deleteWorkspace`, `addDocument`, `updateDocument`, `deleteDocument`, `setActiveDocumentId`.
+  - Persists index and workspace data on every mutation.
+  - Runs migration from `supporting_docs` on first load.
+- Wrap the app with `WorkspacesProvider` in `main.tsx` or `App.tsx`.
+- Replace `AppState.editorContent` / `setEditorContent` with reads/writes on `activeDocument.content` via `WorkspacesContext`. Remove those fields from `AppState`.
+- Update `EditorPanel.tsx` to read initial content from `activeDocument.content` and call `updateDocument` on change (debounced 500 ms).
+- Remove `SupportingDocsContext` and its provider.
+- Update `ReferenceTab.tsx` to read from `WorkspacesContext` instead of `SupportingDocsContext` (minimal change; full UI redesign in Phase 11b/11c).
+
+**Files:** `src/lib/workspace.ts` (new), `src/lib/WorkspacesContext.tsx` (new, replaces `SupportingDocsContext.tsx`), `src/components/EditorPanel.tsx`, `src/lib/store.tsx`, `src/components/ReferenceTab.tsx`, `src/App.tsx` / `src/main.tsx`
+
+**Tests:**
+- `WorkspacesContext`: create/open/delete workspace, document CRUD within a workspace, localStorage persistence, migration from `supporting_docs`, empty initial state.
+- `EditorPanel`: content initialised from `activeDocument`, `updateDocument` called on editor change.
+
+**Working state:** The editor reads/writes the active workspace document. Documents survive page reload. Existing supporting docs are migrated into the default workspace. The Reference drawer still renders (minimally updated to use the new context).
+
+---
+
+### Phase 11b: Workspace picker
+
+**Goal:** The user can create, open, and delete workspaces via a dedicated UI.
+
+**Tasks:**
+- Create `WorkspacePicker` component (`src/components/WorkspacePicker.tsx`):
+  - Shows the list of workspaces: name, last-modified date, **Open** button, **Rename** button (inline edit or prompt), **Delete** button (with confirmation dialog — deletes the workspace and all its documents).
+  - **New Workspace** button: prompts for a name, creates the workspace, and opens it.
+  - Shown full-screen when `activeWorkspaceId` is `null` (e.g. all workspaces deleted, or future sign-in flow).
+  - Add `renameWorkspace(id, newName)` to `WorkspacesContext`.
+- Add a **Switch Workspace** affordance in the editor view header (a small button next to the workspace name) that closes the current workspace (sets `activeWorkspaceId = null`) and shows `WorkspacePicker`.
+- Show workspace name in the header bar when a workspace is open.
+- Handle the edge case of deleting the currently active workspace: close it and show `WorkspacePicker`.
+
+**Files:** `src/components/WorkspacePicker.tsx` (new), `src/App.tsx`
+
+**Tests:**
+- `WorkspacePicker`: renders workspace list, create interaction, open sets active workspace, rename updates the name in the index, delete with confirmation removes it from index.
+- Edge: deleting the last workspace leaves `activeWorkspaceId` null.
+
+**Working state:** Users can create named workspaces, switch between them, and delete them. The editor view shows the workspace name and provides a way to return to the picker.
+
+---
+
+### Phase 11c: Document navigator
+
+**Goal:** The left drawer becomes a first-class document navigator for the active workspace.
+
+**Tasks:**
+- Replace `ReferenceTab.tsx` with `WorkspacePanel.tsx` (`src/components/WorkspacePanel.tsx`):
+  - Lists all documents in the active workspace.
+  - Active document is highlighted.
+  - Click to open a document (sets `activeDocumentId`).
+  - Inline rename on double-click (or small edit icon).
+  - Delete button per document (with confirmation if document has content).
+  - **New Document** button: creates `"Untitled Document"`, activates it.
+  - Drawer header shows the workspace name (read-only — rename goes via a future workspace settings screen).
+- Update `App.tsx` `DesktopLayout` and `MobileLayout` to use `WorkspacePanel` in place of `ReferenceTab`.
+
+**Files:** `src/components/WorkspacePanel.tsx` (replaces `ReferenceTab.tsx`), `src/App.tsx`
+
+**Tests:**
+- `WorkspacePanel`: renders doc list, create/delete/rename interactions, clicking a doc sets `activeDocumentId`.
+
+**Working state:** Users can create multiple documents within a workspace, switch between them, rename and delete them. The Monaco editor always shows the active document's content.
+
+---
+
+### Phase 11d: Agent workspace tools
+
+**Goal:** The agent can list, read, and query any document in the active workspace.
+
+This phase supersedes Phases 10b, 10c, and 10d from the original Phase 10 plan.
+
+**Tasks:**
+- Create `src/lib/WorkspaceTools.ts` with four tools scoped to the active workspace:
+  - `list_workspace_docs` — returns `[{ id, title }]` (no content).
+  - `read_workspace_doc(id)` — returns `{ title, content }` or `{ error: "Document not found" }`.
+  - `query_workspace_doc(id, query)` — spins up a short-lived sub-agent (`gemini-2.5-flash`) with the doc content and query; returns `{ summary }`. Sub-agent factory is injected for testability.
+  - `query_workspace(query)` — calls `list_workspace_docs`, then `query_workspace_doc` per doc, passes all summaries to a synthesizer sub-agent; returns `{ answer }`.
+- Wire tools in `App.tsx`, passing a `docsRef` snapshot of the active workspace's `documents`.
+- Update `BASE_INSTRUCTIONS` in `App.tsx` and the agent `tools` array to include the four workspace tools.
+
+**Files:** `src/lib/WorkspaceTools.ts` (new), `src/App.tsx`
+
+**Tests:**
+- `list_workspace_docs` returns `id` and `title` only.
+- `read_workspace_doc` returns content for a valid ID, error for unknown.
+- `query_workspace_doc` creates a child `AgentRunner` with doc content + query; factory injection allows mocking.
+- `query_workspace` calls `query_workspace_doc` per doc, passes summaries to synthesizer, returns final answer.
+
+**Working state:** The agent can list, read, and semantically query any document in the current workspace.
+
+---
+
+## Decisions
+
+1. **Workspace rename** — Renaming is supported. Inline rename in `WorkspacePicker` (double-click on name or a pencil icon). The `WorkspacePanel` header can show the name but rename is initiated from the picker to keep one canonical place for workspace-level operations.
+2. **Active document across workspace switches** — Restoring the last active document is the default. `activeDocumentId` is persisted inside `workspace_{id}`, so reopening a workspace automatically returns to where the user left off.
+3. **Parallel sub-agent queries** — Deferred. `query_workspace` will call `query_workspace_doc` sequentially for now; parallelism can be added later if latency on large workspaces is noticeable.
+4. **Document size warning** — Deferred. Can be added to `WorkspacePanel` later if needed.
+5. **`read()` scope** — `read()`, `edit()`, and `write()` all operate exclusively on the open document, keeping the three tools symmetric. To access other documents the agent uses the workspace tools (`list_workspace_docs`, `read_workspace_doc`, etc.). No change to the existing editor tools.
+
+---
+
+## Impact on Phase 10
+
+| Phase 10 subphase     | Status after Workspaces plan                                                              |
+| --------------------- | ----------------------------------------------------------------------------------------- |
+| 10a: Docs UI          | ✅ Complete — data migrated into `WorkspacesContext` (11a); UI replaced by `WorkspacePanel` (11c) |
+| 10b: Basic read tools | Superseded by `list_workspace_docs` + `read_workspace_doc` in Phase 11d                  |
+| 10c: Single-doc query | Superseded by `query_workspace_doc` in Phase 11d                                         |
+| 10d: Multi-doc synthesis | Superseded by `query_workspace` in Phase 11d                                          |

--- a/docs/WORKSPACES_PLAN.md
+++ b/docs/WORKSPACES_PLAN.md
@@ -189,7 +189,7 @@ If `workspaces_index` already exists, skip migration entirely.
 
 ---
 
-### Phase 11d: Agent workspace tools
+### ✅ Phase 11d: Agent workspace tools
 
 **Goal:** The agent can list, read, and query any document in the active workspace.
 

--- a/docs/WORKSPACES_PLAN.md
+++ b/docs/WORKSPACES_PLAN.md
@@ -13,7 +13,7 @@ The current design has two broken assumptions:
 | Current                       | Problem                                                    |
 | ----------------------------- | ---------------------------------------------------------- |
 | `AppState.editorContent`      | Ephemeral — lost on page reload. Only one document exists. |
-| `SupportingDocsContext` (10a) | Persistent, but second-class "reference" — not editable.  |
+| `SupportingDocsContext` (10a) | Persistent, but second-class "reference" — not editable.   |
 
 A workspace collapses these into a single model: all documents are peers, any can be edited, all persist, and multiple independent workspaces can be created and switched between.
 
@@ -23,14 +23,14 @@ A workspace collapses these into a single model: all documents are peers, any ca
 
 ```ts
 interface WorkspaceDocument {
-  id: string;              // crypto.randomUUID()
+  id: string; // crypto.randomUUID()
   title: string;
-  content: string;         // raw text / markdown
-  updatedAt: number;       // Date.now()
+  content: string; // raw text / markdown
+  updatedAt: number; // Date.now()
 }
 
 interface WorkspaceMeta {
-  id: string;              // crypto.randomUUID()
+  id: string; // crypto.randomUUID()
   name: string;
   createdAt: number;
   updatedAt: number;
@@ -44,11 +44,11 @@ interface WorkspaceData {
 
 `localStorage` layout — workspaces are stored separately to keep the index small and avoid loading all document content on start:
 
-| Key                        | Value                                    |
-| -------------------------- | ---------------------------------------- |
-| `workspaces_index`         | `JSON.stringify(WorkspaceMeta[])`        |
-| `workspace_{id}`           | `JSON.stringify(WorkspaceData)`          |
-| `active_workspace_id`      | the ID of the currently open workspace   |
+| Key                   | Value                                  |
+| --------------------- | -------------------------------------- |
+| `workspaces_index`    | `JSON.stringify(WorkspaceMeta[])`      |
+| `workspace_{id}`      | `JSON.stringify(WorkspaceData)`        |
+| `active_workspace_id` | the ID of the currently open workspace |
 
 ---
 
@@ -112,6 +112,7 @@ If `workspaces_index` already exists, skip migration entirely.
 **Goal:** Establish the multi-workspace data model. The app continues to work as before (single implicit workspace), but data is now persisted correctly.
 
 **Tasks:**
+
 - Define `WorkspaceMeta`, `WorkspaceDocument`, `WorkspaceData` types in `src/lib/workspace.ts`.
 - Create `WorkspacesContext` (`src/lib/WorkspacesContext.tsx`):
   - Reads `workspaces_index` and `active_workspace_id` from localStorage on init.
@@ -128,6 +129,7 @@ If `workspaces_index` already exists, skip migration entirely.
 **Files:** `src/lib/workspace.ts` (new), `src/lib/WorkspacesContext.tsx` (new, replaces `SupportingDocsContext.tsx`), `src/components/EditorPanel.tsx`, `src/lib/store.tsx`, `src/components/ReferenceTab.tsx`, `src/App.tsx` / `src/main.tsx`
 
 **Tests:**
+
 - `WorkspacesContext`: create/open/delete workspace, document CRUD within a workspace, localStorage persistence, migration from `supporting_docs`, empty initial state.
 - `EditorPanel`: content initialised from `activeDocument`, `updateDocument` called on editor change.
 
@@ -140,6 +142,7 @@ If `workspaces_index` already exists, skip migration entirely.
 **Goal:** The user can create, open, and delete workspaces via a dedicated UI.
 
 **Tasks:**
+
 - Create `WorkspacePicker` component (`src/components/WorkspacePicker.tsx`):
   - Shows the list of workspaces: name, last-modified date, **Open** button, **Rename** button (inline edit or prompt), **Delete** button (with confirmation dialog — deletes the workspace and all its documents).
   - **New Workspace** button: prompts for a name, creates the workspace, and opens it.
@@ -152,6 +155,7 @@ If `workspaces_index` already exists, skip migration entirely.
 **Files:** `src/components/WorkspacePicker.tsx` (new), `src/App.tsx`
 
 **Tests:**
+
 - `WorkspacePicker`: renders workspace list, create interaction, open sets active workspace, rename updates the name in the index, delete with confirmation removes it from index.
 - Edge: deleting the last workspace leaves `activeWorkspaceId` null.
 
@@ -164,6 +168,7 @@ If `workspaces_index` already exists, skip migration entirely.
 **Goal:** The left drawer becomes a first-class document navigator for the active workspace.
 
 **Tasks:**
+
 - Replace `ReferenceTab.tsx` with `WorkspacePanel.tsx` (`src/components/WorkspacePanel.tsx`):
   - Lists all documents in the active workspace.
   - Active document is highlighted.
@@ -177,6 +182,7 @@ If `workspaces_index` already exists, skip migration entirely.
 **Files:** `src/components/WorkspacePanel.tsx` (replaces `ReferenceTab.tsx`), `src/App.tsx`
 
 **Tests:**
+
 - `WorkspacePanel`: renders doc list, create/delete/rename interactions, clicking a doc sets `activeDocumentId`.
 
 **Working state:** Users can create multiple documents within a workspace, switch between them, rename and delete them. The Monaco editor always shows the active document's content.
@@ -190,6 +196,7 @@ If `workspaces_index` already exists, skip migration entirely.
 This phase supersedes Phases 10b, 10c, and 10d from the original Phase 10 plan.
 
 **Tasks:**
+
 - Create `src/lib/WorkspaceTools.ts` with four tools scoped to the active workspace:
   - `list_workspace_docs` — returns `[{ id, title }]` (no content).
   - `read_workspace_doc(id)` — returns `{ title, content }` or `{ error: "Document not found" }`.
@@ -201,6 +208,7 @@ This phase supersedes Phases 10b, 10c, and 10d from the original Phase 10 plan.
 **Files:** `src/lib/WorkspaceTools.ts` (new), `src/App.tsx`
 
 **Tests:**
+
 - `list_workspace_docs` returns `id` and `title` only.
 - `read_workspace_doc` returns content for a valid ID, error for unknown.
 - `query_workspace_doc` creates a child `AgentRunner` with doc content + query; factory injection allows mocking.
@@ -222,9 +230,9 @@ This phase supersedes Phases 10b, 10c, and 10d from the original Phase 10 plan.
 
 ## Impact on Phase 10
 
-| Phase 10 subphase     | Status after Workspaces plan                                                              |
-| --------------------- | ----------------------------------------------------------------------------------------- |
-| 10a: Docs UI          | ✅ Complete — data migrated into `WorkspacesContext` (11a); UI replaced by `WorkspacePanel` (11c) |
-| 10b: Basic read tools | Superseded by `list_workspace_docs` + `read_workspace_doc` in Phase 11d                  |
-| 10c: Single-doc query | Superseded by `query_workspace_doc` in Phase 11d                                         |
-| 10d: Multi-doc synthesis | Superseded by `query_workspace` in Phase 11d                                          |
+| Phase 10 subphase        | Status after Workspaces plan                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------- |
+| 10a: Docs UI             | ✅ Complete — data migrated into `WorkspacesContext` (11a); UI replaced by `WorkspacePanel` (11c) |
+| 10b: Basic read tools    | Superseded by `list_workspace_docs` + `read_workspace_doc` in Phase 11d                           |
+| 10c: Single-doc query    | Superseded by `query_workspace_doc` in Phase 11d                                                  |
+| 10d: Multi-doc synthesis | Superseded by `query_workspace` in Phase 11d                                                      |

--- a/docs/WORKSPACES_PLAN.md
+++ b/docs/WORKSPACES_PLAN.md
@@ -107,7 +107,7 @@ If `workspaces_index` already exists, skip migration entirely.
 
 ## Subphases
 
-### Phase 11a: Data model & context
+### ✅ Phase 11a: Data model & context
 
 **Goal:** Establish the multi-workspace data model. The app continues to work as before (single implicit workspace), but data is now persisted correctly.
 
@@ -137,7 +137,7 @@ If `workspaces_index` already exists, skip migration entirely.
 
 ---
 
-### Phase 11b: Workspace picker
+### ✅ Phase 11b: Workspace picker
 
 **Goal:** The user can create, open, and delete workspaces via a dedicated UI.
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,7 +6,7 @@ import App from "./App";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AppProvider } from "./lib/store";
 import { ThemeProvider } from "./lib/ThemeProvider";
-import { SupportingDocsProvider } from "./lib/SupportingDocsContext";
+import { WorkspacesProvider } from "./lib/WorkspacesContext";
 
 // Mock Monaco Editor
 vi.mock("@monaco-editor/react", () => ({
@@ -29,9 +29,9 @@ function renderApp() {
   return render(
     <ThemeProvider>
       <AppProvider>
-        <SupportingDocsProvider>
+        <WorkspacesProvider>
           <App />
-        </SupportingDocsProvider>
+        </WorkspacesProvider>
       </AppProvider>
     </ThemeProvider>,
   );

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,6 +6,7 @@ import App from "./App";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AppProvider } from "./lib/store";
 import { ThemeProvider } from "./lib/ThemeProvider";
+import { SupportingDocsProvider } from "./lib/SupportingDocsContext";
 
 // Mock Monaco Editor
 vi.mock("@monaco-editor/react", () => ({
@@ -28,7 +29,9 @@ function renderApp() {
   return render(
     <ThemeProvider>
       <AppProvider>
-        <App />
+        <SupportingDocsProvider>
+          <App />
+        </SupportingDocsProvider>
       </AppProvider>
     </ThemeProvider>,
   );
@@ -79,12 +82,13 @@ describe("App responsive layout", () => {
     // Editor and sidebar both visible
     expect(screen.getByTestId("mock-monaco-editor")).toBeInTheDocument();
     expect(screen.getByText("AI Assistant")).toBeInTheDocument();
-    // No Chat trigger in any tablist
-    const tabs = screen.queryAllByRole("tab").map((t) => t.textContent ?? "");
-    expect(tabs).not.toContain("Chat");
+    // Reference drawer toggle button is present
+    expect(
+      screen.getByRole("button", { name: "Expand reference drawer" }),
+    ).toBeInTheDocument();
   });
 
-  it("renders mobile layout with FAB and no Chat tab", () => {
+  it("renders mobile layout with chat and reference FABs", () => {
     mockMatchMedia(true);
     renderApp();
 
@@ -95,8 +99,9 @@ describe("App responsive layout", () => {
     expect(
       screen.getByRole("button", { name: "Open chat" }),
     ).toBeInTheDocument();
-    const tabs = screen.queryAllByRole("tab").map((t) => t.textContent ?? "");
-    expect(tabs).not.toContain("Chat");
+    expect(
+      screen.getByRole("button", { name: "Open reference" }),
+    ).toBeInTheDocument();
   });
 
   it("opening the sheet shows the chat sidebar", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,14 +4,17 @@ import { useState, useMemo, useEffect, useRef } from "react";
 import { EditorPanel } from "@/components/EditorPanel";
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { ReferenceTab } from "@/components/ReferenceTab";
+import { WorkspacePicker } from "@/components/WorkspacePicker";
 import {
   MessageCircle,
   ChevronDown,
   BookOpen,
   PanelLeftClose,
   PanelLeftOpen,
+  LayoutGrid,
 } from "lucide-react";
 import { useApp } from "@/lib/store";
+import { useWorkspaces } from "@/lib/WorkspacesContext";
 import {
   Dialog,
   DialogContent,
@@ -53,6 +56,8 @@ interface LayoutProps {
 
 function DesktopLayout({ conversation }: LayoutProps) {
   const [refOpen, setRefOpen] = useState(false);
+  const { index, activeWorkspaceId, closeWorkspace } = useWorkspaces();
+  const activeMeta = index.find((w) => w.id === activeWorkspaceId);
 
   return (
     <div className="flex h-screen w-screen overflow-hidden bg-background text-foreground">
@@ -89,8 +94,25 @@ function DesktopLayout({ conversation }: LayoutProps) {
         )}
       </aside>
 
-      <main className="flex-1 min-w-0">
-        <EditorPanel />
+      <main className="flex-1 min-w-0 flex flex-col">
+        {activeMeta && (
+          <div className="flex items-center gap-2 px-3 h-10 border-b border-border shrink-0">
+            <span className="text-xs font-medium text-muted-foreground truncate flex-1">
+              {activeMeta.name}
+            </span>
+            <button
+              onClick={closeWorkspace}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground px-2 py-1 rounded hover:bg-muted/60 shrink-0"
+              aria-label="Switch workspace"
+            >
+              <LayoutGrid className="w-3 h-3" />
+              Switch
+            </button>
+          </div>
+        )}
+        <div className="flex-1 min-h-0">
+          <EditorPanel />
+        </div>
       </main>
       <aside className="w-[400px] shrink-0 border-l border-border">
         <ChatSidebar conversation={conversation} />
@@ -102,6 +124,8 @@ function DesktopLayout({ conversation }: LayoutProps) {
 function MobileLayout({ conversation }: LayoutProps) {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetMode, setSheetMode] = useState<"chat" | "reference">("chat");
+  const { index, activeWorkspaceId, closeWorkspace } = useWorkspaces();
+  const activeMeta = index.find((w) => w.id === activeWorkspaceId);
   const sheetRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -124,8 +148,25 @@ function MobileLayout({ conversation }: LayoutProps) {
   return (
     <div className="relative h-screen w-screen overflow-hidden bg-background text-foreground">
       {/* Editor always mounted, full screen */}
-      <div className="h-full w-full">
-        <EditorPanel />
+      <div className="h-full w-full flex flex-col">
+        {activeMeta && (
+          <div className="flex items-center gap-2 px-3 h-10 border-b border-border shrink-0">
+            <span className="text-xs font-medium text-muted-foreground truncate flex-1">
+              {activeMeta.name}
+            </span>
+            <button
+              onClick={closeWorkspace}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground px-2 py-1 rounded hover:bg-muted/60 shrink-0"
+              aria-label="Switch workspace"
+            >
+              <LayoutGrid className="w-3 h-3" />
+              Switch
+            </button>
+          </div>
+        )}
+        <div className="flex-1 min-h-0">
+          <EditorPanel />
+        </div>
       </div>
 
       {/* FABs */}
@@ -195,6 +236,7 @@ const BASE_INSTRUCTIONS =
   "You will then receive the user's decision (and feedback if any) as the tool result.";
 
 function App() {
+  const { activeWorkspaceId } = useWorkspaces();
   const {
     apiKey,
     setApiKey,
@@ -288,6 +330,10 @@ function App() {
       setShowKeyDialog(false);
     }
   };
+
+  if (!activeWorkspaceId) {
+    return <WorkspacePicker />;
+  }
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import {
   BookOpen,
   PanelLeftClose,
   PanelLeftOpen,
+  PanelRightClose,
+  PanelRightOpen,
   LayoutGrid,
 } from "lucide-react";
 import { useApp } from "@/lib/store";
@@ -57,6 +59,7 @@ interface LayoutProps {
 
 function DesktopLayout({ conversation }: LayoutProps) {
   const [refOpen, setRefOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(true);
   const { index, activeWorkspaceId, closeWorkspace } = useWorkspaces();
   const activeMeta = index.find((w) => w.id === activeWorkspaceId);
 
@@ -115,8 +118,37 @@ function DesktopLayout({ conversation }: LayoutProps) {
           <EditorPanel />
         </div>
       </main>
-      <aside className="w-[400px] shrink-0 border-l border-border">
-        <ChatSidebar conversation={conversation} />
+      {/* Collapsible chat sidebar */}
+      <aside
+        className={`shrink-0 border-l border-border flex flex-col overflow-hidden transition-[width] duration-300 ease-in-out ${
+          chatOpen ? "w-[400px]" : "w-10"
+        }`}
+      >
+        <div className="flex items-center border-b border-border h-10 shrink-0">
+          {chatOpen && (
+            <span className="text-xs font-medium text-muted-foreground ml-3 truncate flex-1">
+              AI Assistant
+            </span>
+          )}
+          <button
+            onClick={() => setChatOpen((v) => !v)}
+            className="flex items-center justify-center w-10 h-10 hover:bg-muted/60 text-muted-foreground shrink-0"
+            aria-label={
+              chatOpen ? "Collapse chat sidebar" : "Expand chat sidebar"
+            }
+          >
+            {chatOpen ? (
+              <PanelRightClose className="w-4 h-4" />
+            ) : (
+              <PanelRightOpen className="w-4 h-4" />
+            )}
+          </button>
+        </div>
+        {chatOpen && (
+          <div className="flex-1 min-h-0 overflow-hidden">
+            <ChatSidebar conversation={conversation} />
+          </div>
+        )}
       </aside>
     </div>
   );
@@ -241,7 +273,8 @@ const BASE_INSTRUCTIONS =
   "Use `query_workspace(query)` to synthesize an answer that draws from all workspace documents.";
 
 function App() {
-  const { activeWorkspaceId, activeWorkspace, activeDocument } = useWorkspaces();
+  const { activeWorkspaceId, activeWorkspace, activeDocument } =
+    useWorkspaces();
   const {
     apiKey,
     setApiKey,
@@ -261,7 +294,9 @@ function App() {
   }, [activeWorkspace]);
 
   const activeDocRef = useRef(
-    activeDocument ? { id: activeDocument.id, title: activeDocument.title } : null,
+    activeDocument
+      ? { id: activeDocument.id, title: activeDocument.title }
+      : null,
   );
   useEffect(() => {
     activeDocRef.current = activeDocument

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -203,7 +203,6 @@ function App() {
     editorInstance,
     setSuggestions,
     approveAll,
-    setEditorContent,
     skills,
   } = useApp();
   const [tempKey, setTempKey] = useState("");
@@ -220,7 +219,6 @@ function App() {
       editorInstance,
       setSuggestions,
       approveAll,
-      setEditorContent,
     );
 
     registerEditorTools(registry, editorTools);
@@ -257,7 +255,6 @@ function App() {
     editorInstance,
     setSuggestions,
     approveAll,
-    setEditorContent,
   ]);
 
   const conversation = useMemo(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,14 @@
 import { useState, useMemo, useEffect, useRef } from "react";
 import { EditorPanel } from "@/components/EditorPanel";
 import { ChatSidebar } from "@/components/ChatSidebar";
-import { MessageCircle, ChevronDown } from "lucide-react";
+import { ReferenceTab } from "@/components/ReferenceTab";
+import {
+  MessageCircle,
+  ChevronDown,
+  BookOpen,
+  PanelLeftClose,
+  PanelLeftOpen,
+} from "lucide-react";
 import { useApp } from "@/lib/store";
 import {
   Dialog,
@@ -45,8 +52,43 @@ interface LayoutProps {
 }
 
 function DesktopLayout({ conversation }: LayoutProps) {
+  const [refOpen, setRefOpen] = useState(false);
+
   return (
     <div className="flex h-screen w-screen overflow-hidden bg-background text-foreground">
+      {/* Collapsible reference drawer */}
+      <aside
+        className={`shrink-0 border-r border-border flex flex-col overflow-hidden transition-[width] duration-300 ease-in-out ${
+          refOpen ? "w-[280px]" : "w-10"
+        }`}
+      >
+        <div className="flex items-center border-b border-border h-10 shrink-0">
+          <button
+            onClick={() => setRefOpen((v) => !v)}
+            className="flex items-center justify-center w-10 h-10 hover:bg-muted/60 text-muted-foreground"
+            aria-label={
+              refOpen ? "Collapse reference drawer" : "Expand reference drawer"
+            }
+          >
+            {refOpen ? (
+              <PanelLeftClose className="w-4 h-4" />
+            ) : (
+              <PanelLeftOpen className="w-4 h-4" />
+            )}
+          </button>
+          {refOpen && (
+            <span className="text-xs font-medium text-muted-foreground ml-1 truncate">
+              Reference
+            </span>
+          )}
+        </div>
+        {refOpen && (
+          <div className="flex-1 min-h-0 overflow-hidden">
+            <ReferenceTab />
+          </div>
+        )}
+      </aside>
+
       <main className="flex-1 min-w-0">
         <EditorPanel />
       </main>
@@ -59,6 +101,7 @@ function DesktopLayout({ conversation }: LayoutProps) {
 
 function MobileLayout({ conversation }: LayoutProps) {
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [sheetMode, setSheetMode] = useState<"chat" | "reference">("chat");
   const sheetRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -73,6 +116,11 @@ function MobileLayout({ conversation }: LayoutProps) {
     }
   }, [sheetOpen]);
 
+  const openSheet = (mode: "chat" | "reference") => {
+    setSheetMode(mode);
+    setSheetOpen(true);
+  };
+
   return (
     <div className="relative h-screen w-screen overflow-hidden bg-background text-foreground">
       {/* Editor always mounted, full screen */}
@@ -80,15 +128,24 @@ function MobileLayout({ conversation }: LayoutProps) {
         <EditorPanel />
       </div>
 
-      {/* FAB */}
+      {/* FABs */}
       {!sheetOpen && (
-        <button
-          onClick={() => setSheetOpen(true)}
-          className="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg"
-          aria-label="Open chat"
-        >
-          <MessageCircle className="h-6 w-6" />
-        </button>
+        <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-3">
+          <button
+            onClick={() => openSheet("reference")}
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-secondary text-secondary-foreground shadow-lg border border-border"
+            aria-label="Open reference"
+          >
+            <BookOpen className="h-5 w-5" />
+          </button>
+          <button
+            onClick={() => openSheet("chat")}
+            className="flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg"
+            aria-label="Open chat"
+          >
+            <MessageCircle className="h-6 w-6" />
+          </button>
+        </div>
       )}
 
       {/* Bottom sheet overlay */}
@@ -100,7 +157,9 @@ function MobileLayout({ conversation }: LayoutProps) {
         style={{ height: "70vh" }}
       >
         <div className="flex items-center justify-between border-b px-4 py-3">
-          <span className="font-medium">AI Assistant</span>
+          <span className="font-medium">
+            {sheetMode === "chat" ? "AI Assistant" : "Reference"}
+          </span>
           <button
             onClick={() => {
               (document.activeElement as HTMLElement)?.blur();
@@ -113,7 +172,11 @@ function MobileLayout({ conversation }: LayoutProps) {
           </button>
         </div>
         <div className="flex-1 min-h-0 overflow-hidden">
-          <ChatSidebar conversation={conversation} />
+          {sheetMode === "chat" ? (
+            <ChatSidebar conversation={conversation} />
+          ) : (
+            <ReferenceTab />
+          )}
         </div>
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useEffect, useRef } from "react";
 import { EditorPanel } from "@/components/EditorPanel";
 import { ChatSidebar } from "@/components/ChatSidebar";
-import { ReferenceTab } from "@/components/ReferenceTab";
+import { WorkspacePanel } from "@/components/WorkspacePanel";
 import { WorkspacePicker } from "@/components/WorkspacePicker";
 import {
   MessageCircle,
@@ -83,13 +83,13 @@ function DesktopLayout({ conversation }: LayoutProps) {
           </button>
           {refOpen && (
             <span className="text-xs font-medium text-muted-foreground ml-1 truncate">
-              Reference
+              Documents
             </span>
           )}
         </div>
         {refOpen && (
           <div className="flex-1 min-h-0 overflow-hidden">
-            <ReferenceTab />
+            <WorkspacePanel />
           </div>
         )}
       </aside>
@@ -216,7 +216,7 @@ function MobileLayout({ conversation }: LayoutProps) {
           {sheetMode === "chat" ? (
             <ChatSidebar conversation={conversation} />
           ) : (
-            <ReferenceTab />
+            <WorkspacePanel />
           )}
         </div>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import {
   registerEditorTools,
   createDelegateToSkillHandler,
 } from "@/lib/EditorTools";
+import { WorkspaceTools, registerWorkspaceTools } from "@/lib/WorkspaceTools";
 
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(
@@ -233,10 +234,14 @@ const BASE_INSTRUCTIONS =
   "CRITICAL: Prefer small, surgical edits using `edit()`. Do not rewrite the entire document unless explicitly asked to. " +
   "When using `edit()`, the `originalText` should be as short as possible (just the sentence or words changing), not the whole file. " +
   "When you call `edit()` or `write()`, the execution will PAUSE until the user manually Accepts or Rejects the change. " +
-  "You will then receive the user's decision (and feedback if any) as the tool result.";
+  "You will then receive the user's decision (and feedback if any) as the tool result. " +
+  "The workspace may contain multiple documents. Use `get_active_doc_info()` to get the id and title of the currently open document. " +
+  "Use `list_workspace_docs()` to discover all documents. " +
+  "Use `read_workspace_doc(id)` to read another document in full, or `query_workspace_doc(id, query)` for a targeted question. " +
+  "Use `query_workspace(query)` to synthesize an answer that draws from all workspace documents.";
 
 function App() {
-  const { activeWorkspaceId } = useWorkspaces();
+  const { activeWorkspaceId, activeWorkspace, activeDocument } = useWorkspaces();
   const {
     apiKey,
     setApiKey,
@@ -249,6 +254,20 @@ function App() {
   } = useApp();
   const [tempKey, setTempKey] = useState("");
   const [showKeyDialog, setShowKeyDialog] = useState(!apiKey);
+
+  const docsRef = useRef(activeWorkspace?.documents ?? []);
+  useEffect(() => {
+    docsRef.current = activeWorkspace?.documents ?? [];
+  }, [activeWorkspace]);
+
+  const activeDocRef = useRef(
+    activeDocument ? { id: activeDocument.id, title: activeDocument.title } : null,
+  );
+  useEffect(() => {
+    activeDocRef.current = activeDocument
+      ? { id: activeDocument.id, title: activeDocument.title }
+      : null;
+  }, [activeDocument]);
 
   const runner = useMemo(() => {
     if (!apiKey) return null;
@@ -264,6 +283,13 @@ function App() {
     );
 
     registerEditorTools(registry, editorTools);
+
+    const workspaceTools = new WorkspaceTools(
+      docsRef,
+      activeDocRef,
+      () => new GoogleGenAIAdapter(apiKey, "gemini-2.5-flash"),
+    );
+    registerWorkspaceTools(registry, workspaceTools);
 
     registry.register({
       definition: () => ({
@@ -297,6 +323,8 @@ function App() {
     editorInstance,
     setSuggestions,
     approveAll,
+    docsRef,
+    activeDocRef,
   ]);
 
   const conversation = useMemo(() => {
@@ -317,6 +345,11 @@ function App() {
         "edit",
         "write",
         "delegate_to_skill",
+        "get_active_doc_info",
+        "list_workspace_docs",
+        "read_workspace_doc",
+        "query_workspace_doc",
+        "query_workspace",
       ],
     };
     return runner.conversation(agent);

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -228,7 +228,9 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
       <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
       <SkillsDialog open={skillsOpen} onOpenChange={setSkillsOpen} />
       <div className="p-4 border-b flex justify-between items-center gap-4">
-        <span className="text-sm font-medium whitespace-nowrap">AI Assistant</span>
+        <span className="text-sm font-medium whitespace-nowrap">
+          AI Assistant
+        </span>
         <div className="flex items-center gap-2 text-xs text-muted-foreground ml-auto">
           <div className="flex items-center space-x-2 min-h-11">
             <Switch
@@ -240,7 +242,7 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
               Approve All
             </Label>
           </div>
-<Button
+          <Button
             variant="ghost"
             size="icon"
             className="h-11 w-11"

--- a/src/components/EditorPanel.test.tsx
+++ b/src/components/EditorPanel.test.tsx
@@ -2,32 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { EditorPanel } from "./EditorPanel";
 import { AppProvider } from "@/lib/store";
 import { ThemeProvider } from "@/lib/ThemeProvider";
+import { WorkspacesProvider } from "@/lib/WorkspacesContext";
+
+function renderEditor() {
+  return render(
+    <ThemeProvider>
+      <AppProvider>
+        <WorkspacesProvider>
+          <EditorPanel />
+        </WorkspacesProvider>
+      </AppProvider>
+    </ThemeProvider>,
+  );
+}
 
 describe("EditorPanel", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("renders editor tab by default", () => {
-    render(
-      <ThemeProvider>
-        <AppProvider>
-          <EditorPanel />
-        </AppProvider>
-      </ThemeProvider>,
-    );
+    renderEditor();
     expect(screen.getByTestId("mock-monaco-editor")).toBeInTheDocument();
   });
 
   it("can switch to the preview tab and render markdown", async () => {
     const user = userEvent.setup();
-    render(
-      <ThemeProvider>
-        <AppProvider>
-          <EditorPanel />
-        </AppProvider>
-      </ThemeProvider>,
-    );
+    renderEditor();
 
     // Switch to preview tab
     const previewTab = screen.getByRole("tab", { name: "Preview" });
@@ -43,13 +48,7 @@ describe("EditorPanel", () => {
 
   it("updates preview when editor content changes", async () => {
     const user = userEvent.setup();
-    render(
-      <ThemeProvider>
-        <AppProvider>
-          <EditorPanel />
-        </AppProvider>
-      </ThemeProvider>,
-    );
+    renderEditor();
 
     const editor = screen.getByTestId("mock-monaco-editor");
     fireEvent.change(editor, { target: { value: "# New Markdown Heading" } });

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -7,24 +7,28 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { MarkdownContent } from "./MarkdownContent";
 import { useApp } from "@/lib/store";
 import { useTheme } from "@/lib/ThemeProvider";
+import { useWorkspaces } from "@/lib/WorkspacesContext";
 import { SuggestionWidget } from "./SuggestionWidget";
 import { createPortal } from "react-dom";
 
 const DEFAULT_CONTENT =
   "# Welcome to the AI Agent Text Editor\n\nStart typing here, and switch to the **Preview** tab to see the rendered Markdown.\n\n- React\n- Monaco Editor\n- MAST AI";
 
+const DEBOUNCE_MS = 500;
+
 export function EditorPanel() {
-  const {
-    editorContent,
-    setEditorContent,
-    setEditorInstance,
-    suggestions,
-    setSuggestions,
-    editorInstance,
-  } = useApp();
+  const { setEditorInstance, suggestions, setSuggestions, editorInstance } =
+    useApp();
+  const { activeDocument, updateDocument } = useWorkspaces();
 
   const { theme } = useTheme();
   const monacoTheme = theme === "dark" ? "vs-dark" : "light";
+
+  const [localContent, setLocalContent] = useState<string>(
+    () => activeDocument?.content || DEFAULT_CONTENT,
+  );
+  const prevDocIdRef = useRef<string | null>(activeDocument?.id ?? null);
+  const updateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [suggestionNodes, setSuggestionNodes] = useState<
     { id: string; node: HTMLElement }[]
@@ -34,14 +38,27 @@ export function EditorPanel() {
     new Map(),
   );
 
+  // Sync editor content when switching documents
   useEffect(() => {
-    if (!editorContent) {
-      setEditorContent(DEFAULT_CONTENT);
+    if (activeDocument?.id !== prevDocIdRef.current) {
+      prevDocIdRef.current = activeDocument?.id ?? null;
+      setLocalContent(activeDocument?.content || DEFAULT_CONTENT);
     }
-  }, []);
+  }, [activeDocument]);
 
   const handleEditorDidMount: OnMount = (editor) => {
     setEditorInstance(editor);
+  };
+
+  const handleChange = (value: string | undefined) => {
+    const content = value || "";
+    setLocalContent(content);
+    if (updateTimerRef.current) clearTimeout(updateTimerRef.current);
+    updateTimerRef.current = setTimeout(() => {
+      if (activeDocument) {
+        updateDocument(activeDocument.id, { content });
+      }
+    }, DEBOUNCE_MS);
   };
 
   useEffect(() => {
@@ -175,8 +192,8 @@ export function EditorPanel() {
             <Editor
               height="100%"
               defaultLanguage="markdown"
-              value={editorContent}
-              onChange={(value) => setEditorContent(value || "")}
+              value={localContent}
+              onChange={handleChange}
               onMount={handleEditorDidMount}
               theme={monacoTheme}
               options={{
@@ -207,7 +224,7 @@ export function EditorPanel() {
           className="m-0 flex-1 overflow-auto p-8 outline-none data-[state=active]:block"
         >
           <MarkdownContent
-            content={editorContent}
+            content={localContent}
             className="mx-auto max-w-3xl text-foreground"
           />
         </TabsContent>

--- a/src/components/ReferenceTab.test.tsx
+++ b/src/components/ReferenceTab.test.tsx
@@ -4,15 +4,25 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
-import { SupportingDocsProvider } from "@/lib/SupportingDocsContext";
+import { WorkspacesProvider } from "@/lib/WorkspacesContext";
+import { WorkspaceMeta, WorkspaceData } from "@/lib/workspace";
 import { ReferenceTab } from "./ReferenceTab";
 
 function renderTab() {
   return render(
-    <SupportingDocsProvider>
+    <WorkspacesProvider>
       <ReferenceTab />
-    </SupportingDocsProvider>,
+    </WorkspacesProvider>,
   );
+}
+
+function getActiveWorkspaceData(): WorkspaceData {
+  const index: WorkspaceMeta[] = JSON.parse(
+    localStorage.getItem("workspaces_index")!,
+  );
+  const id = localStorage.getItem("active_workspace_id")!;
+  expect(index.find((m) => m.id === id)).toBeTruthy();
+  return JSON.parse(localStorage.getItem(`workspace_${id}`)!);
 }
 
 describe("ReferenceTab", () => {
@@ -26,20 +36,25 @@ describe("ReferenceTab", () => {
     localStorage.clear();
   });
 
-  it("shows empty state when no documents", () => {
+  it("shows empty state when no documents (only default Untitled deleted)", () => {
     renderTab();
+    // After migration, one "Untitled Document" exists — delete it to test empty state
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
     expect(screen.getByText(/no reference documents yet/i)).toBeTruthy();
   });
 
   it("adds a document when New is clicked", () => {
     renderTab();
     fireEvent.click(screen.getByRole("button", { name: /new document/i }));
-    expect(screen.getByText("New Document")).toBeTruthy();
+    // Should now have 2 docs (Untitled from migration + newly added)
+    const expandBtns = screen
+      .getAllByRole("button")
+      .filter((b) => b.getAttribute("aria-expanded") !== null);
+    expect(expandBtns.length).toBeGreaterThanOrEqual(1);
   });
 
   it("expands a doc when its row is clicked", () => {
     renderTab();
-    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
     const expandBtn = screen
       .getAllByRole("button")
       .find((b) => b.getAttribute("aria-expanded") !== null);
@@ -56,16 +71,18 @@ describe("ReferenceTab", () => {
   it("deletes a document when the delete button is clicked", () => {
     renderTab();
     fireEvent.click(screen.getByRole("button", { name: /new document/i }));
-    expect(screen.getByText("New Document")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
-    expect(screen.queryByText("New Document")).toBeNull();
-    expect(screen.getByText(/no reference documents yet/i)).toBeTruthy();
+    // Now 2 docs; delete the new one (last delete button)
+    const deleteBtns = screen.getAllByRole("button", { name: /delete/i });
+    fireEvent.click(deleteBtns[deleteBtns.length - 1]);
+    // Back to 1 doc
+    const expandBtns = screen
+      .getAllByRole("button")
+      .filter((b) => b.getAttribute("aria-expanded") !== null);
+    expect(expandBtns).toHaveLength(1);
   });
 
   it("auto-saves title after debounce", () => {
     renderTab();
-    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
-
     const expandBtn = screen
       .getAllByRole("button")
       .find((b) => b.getAttribute("aria-expanded") !== null)!;
@@ -74,22 +91,16 @@ describe("ReferenceTab", () => {
     const titleInput = screen.getByRole("textbox", { name: /document title/i });
     fireEvent.change(titleInput, { target: { value: "My Notes" } });
 
-    // Before debounce fires, localStorage still has old title
-    const beforeFlush = JSON.parse(localStorage.getItem("supporting_docs")!);
-    expect(beforeFlush[0].title).toBe("New Document");
-
     act(() => {
       vi.advanceTimersByTime(500);
     });
 
-    const stored = JSON.parse(localStorage.getItem("supporting_docs")!);
-    expect(stored[0].title).toBe("My Notes");
+    const data = getActiveWorkspaceData();
+    expect(data.documents.some((d) => d.title === "My Notes")).toBe(true);
   });
 
   it("auto-saves content after debounce", () => {
     renderTab();
-    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
-
     const expandBtn = screen
       .getAllByRole("button")
       .find((b) => b.getAttribute("aria-expanded") !== null)!;
@@ -104,8 +115,8 @@ describe("ReferenceTab", () => {
       vi.advanceTimersByTime(500);
     });
 
-    const stored = JSON.parse(localStorage.getItem("supporting_docs")!);
-    expect(stored[0].content).toBe("# Hello");
+    const data = getActiveWorkspaceData();
+    expect(data.documents.some((d) => d.content === "# Hello")).toBe(true);
   });
 
   it("renders multiple documents", () => {
@@ -113,10 +124,10 @@ describe("ReferenceTab", () => {
     const newBtn = screen.getByRole("button", { name: /new document/i });
     fireEvent.click(newBtn);
     fireEvent.click(newBtn);
-    fireEvent.click(newBtn);
     const expandBtns = screen
       .getAllByRole("button")
       .filter((b) => b.getAttribute("aria-expanded") !== null);
+    // 1 from migration + 2 added = 3
     expect(expandBtns).toHaveLength(3);
   });
 });

--- a/src/components/ReferenceTab.test.tsx
+++ b/src/components/ReferenceTab.test.tsx
@@ -1,0 +1,122 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import React from "react";
+import { SupportingDocsProvider } from "@/lib/SupportingDocsContext";
+import { ReferenceTab } from "./ReferenceTab";
+
+function renderTab() {
+  return render(
+    <SupportingDocsProvider>
+      <ReferenceTab />
+    </SupportingDocsProvider>,
+  );
+}
+
+describe("ReferenceTab", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it("shows empty state when no documents", () => {
+    renderTab();
+    expect(screen.getByText(/no reference documents yet/i)).toBeTruthy();
+  });
+
+  it("adds a document when New is clicked", () => {
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
+    expect(screen.getByText("New Document")).toBeTruthy();
+  });
+
+  it("expands a doc when its row is clicked", () => {
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
+    const expandBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("aria-expanded") !== null);
+    expect(expandBtn).toBeTruthy();
+    fireEvent.click(expandBtn!);
+    expect(
+      screen.getByRole("textbox", { name: /document title/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("textbox", { name: /document content/i }),
+    ).toBeTruthy();
+  });
+
+  it("deletes a document when the delete button is clicked", () => {
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
+    expect(screen.getByText("New Document")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+    expect(screen.queryByText("New Document")).toBeNull();
+    expect(screen.getByText(/no reference documents yet/i)).toBeTruthy();
+  });
+
+  it("auto-saves title after debounce", () => {
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
+
+    const expandBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("aria-expanded") !== null)!;
+    fireEvent.click(expandBtn);
+
+    const titleInput = screen.getByRole("textbox", { name: /document title/i });
+    fireEvent.change(titleInput, { target: { value: "My Notes" } });
+
+    // Before debounce fires, localStorage still has old title
+    const beforeFlush = JSON.parse(localStorage.getItem("supporting_docs")!);
+    expect(beforeFlush[0].title).toBe("New Document");
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const stored = JSON.parse(localStorage.getItem("supporting_docs")!);
+    expect(stored[0].title).toBe("My Notes");
+  });
+
+  it("auto-saves content after debounce", () => {
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
+
+    const expandBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("aria-expanded") !== null)!;
+    fireEvent.click(expandBtn);
+
+    const contentArea = screen.getByRole("textbox", {
+      name: /document content/i,
+    });
+    fireEvent.change(contentArea, { target: { value: "# Hello" } });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const stored = JSON.parse(localStorage.getItem("supporting_docs")!);
+    expect(stored[0].content).toBe("# Hello");
+  });
+
+  it("renders multiple documents", () => {
+    renderTab();
+    const newBtn = screen.getByRole("button", { name: /new document/i });
+    fireEvent.click(newBtn);
+    fireEvent.click(newBtn);
+    fireEvent.click(newBtn);
+    const expandBtns = screen
+      .getAllByRole("button")
+      .filter((b) => b.getAttribute("aria-expanded") !== null);
+    expect(expandBtns).toHaveLength(3);
+  });
+});

--- a/src/components/ReferenceTab.tsx
+++ b/src/components/ReferenceTab.tsx
@@ -1,0 +1,116 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useRef } from "react";
+import { Button } from "./ui/button";
+import { Trash2, ChevronDown, ChevronRight, Plus } from "lucide-react";
+import { useSupportingDocs, SupportingDoc } from "@/lib/SupportingDocsContext";
+
+const DEBOUNCE_MS = 500;
+
+function DocEditor({ doc }: { doc: SupportingDoc }) {
+  const { updateDoc } = useSupportingDocs();
+  const [title, setTitle] = useState(doc.title);
+  const [content, setContent] = useState(doc.content);
+  const titleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const contentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleTitleChange = (value: string) => {
+    setTitle(value);
+    if (titleTimerRef.current) clearTimeout(titleTimerRef.current);
+    titleTimerRef.current = setTimeout(() => {
+      updateDoc(doc.id, { title: value });
+    }, DEBOUNCE_MS);
+  };
+
+  const handleContentChange = (value: string) => {
+    setContent(value);
+    if (contentTimerRef.current) clearTimeout(contentTimerRef.current);
+    contentTimerRef.current = setTimeout(() => {
+      updateDoc(doc.id, { content: value });
+    }, DEBOUNCE_MS);
+  };
+
+  return (
+    <div className="flex flex-col gap-2 mt-2 px-1">
+      <input
+        aria-label="Document title"
+        className="w-full text-sm font-medium bg-transparent border-b border-border focus:outline-none focus:border-primary py-1"
+        value={title}
+        onChange={(e) => handleTitleChange(e.target.value)}
+      />
+      <textarea
+        aria-label="Document content"
+        className="w-full min-h-[160px] text-xs font-mono bg-muted/30 border border-border rounded p-2 resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+        value={content}
+        onChange={(e) => handleContentChange(e.target.value)}
+        placeholder="Write your notes here (Markdown supported)..."
+      />
+    </div>
+  );
+}
+
+function DocRow({ doc }: { doc: SupportingDoc }) {
+  const { deleteDoc } = useSupportingDocs();
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="border border-border rounded-md overflow-hidden">
+      <div className="flex items-center gap-1 px-2 py-2 bg-muted/20 hover:bg-muted/40">
+        <button
+          className="flex-1 flex items-center gap-2 text-sm text-left min-w-0"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+        >
+          {expanded ? (
+            <ChevronDown className="w-3 h-3 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="w-3 h-3 shrink-0 text-muted-foreground" />
+          )}
+          <span className="truncate">{doc.title || "Untitled"}</span>
+        </button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+          onClick={() => deleteDoc(doc.id)}
+          aria-label={`Delete ${doc.title || "document"}`}
+        >
+          <Trash2 className="w-3 h-3" />
+        </Button>
+      </div>
+      {expanded && <DocEditor doc={doc} />}
+    </div>
+  );
+}
+
+export function ReferenceTab() {
+  const { docs, addDoc } = useSupportingDocs();
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-4 py-3 border-b">
+        <span className="text-sm font-medium">Reference Documents</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="gap-1 text-xs"
+          onClick={addDoc}
+          aria-label="New document"
+        >
+          <Plus className="w-3 h-3" />
+          New
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-2">
+        {docs.length === 0 ? (
+          <p className="text-xs text-muted-foreground italic text-center mt-4">
+            No reference documents yet. Click &ldquo;New&rdquo; to create one.
+          </p>
+        ) : (
+          docs.map((doc) => <DocRow key={doc.id} doc={doc} />)
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ReferenceTab.tsx
+++ b/src/components/ReferenceTab.tsx
@@ -4,12 +4,13 @@
 import { useState, useRef } from "react";
 import { Button } from "./ui/button";
 import { Trash2, ChevronDown, ChevronRight, Plus } from "lucide-react";
-import { useSupportingDocs, SupportingDoc } from "@/lib/SupportingDocsContext";
+import { useWorkspaces } from "@/lib/WorkspacesContext";
+import { WorkspaceDocument } from "@/lib/workspace";
 
 const DEBOUNCE_MS = 500;
 
-function DocEditor({ doc }: { doc: SupportingDoc }) {
-  const { updateDoc } = useSupportingDocs();
+function DocEditor({ doc }: { doc: WorkspaceDocument }) {
+  const { updateDocument } = useWorkspaces();
   const [title, setTitle] = useState(doc.title);
   const [content, setContent] = useState(doc.content);
   const titleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -19,7 +20,7 @@ function DocEditor({ doc }: { doc: SupportingDoc }) {
     setTitle(value);
     if (titleTimerRef.current) clearTimeout(titleTimerRef.current);
     titleTimerRef.current = setTimeout(() => {
-      updateDoc(doc.id, { title: value });
+      updateDocument(doc.id, { title: value });
     }, DEBOUNCE_MS);
   };
 
@@ -27,7 +28,7 @@ function DocEditor({ doc }: { doc: SupportingDoc }) {
     setContent(value);
     if (contentTimerRef.current) clearTimeout(contentTimerRef.current);
     contentTimerRef.current = setTimeout(() => {
-      updateDoc(doc.id, { content: value });
+      updateDocument(doc.id, { content: value });
     }, DEBOUNCE_MS);
   };
 
@@ -50,8 +51,8 @@ function DocEditor({ doc }: { doc: SupportingDoc }) {
   );
 }
 
-function DocRow({ doc }: { doc: SupportingDoc }) {
-  const { deleteDoc } = useSupportingDocs();
+function DocRow({ doc }: { doc: WorkspaceDocument }) {
+  const { deleteDocument } = useWorkspaces();
   const [expanded, setExpanded] = useState(false);
 
   return (
@@ -73,7 +74,7 @@ function DocRow({ doc }: { doc: SupportingDoc }) {
           variant="ghost"
           size="icon"
           className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
-          onClick={() => deleteDoc(doc.id)}
+          onClick={() => deleteDocument(doc.id)}
           aria-label={`Delete ${doc.title || "document"}`}
         >
           <Trash2 className="w-3 h-3" />
@@ -85,7 +86,8 @@ function DocRow({ doc }: { doc: SupportingDoc }) {
 }
 
 export function ReferenceTab() {
-  const { docs, addDoc } = useSupportingDocs();
+  const { activeWorkspace, addDocument } = useWorkspaces();
+  const docs = activeWorkspace?.documents ?? [];
 
   return (
     <div className="flex flex-col h-full">
@@ -95,7 +97,7 @@ export function ReferenceTab() {
           variant="ghost"
           size="sm"
           className="gap-1 text-xs"
-          onClick={addDoc}
+          onClick={addDocument}
           aria-label="New document"
         >
           <Plus className="w-3 h-3" />

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -20,8 +20,6 @@ function mockStore(apiKey: string | null, modelName: string) {
     setModelName: mockSetModelName,
     totalTokens: 0,
     setTotalTokens: vi.fn(),
-    editorContent: "",
-    setEditorContent: vi.fn(),
     suggestions: [],
     setSuggestions: vi.fn(),
     editorInstance: null,

--- a/src/components/SkillsDialog.test.tsx
+++ b/src/components/SkillsDialog.test.tsx
@@ -28,8 +28,6 @@ function mockStore(skills: Skill[]) {
     setModelName: vi.fn(),
     totalTokens: 0,
     setTotalTokens: vi.fn(),
-    editorContent: "",
-    setEditorContent: vi.fn(),
     suggestions: [],
     setSuggestions: vi.fn(),
     editorInstance: null,

--- a/src/components/WorkspacePanel.test.tsx
+++ b/src/components/WorkspacePanel.test.tsx
@@ -1,0 +1,171 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { WorkspacesProvider } from "@/lib/WorkspacesContext";
+import { WorkspaceMeta, WorkspaceData, WorkspaceDocument } from "@/lib/workspace";
+import { WorkspacePanel } from "./WorkspacePanel";
+
+function renderPanel() {
+  return render(
+    <WorkspacesProvider>
+      <WorkspacePanel />
+    </WorkspacesProvider>,
+  );
+}
+
+function getActiveWorkspaceData(): WorkspaceData {
+  const index: WorkspaceMeta[] = JSON.parse(
+    localStorage.getItem("workspaces_index")!,
+  );
+  const id = localStorage.getItem("active_workspace_id")!;
+  return JSON.parse(localStorage.getItem(`workspace_${id}`)!);
+}
+
+function setupWorkspace(docs: Partial<WorkspaceDocument>[], activeIdx = 0) {
+  const wsId = "test-ws-id";
+  const now = Date.now();
+  const fullDocs: WorkspaceDocument[] = docs.map((d, i) => ({
+    id: `doc-${i}`,
+    title: `Doc ${i + 1}`,
+    content: "",
+    updatedAt: now,
+    ...d,
+  }));
+  const data: WorkspaceData = {
+    documents: fullDocs,
+    activeDocumentId: fullDocs[activeIdx]?.id ?? null,
+  };
+  const index: WorkspaceMeta[] = [
+    { id: wsId, name: "Test WS", createdAt: now, updatedAt: now },
+  ];
+  localStorage.setItem("workspaces_index", JSON.stringify(index));
+  localStorage.setItem(`workspace_${wsId}`, JSON.stringify(data));
+  localStorage.setItem("active_workspace_id", wsId);
+  return { wsId, docs: fullDocs, data };
+}
+
+describe("WorkspacePanel", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it("renders the workspace name in the header", () => {
+    renderPanel();
+    expect(screen.getByText("My Workspace")).toBeTruthy();
+  });
+
+  it("renders workspace name from pre-populated state", () => {
+    setupWorkspace([{ title: "First Doc" }]);
+    renderPanel();
+    expect(screen.getByText("Test WS")).toBeTruthy();
+  });
+
+  it("renders the default Untitled Document from migration", () => {
+    renderPanel();
+    expect(screen.getByText("Untitled Document")).toBeTruthy();
+  });
+
+  it("creates a new document when New button is clicked", () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
+    const data = getActiveWorkspaceData();
+    expect(data.documents.length).toBe(2);
+  });
+
+  it("sets the new document as active when created", () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
+    const data = getActiveWorkspaceData();
+    const lastDoc = data.documents[data.documents.length - 1];
+    expect(data.activeDocumentId).toBe(lastDoc.id);
+  });
+
+  it("shows active document with aria-current", () => {
+    renderPanel();
+    const activeRow = screen.getByRole("button", {
+      name: /open untitled document/i,
+    });
+    expect(activeRow.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("switches active document when a doc row is clicked", () => {
+    setupWorkspace(
+      [{ id: "doc-0", title: "First" }, { id: "doc-1", title: "Second" }],
+      1,
+    );
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: /open first/i }));
+
+    const data = getActiveWorkspaceData();
+    expect(data.activeDocumentId).toBe("doc-0");
+  });
+
+  it("deletes a document without confirmation when it has no content", () => {
+    renderPanel();
+    fireEvent.click(
+      screen.getByRole("button", { name: /delete untitled document/i }),
+    );
+    const data = getActiveWorkspaceData();
+    expect(data.documents.length).toBe(0);
+  });
+
+  it("shows confirmation before deleting a document with content", () => {
+    setupWorkspace([
+      { id: "doc-0", title: "Rich Doc", content: "some content" },
+      { id: "doc-1", title: "Empty Doc", content: "" },
+    ], 1);
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: /delete rich doc/i }));
+
+    expect(screen.getByRole("button", { name: /confirm delete/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /cancel delete/i })).toBeTruthy();
+  });
+
+  it("cancels deletion when Cancel is clicked in confirm dialog", () => {
+    setupWorkspace([
+      { id: "doc-0", title: "Rich Doc", content: "some content" },
+      { id: "doc-1", title: "Empty Doc", content: "" },
+    ], 1);
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: /delete rich doc/i }));
+    fireEvent.click(screen.getByRole("button", { name: /cancel delete/i }));
+
+    const data = getActiveWorkspaceData();
+    expect(data.documents.length).toBe(2);
+  });
+
+  it("confirms deletion in confirm dialog", () => {
+    setupWorkspace([
+      { id: "doc-0", title: "Rich Doc", content: "some content" },
+      { id: "doc-1", title: "Empty Doc", content: "" },
+    ], 1);
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: /delete rich doc/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm delete/i }));
+
+    const data = getActiveWorkspaceData();
+    expect(data.documents.length).toBe(1);
+    expect(data.documents[0].id).toBe("doc-1");
+  });
+
+  it("renders multiple documents", () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
+    fireEvent.click(screen.getByRole("button", { name: /new document/i }));
+    const data = getActiveWorkspaceData();
+    expect(data.documents.length).toBe(3);
+  });
+});

--- a/src/components/WorkspacePanel.test.tsx
+++ b/src/components/WorkspacePanel.test.tsx
@@ -5,7 +5,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 import { WorkspacesProvider } from "@/lib/WorkspacesContext";
-import { WorkspaceMeta, WorkspaceData, WorkspaceDocument } from "@/lib/workspace";
+import {
+  WorkspaceMeta,
+  WorkspaceData,
+  WorkspaceDocument,
+} from "@/lib/workspace";
 import { WorkspacePanel } from "./WorkspacePanel";
 
 function renderPanel() {
@@ -99,7 +103,10 @@ describe("WorkspacePanel", () => {
 
   it("switches active document when a doc row is clicked", () => {
     setupWorkspace(
-      [{ id: "doc-0", title: "First" }, { id: "doc-1", title: "Second" }],
+      [
+        { id: "doc-0", title: "First" },
+        { id: "doc-1", title: "Second" },
+      ],
       1,
     );
     renderPanel();
@@ -120,23 +127,31 @@ describe("WorkspacePanel", () => {
   });
 
   it("shows confirmation before deleting a document with content", () => {
-    setupWorkspace([
-      { id: "doc-0", title: "Rich Doc", content: "some content" },
-      { id: "doc-1", title: "Empty Doc", content: "" },
-    ], 1);
+    setupWorkspace(
+      [
+        { id: "doc-0", title: "Rich Doc", content: "some content" },
+        { id: "doc-1", title: "Empty Doc", content: "" },
+      ],
+      1,
+    );
     renderPanel();
 
     fireEvent.click(screen.getByRole("button", { name: /delete rich doc/i }));
 
-    expect(screen.getByRole("button", { name: /confirm delete/i })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /confirm delete/i }),
+    ).toBeTruthy();
     expect(screen.getByRole("button", { name: /cancel delete/i })).toBeTruthy();
   });
 
   it("cancels deletion when Cancel is clicked in confirm dialog", () => {
-    setupWorkspace([
-      { id: "doc-0", title: "Rich Doc", content: "some content" },
-      { id: "doc-1", title: "Empty Doc", content: "" },
-    ], 1);
+    setupWorkspace(
+      [
+        { id: "doc-0", title: "Rich Doc", content: "some content" },
+        { id: "doc-1", title: "Empty Doc", content: "" },
+      ],
+      1,
+    );
     renderPanel();
 
     fireEvent.click(screen.getByRole("button", { name: /delete rich doc/i }));
@@ -147,10 +162,13 @@ describe("WorkspacePanel", () => {
   });
 
   it("confirms deletion in confirm dialog", () => {
-    setupWorkspace([
-      { id: "doc-0", title: "Rich Doc", content: "some content" },
-      { id: "doc-1", title: "Empty Doc", content: "" },
-    ], 1);
+    setupWorkspace(
+      [
+        { id: "doc-0", title: "Rich Doc", content: "some content" },
+        { id: "doc-1", title: "Empty Doc", content: "" },
+      ],
+      1,
+    );
     renderPanel();
 
     fireEvent.click(screen.getByRole("button", { name: /delete rich doc/i }));

--- a/src/components/WorkspacePanel.tsx
+++ b/src/components/WorkspacePanel.tsx
@@ -1,0 +1,200 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useRef, useEffect } from "react";
+import { Button } from "./ui/button";
+import { Trash2, Plus, Pencil } from "lucide-react";
+import { useWorkspaces } from "@/lib/WorkspacesContext";
+import { WorkspaceDocument } from "@/lib/workspace";
+
+function DocRow({
+  doc,
+  isActive,
+  onSelect,
+}: {
+  doc: WorkspaceDocument;
+  isActive: boolean;
+  onSelect: () => void;
+}) {
+  const { updateDocument, deleteDocument, activeWorkspace } = useWorkspaces();
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(doc.title);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  const startEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditValue(doc.title);
+    setEditing(true);
+  };
+
+  const commitEdit = () => {
+    const trimmed = (inputRef.current?.value ?? editValue).trim();
+    if (trimmed && trimmed !== doc.title) {
+      updateDocument(doc.id, { title: trimmed });
+    }
+    setEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") commitEdit();
+    if (e.key === "Escape") setEditing(false);
+  };
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const hasContent = doc.content.trim().length > 0;
+    const docCount = activeWorkspace?.documents.length ?? 0;
+    if (hasContent && docCount > 1) {
+      setConfirmDelete(true);
+    } else {
+      deleteDocument(doc.id);
+    }
+  };
+
+  const cancelDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setConfirmDelete(false);
+  };
+
+  const confirmAndDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    deleteDocument(doc.id);
+  };
+
+  if (confirmDelete) {
+    return (
+      <div
+        className="flex items-center gap-1 px-2 py-2 rounded border border-destructive/50 bg-destructive/10"
+        role="group"
+        aria-label={`Confirm delete ${doc.title || "document"}`}
+      >
+        <span className="flex-1 text-xs text-destructive truncate">
+          Delete &ldquo;{doc.title || "Untitled"}&rdquo;?
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs text-destructive hover:bg-destructive/20"
+          onClick={confirmAndDelete}
+          aria-label="Confirm delete"
+        >
+          Delete
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          onClick={cancelDelete}
+          aria-label="Cancel delete"
+        >
+          Cancel
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`group flex items-center gap-1 px-2 py-2 rounded cursor-pointer ${
+        isActive
+          ? "bg-primary/15 text-primary font-medium"
+          : "hover:bg-muted/60 text-foreground"
+      }`}
+      onClick={onSelect}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => e.key === "Enter" && onSelect()}
+      aria-label={`Open ${doc.title || "Untitled"}`}
+      aria-current={isActive ? "true" : undefined}
+    >
+      {editing ? (
+        <input
+          ref={inputRef}
+          className="flex-1 min-w-0 text-sm bg-transparent border-b border-primary focus:outline-none"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Rename document"
+        />
+      ) : (
+        <span className="flex-1 min-w-0 text-sm truncate">
+          {doc.title || "Untitled"}
+        </span>
+      )}
+      {!editing && (
+        <>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
+            onClick={startEdit}
+            aria-label={`Rename ${doc.title || "document"}`}
+          >
+            <Pencil className="w-3 h-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive"
+            onClick={handleDelete}
+            aria-label={`Delete ${doc.title || "document"}`}
+          >
+            <Trash2 className="w-3 h-3" />
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function WorkspacePanel() {
+  const { activeWorkspace, activeDocument, addDocument, setActiveDocumentId, index, activeWorkspaceId } =
+    useWorkspaces();
+  const docs = activeWorkspace?.documents ?? [];
+  const workspaceName = index.find((m) => m.id === activeWorkspaceId)?.name ?? "Workspace";
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-3 py-2 border-b shrink-0">
+        <span className="text-xs font-medium text-muted-foreground truncate flex-1">
+          {workspaceName}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={addDocument}
+          aria-label="New document"
+        >
+          <Plus className="w-4 h-4" />
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2 flex flex-col gap-0.5">
+        {docs.length === 0 ? (
+          <p className="text-xs text-muted-foreground italic text-center mt-4">
+            No documents yet.
+          </p>
+        ) : (
+          docs.map((doc) => (
+            <DocRow
+              key={doc.id}
+              doc={doc}
+              isActive={doc.id === activeDocument?.id}
+              onSelect={() => setActiveDocumentId(doc.id)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/WorkspacePanel.tsx
+++ b/src/components/WorkspacePanel.tsx
@@ -158,10 +158,17 @@ function DocRow({
 }
 
 export function WorkspacePanel() {
-  const { activeWorkspace, activeDocument, addDocument, setActiveDocumentId, index, activeWorkspaceId } =
-    useWorkspaces();
+  const {
+    activeWorkspace,
+    activeDocument,
+    addDocument,
+    setActiveDocumentId,
+    index,
+    activeWorkspaceId,
+  } = useWorkspaces();
   const docs = activeWorkspace?.documents ?? [];
-  const workspaceName = index.find((m) => m.id === activeWorkspaceId)?.name ?? "Workspace";
+  const workspaceName =
+    index.find((m) => m.id === activeWorkspaceId)?.name ?? "Workspace";
 
   return (
     <div className="flex flex-col h-full">

--- a/src/components/WorkspacePicker.test.tsx
+++ b/src/components/WorkspacePicker.test.tsx
@@ -1,0 +1,193 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import React from "react";
+import { WorkspacesProvider } from "@/lib/WorkspacesContext";
+import { WorkspaceMeta, WorkspaceData } from "@/lib/workspace";
+import { WorkspacePicker } from "./WorkspacePicker";
+
+function renderPicker() {
+  return render(
+    <WorkspacesProvider>
+      <WorkspacePicker />
+    </WorkspacesProvider>,
+  );
+}
+
+function getIndex(): WorkspaceMeta[] {
+  return JSON.parse(localStorage.getItem("workspaces_index")!);
+}
+
+function seedTwoWorkspaces() {
+  const ws1: WorkspaceMeta = {
+    id: "ws1",
+    name: "Alpha",
+    createdAt: 1000,
+    updatedAt: 1000,
+  };
+  const ws2: WorkspaceMeta = {
+    id: "ws2",
+    name: "Beta",
+    createdAt: 2000,
+    updatedAt: 2000,
+  };
+  const data: WorkspaceData = {
+    documents: [{ id: "d1", title: "Doc", content: "", updatedAt: 1000 }],
+    activeDocumentId: "d1",
+  };
+  localStorage.setItem("workspaces_index", JSON.stringify([ws1, ws2]));
+  localStorage.setItem("workspace_ws1", JSON.stringify(data));
+  localStorage.setItem("workspace_ws2", JSON.stringify(data));
+  // No active workspace — picker should be shown
+  localStorage.removeItem("active_workspace_id");
+}
+
+describe("WorkspacePicker — rendering", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("renders workspace names in the list", () => {
+    seedTwoWorkspaces();
+    renderPicker();
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.getByText("Beta")).toBeTruthy();
+  });
+
+  it("shows empty state when no workspaces exist", () => {
+    // Pre-seed workspaces_index as empty to skip migration
+    localStorage.setItem("workspaces_index", JSON.stringify([]));
+    renderPicker();
+    expect(screen.getByText(/no workspaces yet/i)).toBeTruthy();
+  });
+
+  it("renders New Workspace button", () => {
+    renderPicker();
+    expect(screen.getByRole("button", { name: /new workspace/i })).toBeTruthy();
+  });
+});
+
+describe("WorkspacePicker — create workspace", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("opens dialog when New Workspace is clicked", () => {
+    renderPicker();
+    fireEvent.click(screen.getByRole("button", { name: /new workspace/i }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("creates a workspace and closes the dialog on confirm", () => {
+    renderPicker();
+    fireEvent.click(screen.getByRole("button", { name: /new workspace/i }));
+    const input = screen.getByPlaceholderText(/workspace name/i);
+    fireEvent.change(input, { target: { value: "My New WS" } });
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    const idx = getIndex();
+    expect(idx.find((w) => w.name === "My New WS")).toBeTruthy();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("create button is disabled when name is empty", () => {
+    renderPicker();
+    fireEvent.click(screen.getByRole("button", { name: /new workspace/i }));
+    const createBtn = screen.getByRole("button", { name: /^create$/i });
+    expect(createBtn).toBeDisabled();
+  });
+
+  it("creates workspace via Enter key", () => {
+    renderPicker();
+    fireEvent.click(screen.getByRole("button", { name: /new workspace/i }));
+    const input = screen.getByPlaceholderText(/workspace name/i);
+    fireEvent.change(input, { target: { value: "Keyboard WS" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(getIndex().find((w) => w.name === "Keyboard WS")).toBeTruthy();
+  });
+});
+
+describe("WorkspacePicker — rename workspace", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    seedTwoWorkspaces();
+  });
+  afterEach(() => localStorage.clear());
+
+  it("shows rename input when pencil icon is clicked", () => {
+    renderPicker();
+    const renameBtn = screen.getAllByRole("button", { name: /rename/i })[0];
+    fireEvent.click(renameBtn);
+    expect(screen.getByDisplayValue("Alpha")).toBeTruthy();
+  });
+
+  it("saves renamed workspace on confirm", () => {
+    renderPicker();
+    fireEvent.click(screen.getAllByRole("button", { name: /rename/i })[0]);
+    const input = screen.getByDisplayValue("Alpha");
+    fireEvent.change(input, { target: { value: "Alpha Renamed" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm rename/i }));
+    expect(getIndex().find((w) => w.name === "Alpha Renamed")).toBeTruthy();
+  });
+
+  it("cancels rename without saving on cancel", () => {
+    renderPicker();
+    fireEvent.click(screen.getAllByRole("button", { name: /rename/i })[0]);
+    const input = screen.getByDisplayValue("Alpha");
+    fireEvent.change(input, { target: { value: "Discard Me" } });
+    fireEvent.click(screen.getByRole("button", { name: /cancel rename/i }));
+    expect(getIndex().find((w) => w.name === "Alpha")).toBeTruthy();
+    expect(getIndex().find((w) => w.name === "Discard Me")).toBeUndefined();
+  });
+});
+
+describe("WorkspacePicker — delete workspace", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    seedTwoWorkspaces();
+  });
+  afterEach(() => localStorage.clear());
+
+  it("shows confirmation dialog when delete is clicked", () => {
+    renderPicker();
+    fireEvent.click(screen.getAllByRole("button", { name: /delete/i })[0]);
+    expect(screen.getByText(/cannot be undone/i)).toBeTruthy();
+  });
+
+  it("deletes workspace after confirmation", () => {
+    renderPicker();
+    fireEvent.click(screen.getAllByRole("button", { name: /delete alpha/i })[0]);
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+    expect(getIndex().find((w) => w.name === "Alpha")).toBeUndefined();
+  });
+
+  it("cancels deletion when cancel is clicked in dialog", () => {
+    renderPicker();
+    fireEvent.click(screen.getAllByRole("button", { name: /delete alpha/i })[0]);
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
+    expect(getIndex().find((w) => w.name === "Alpha")).toBeTruthy();
+  });
+
+  it("deleting the last workspace leaves index empty", () => {
+    // Remove ws2, keep only ws1
+    const ws1: WorkspaceMeta = {
+      id: "ws1",
+      name: "Solo",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const data: WorkspaceData = {
+      documents: [],
+      activeDocumentId: null,
+    };
+    localStorage.setItem("workspaces_index", JSON.stringify([ws1]));
+    localStorage.setItem("workspace_ws1", JSON.stringify(data));
+    renderPicker();
+    fireEvent.click(screen.getByRole("button", { name: /delete solo/i }));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+    expect(getIndex()).toHaveLength(0);
+    expect(screen.getByText(/no workspaces yet/i)).toBeTruthy();
+  });
+});

--- a/src/components/WorkspacePicker.test.tsx
+++ b/src/components/WorkspacePicker.test.tsx
@@ -155,7 +155,9 @@ describe("WorkspacePicker — delete workspace", () => {
 
   it("deletes workspace after confirmation", () => {
     renderPicker();
-    fireEvent.click(screen.getAllByRole("button", { name: /delete alpha/i })[0]);
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /delete alpha/i })[0],
+    );
     const dialog = screen.getByRole("dialog");
     fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
     expect(getIndex().find((w) => w.name === "Alpha")).toBeUndefined();
@@ -163,7 +165,9 @@ describe("WorkspacePicker — delete workspace", () => {
 
   it("cancels deletion when cancel is clicked in dialog", () => {
     renderPicker();
-    fireEvent.click(screen.getAllByRole("button", { name: /delete alpha/i })[0]);
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /delete alpha/i })[0],
+    );
     const dialog = screen.getByRole("dialog");
     fireEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
     expect(getIndex().find((w) => w.name === "Alpha")).toBeTruthy();

--- a/src/components/WorkspacePicker.tsx
+++ b/src/components/WorkspacePicker.tsx
@@ -1,0 +1,238 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from "react";
+import { Pencil, Trash2, FolderOpen, Check, X, Plus } from "lucide-react";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "./ui/dialog";
+import { useWorkspaces } from "@/lib/WorkspacesContext";
+import { WorkspaceMeta } from "@/lib/workspace";
+
+function formatDate(ts: number) {
+  return new Date(ts).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function WorkspaceRow({
+  workspace,
+  onDelete,
+}: {
+  workspace: WorkspaceMeta;
+  onDelete: (id: string) => void;
+}) {
+  const { openWorkspace, renameWorkspace } = useWorkspaces();
+  const [editing, setEditing] = useState(false);
+  const [draftName, setDraftName] = useState(workspace.name);
+
+  const commitRename = () => {
+    const trimmed = draftName.trim();
+    if (trimmed && trimmed !== workspace.name) {
+      renameWorkspace(workspace.id, trimmed);
+    } else {
+      setDraftName(workspace.name);
+    }
+    setEditing(false);
+  };
+
+  const cancelRename = () => {
+    setDraftName(workspace.name);
+    setEditing(false);
+  };
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 rounded-lg border border-border bg-card hover:bg-muted/40 transition-colors">
+      {editing ? (
+        <div className="flex-1 flex items-center gap-2 min-w-0">
+          <Input
+            autoFocus
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitRename();
+              if (e.key === "Escape") cancelRename();
+            }}
+            className="h-8 text-sm"
+          />
+          <button
+            onClick={commitRename}
+            aria-label="Confirm rename"
+            className="text-primary hover:text-primary/80 shrink-0"
+          >
+            <Check className="w-4 h-4" />
+          </button>
+          <button
+            onClick={cancelRename}
+            aria-label="Cancel rename"
+            className="text-muted-foreground hover:text-foreground shrink-0"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium truncate">{workspace.name}</p>
+            <p className="text-xs text-muted-foreground">
+              Modified {formatDate(workspace.updatedAt)}
+            </p>
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground hover:text-foreground"
+              aria-label={`Rename ${workspace.name}`}
+              onClick={() => setEditing(true)}
+            >
+              <Pencil className="w-3.5 h-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground hover:text-destructive"
+              aria-label={`Delete ${workspace.name}`}
+              onClick={() => onDelete(workspace.id)}
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+            </Button>
+            <Button
+              size="sm"
+              className="h-8 gap-1.5"
+              aria-label={`Open ${workspace.name}`}
+              onClick={() => openWorkspace(workspace.id)}
+            >
+              <FolderOpen className="w-3.5 h-3.5" />
+              Open
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function WorkspacePicker() {
+  const { index, createWorkspace, deleteWorkspace } = useWorkspaces();
+  const [showNewDialog, setShowNewDialog] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+
+  const handleCreate = () => {
+    const name = newName.trim();
+    if (!name) return;
+    createWorkspace(name);
+    setNewName("");
+    setShowNewDialog(false);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (deleteTargetId) {
+      deleteWorkspace(deleteTargetId);
+    }
+    setDeleteTargetId(null);
+  };
+
+  const deleteTarget = index.find((w) => w.id === deleteTargetId);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-background px-4">
+      <div className="w-full max-w-lg">
+        <div className="mb-8 text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">Workspaces</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Select a workspace to open or create a new one.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2 mb-4">
+          {index.length === 0 ? (
+            <p className="text-sm text-muted-foreground italic text-center py-6">
+              No workspaces yet. Create one to get started.
+            </p>
+          ) : (
+            index.map((ws) => (
+              <WorkspaceRow
+                key={ws.id}
+                workspace={ws}
+                onDelete={(id) => setDeleteTargetId(id)}
+              />
+            ))
+          )}
+        </div>
+
+        <Button
+          className="w-full gap-2"
+          onClick={() => setShowNewDialog(true)}
+        >
+          <Plus className="w-4 h-4" />
+          New Workspace
+        </Button>
+      </div>
+
+      {/* New workspace dialog */}
+      <Dialog open={showNewDialog} onOpenChange={setShowNewDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Workspace</DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <Input
+              autoFocus
+              placeholder="Workspace name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowNewDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={!newName.trim()}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={deleteTargetId !== null}
+        onOpenChange={(open) => !open && setDeleteTargetId(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Workspace</DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <p className="text-sm text-muted-foreground">
+              Delete{" "}
+              <span className="font-medium text-foreground">
+                {deleteTarget?.name}
+              </span>{" "}
+              and all its documents? This cannot be undone.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTargetId(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteConfirm}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/WorkspacePicker.tsx
+++ b/src/components/WorkspacePicker.tsx
@@ -170,10 +170,7 @@ export function WorkspacePicker() {
           )}
         </div>
 
-        <Button
-          className="w-full gap-2"
-          onClick={() => setShowNewDialog(true)}
-        >
+        <Button className="w-full gap-2" onClick={() => setShowNewDialog(true)}>
           <Plus className="w-4 h-4" />
           New Workspace
         </Button>

--- a/src/lib/EditorTools.test.ts
+++ b/src/lib/EditorTools.test.ts
@@ -44,7 +44,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.read()).toBe("Initial content");
     });
@@ -54,7 +53,6 @@ describe("EditorTools", () => {
         null,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.read()).toBe("");
     });
@@ -66,7 +64,6 @@ describe("EditorTools", () => {
         null,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.search({ query: "hello" })).toBe(
         "Error: Editor not initialized.",
@@ -78,7 +75,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.search({ query: "" })).toBe(
         "Error: query parameter is required.",
@@ -91,7 +87,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.search({ query: "xyz" })).toBe(
         'No occurrences of "xyz" found.',
@@ -113,7 +108,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.search({ query: "foo" })).toBe(
         'Found 1 occurrence(s) of "foo": line 3, col 5.',
@@ -143,7 +137,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.search({ query: "foo" })).toBe(
         'Found 2 occurrence(s) of "foo": line 1, col 1; line 5, col 10.',
@@ -157,7 +150,6 @@ describe("EditorTools", () => {
         null,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.get_metadata()).toBe("Error: Editor not initialized.");
     });
@@ -168,7 +160,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.get_metadata()).toBe("Characters: 0, Words: 0, Lines: 0.");
     });
@@ -179,7 +170,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.get_metadata()).toBe("Characters: 11, Words: 2, Lines: 1.");
     });
@@ -190,7 +180,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.get_metadata()).toBe("Characters: 28, Words: 6, Lines: 3.");
     });
@@ -201,7 +190,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       expect(tools.get_metadata()).toBe("Characters: 15, Words: 2, Lines: 1.");
     });
@@ -214,7 +202,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
 
       const result = await tools.edit({
@@ -241,7 +228,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
 
       const promise = tools.edit({
@@ -282,7 +268,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         true,
-        setEditorContent,
       );
 
       const result = await tools.edit({
@@ -312,7 +297,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
       mockRun = vi.fn().mockResolvedValue({ output: "done" });
     });
@@ -419,7 +403,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         false,
-        setEditorContent,
       );
 
       const promise = tools.write({ content: "New document content" });
@@ -444,7 +427,6 @@ describe("EditorTools", () => {
         mockEditor,
         setSuggestions,
         true,
-        setEditorContent,
       );
 
       const result = await tools.write({ content: "New document content" });

--- a/src/lib/EditorTools.test.ts
+++ b/src/lib/EditorTools.test.ts
@@ -40,42 +40,26 @@ describe("EditorTools", () => {
 
   describe("read", () => {
     it("should return the editor content", () => {
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
       expect(tools.read()).toBe("Initial content");
     });
 
     it("should return empty string if editor is not initialized", () => {
-      const tools = new EditorTools(
-        null,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(null, setSuggestions, false);
       expect(tools.read()).toBe("");
     });
   });
 
   describe("search", () => {
     it("should return error if editor is not initialized", () => {
-      const tools = new EditorTools(
-        null,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(null, setSuggestions, false);
       expect(tools.search({ query: "hello" })).toBe(
         "Error: Editor not initialized.",
       );
     });
 
     it("should return error for empty query", () => {
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
       expect(tools.search({ query: "" })).toBe(
         "Error: query parameter is required.",
       );
@@ -83,11 +67,7 @@ describe("EditorTools", () => {
 
     it("should return not-found message when there are no matches", () => {
       mockModel.findMatches.mockReturnValue([]);
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
       expect(tools.search({ query: "xyz" })).toBe(
         'No occurrences of "xyz" found.',
       );
@@ -104,11 +84,7 @@ describe("EditorTools", () => {
           },
         },
       ]);
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
       expect(tools.search({ query: "foo" })).toBe(
         'Found 1 occurrence(s) of "foo": line 3, col 5.',
       );
@@ -133,11 +109,7 @@ describe("EditorTools", () => {
           },
         },
       ]);
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
       expect(tools.search({ query: "foo" })).toBe(
         'Found 2 occurrence(s) of "foo": line 1, col 1; line 5, col 10.',
       );
@@ -146,51 +118,31 @@ describe("EditorTools", () => {
 
   describe("get_metadata", () => {
     it("should return error if editor is not initialized", () => {
-      const tools = new EditorTools(
-        null,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(null, setSuggestions, false);
       expect(tools.get_metadata()).toBe("Error: Editor not initialized.");
     });
 
     it("should return zero counts for an empty document", () => {
       mockEditor.getValue.mockReturnValue("");
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
       expect(tools.get_metadata()).toBe("Characters: 0, Words: 0, Lines: 0.");
     });
 
     it("should return correct counts for a single-line document", () => {
       mockEditor.getValue.mockReturnValue("hello world");
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
       expect(tools.get_metadata()).toBe("Characters: 11, Words: 2, Lines: 1.");
     });
 
     it("should return correct line count for a multi-line document", () => {
       mockEditor.getValue.mockReturnValue("line one\nline two\nline three");
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
       expect(tools.get_metadata()).toBe("Characters: 28, Words: 6, Lines: 3.");
     });
 
     it("should not count leading/trailing whitespace as words", () => {
       mockEditor.getValue.mockReturnValue("  hello world  ");
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
       expect(tools.get_metadata()).toBe("Characters: 15, Words: 2, Lines: 1.");
     });
   });
@@ -198,11 +150,7 @@ describe("EditorTools", () => {
   describe("edit", () => {
     it("should return an error if text is not found", async () => {
       mockModel.findMatches.mockReturnValue([]);
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
 
       const result = await tools.edit({
         originalText: "missing",
@@ -224,11 +172,7 @@ describe("EditorTools", () => {
           },
         },
       ]);
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
 
       const promise = tools.edit({
         originalText: "old",
@@ -264,11 +208,7 @@ describe("EditorTools", () => {
           },
         },
       ]);
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        true,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, true);
 
       const result = await tools.edit({
         originalText: "old",
@@ -293,11 +233,7 @@ describe("EditorTools", () => {
         generate: vi.fn(),
         generateStream: vi.fn(),
       } as unknown as LlmAdapter;
-      editorToolsInstance = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      editorToolsInstance = new EditorTools(mockEditor, setSuggestions, false);
       mockRun = vi.fn().mockResolvedValue({ output: "done" });
     });
 
@@ -399,11 +335,7 @@ describe("EditorTools", () => {
 
   describe("write", () => {
     it("should create a suggestion for the full document if not approveAll", async () => {
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        false,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
 
       const promise = tools.write({ content: "New document content" });
 
@@ -423,11 +355,7 @@ describe("EditorTools", () => {
     });
 
     it("should apply full replacement immediately if approveAll is true", async () => {
-      const tools = new EditorTools(
-        mockEditor,
-        setSuggestions,
-        true,
-      );
+      const tools = new EditorTools(mockEditor, setSuggestions, true);
 
       const result = await tools.write({ content: "New document content" });
 

--- a/src/lib/EditorTools.ts
+++ b/src/lib/EditorTools.ts
@@ -12,7 +12,6 @@ export class EditorTools {
     private editor: monaco.editor.IStandaloneCodeEditor | null,
     private setSuggestions: (fn: (prev: Suggestion[]) => Suggestion[]) => void,
     private approveAll: boolean,
-    private setEditorContent: (content: string) => void,
   ) {}
 
   read(): string {

--- a/src/lib/SupportingDocsContext.test.tsx
+++ b/src/lib/SupportingDocsContext.test.tsx
@@ -1,0 +1,130 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import React from "react";
+import {
+  SupportingDocsProvider,
+  useSupportingDocs,
+  SupportingDoc,
+} from "./SupportingDocsContext";
+
+function Consumer({
+  onRender,
+}: {
+  onRender: (value: ReturnType<typeof useSupportingDocs>) => void;
+}) {
+  const ctx = useSupportingDocs();
+  onRender(ctx);
+  return null;
+}
+
+function renderWithProvider() {
+  let ctx!: ReturnType<typeof useSupportingDocs>;
+  render(
+    <SupportingDocsProvider>
+      <Consumer onRender={(v) => (ctx = v)} />
+    </SupportingDocsProvider>,
+  );
+  return () => ctx;
+}
+
+describe("SupportingDocsContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts empty when localStorage has no data", () => {
+    const getCtx = renderWithProvider();
+    expect(getCtx().docs).toEqual([]);
+  });
+
+  it("loads existing docs from localStorage on mount", () => {
+    const existing: SupportingDoc[] = [
+      { id: "1", title: "Notes", content: "hello", updatedAt: 1000 },
+    ];
+    localStorage.setItem("supporting_docs", JSON.stringify(existing));
+    const getCtx = renderWithProvider();
+    expect(getCtx().docs).toHaveLength(1);
+    expect(getCtx().docs[0].title).toBe("Notes");
+  });
+
+  it("addDoc creates a new document with defaults and persists it", () => {
+    const getCtx = renderWithProvider();
+    act(() => getCtx().addDoc());
+    const docs = getCtx().docs;
+    expect(docs).toHaveLength(1);
+    expect(docs[0].title).toBe("New Document");
+    expect(docs[0].content).toBe("");
+    expect(typeof docs[0].id).toBe("string");
+    expect(JSON.parse(localStorage.getItem("supporting_docs")!)).toHaveLength(
+      1,
+    );
+  });
+
+  it("updateDoc changes title and content", () => {
+    const getCtx = renderWithProvider();
+    act(() => getCtx().addDoc());
+    const id = getCtx().docs[0].id;
+    act(() =>
+      getCtx().updateDoc(id, { title: "My Notes", content: "## Heading" }),
+    );
+    const doc = getCtx().docs[0];
+    expect(doc.title).toBe("My Notes");
+    expect(doc.content).toBe("## Heading");
+  });
+
+  it("updateDoc bumps updatedAt", () => {
+    const getCtx = renderWithProvider();
+    act(() => getCtx().addDoc());
+    const id = getCtx().docs[0].id;
+    const before = getCtx().docs[0].updatedAt;
+    act(() => getCtx().updateDoc(id, { title: "Changed" }));
+    expect(getCtx().docs[0].updatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("deleteDoc removes the document", () => {
+    const getCtx = renderWithProvider();
+    act(() => getCtx().addDoc());
+    act(() => getCtx().addDoc());
+    expect(getCtx().docs).toHaveLength(2);
+    const id = getCtx().docs[0].id;
+    act(() => getCtx().deleteDoc(id));
+    expect(getCtx().docs).toHaveLength(1);
+    expect(getCtx().docs[0].id).not.toBe(id);
+  });
+
+  it("persists updates to localStorage", () => {
+    const getCtx = renderWithProvider();
+    act(() => getCtx().addDoc());
+    const id = getCtx().docs[0].id;
+    act(() => getCtx().updateDoc(id, { title: "Persisted" }));
+    const stored: SupportingDoc[] = JSON.parse(
+      localStorage.getItem("supporting_docs")!,
+    );
+    expect(stored[0].title).toBe("Persisted");
+  });
+
+  it("persists deletions to localStorage", () => {
+    const getCtx = renderWithProvider();
+    act(() => getCtx().addDoc());
+    const id = getCtx().docs[0].id;
+    act(() => getCtx().deleteDoc(id));
+    const stored = JSON.parse(localStorage.getItem("supporting_docs")!);
+    expect(stored).toHaveLength(0);
+  });
+
+  it("useSupportingDocs throws when used outside provider", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Consumer onRender={() => {}} />)).toThrow(
+      "useSupportingDocs must be used within a SupportingDocsProvider",
+    );
+    spy.mockRestore();
+  });
+});

--- a/src/lib/SupportingDocsContext.tsx
+++ b/src/lib/SupportingDocsContext.tsx
@@ -1,0 +1,87 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export interface SupportingDoc {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+}
+
+interface SupportingDocsContextValue {
+  docs: SupportingDoc[];
+  addDoc: () => void;
+  updateDoc: (
+    id: string,
+    updates: Partial<Pick<SupportingDoc, "title" | "content">>,
+  ) => void;
+  deleteDoc: (id: string) => void;
+}
+
+const STORAGE_KEY = "supporting_docs";
+
+const SupportingDocsContext = createContext<
+  SupportingDocsContextValue | undefined
+>(undefined);
+
+export function SupportingDocsProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [docs, setDocs] = useState<SupportingDoc[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(docs));
+  }, [docs]);
+
+  const addDoc = () => {
+    const doc: SupportingDoc = {
+      id: crypto.randomUUID(),
+      title: "New Document",
+      content: "",
+      updatedAt: Date.now(),
+    };
+    setDocs((prev) => [...prev, doc]);
+  };
+
+  const updateDoc = (
+    id: string,
+    updates: Partial<Pick<SupportingDoc, "title" | "content">>,
+  ) => {
+    setDocs((prev) =>
+      prev.map((d) =>
+        d.id === id ? { ...d, ...updates, updatedAt: Date.now() } : d,
+      ),
+    );
+  };
+
+  const deleteDoc = (id: string) => {
+    setDocs((prev) => prev.filter((d) => d.id !== id));
+  };
+
+  return (
+    <SupportingDocsContext.Provider
+      value={{ docs, addDoc, updateDoc, deleteDoc }}
+    >
+      {children}
+    </SupportingDocsContext.Provider>
+  );
+}
+
+export function useSupportingDocs(): SupportingDocsContextValue {
+  const ctx = useContext(SupportingDocsContext);
+  if (!ctx)
+    throw new Error(
+      "useSupportingDocs must be used within a SupportingDocsProvider",
+    );
+  return ctx;
+}

--- a/src/lib/WorkspaceTools.test.ts
+++ b/src/lib/WorkspaceTools.test.ts
@@ -23,9 +23,9 @@ function makeRef(docs: WorkspaceDocument[]): { current: WorkspaceDocument[] } {
   return { current: docs };
 }
 
-function makeActiveDocRef(
-  doc: { id: string; title: string } | null,
-): { current: { id: string; title: string } | null } {
+function makeActiveDocRef(doc: { id: string; title: string } | null): {
+  current: { id: string; title: string } | null;
+} {
   return { current: doc };
 }
 
@@ -38,8 +38,12 @@ describe("WorkspaceTools", () => {
 
   beforeEach(() => {
     mockRun = vi.fn().mockResolvedValue({ output: "mock answer" });
-    adapterFactory = vi.fn().mockReturnValue({} as LlmAdapter) as AdapterFactory;
-    runnerFactory = vi.fn().mockReturnValue({ run: mockRun }) as SubAgentFactory;
+    adapterFactory = vi
+      .fn()
+      .mockReturnValue({} as LlmAdapter) as AdapterFactory;
+    runnerFactory = vi
+      .fn()
+      .mockReturnValue({ run: mockRun }) as SubAgentFactory;
   });
 
   describe("get_active_doc_info", () => {
@@ -51,7 +55,11 @@ describe("WorkspaceTools", () => {
     });
 
     it("returns error when no document is active", () => {
-      const tools = new WorkspaceTools(makeRef([]), noActiveDoc, adapterFactory);
+      const tools = new WorkspaceTools(
+        makeRef([]),
+        noActiveDoc,
+        adapterFactory,
+      );
       const result = JSON.parse(tools.get_active_doc_info());
       expect(result).toEqual({ error: "No active document" });
     });
@@ -63,7 +71,11 @@ describe("WorkspaceTools", () => {
         makeDoc({ id: "a", title: "Alpha", content: "secret" }),
         makeDoc({ id: "b", title: "Beta", content: "also secret" }),
       ];
-      const tools = new WorkspaceTools(makeRef(docs), noActiveDoc, adapterFactory);
+      const tools = new WorkspaceTools(
+        makeRef(docs),
+        noActiveDoc,
+        adapterFactory,
+      );
       const result = JSON.parse(tools.list_workspace_docs());
       expect(result).toEqual([
         { id: "a", title: "Alpha" },
@@ -72,7 +84,11 @@ describe("WorkspaceTools", () => {
     });
 
     it("returns empty array when workspace has no documents", () => {
-      const tools = new WorkspaceTools(makeRef([]), noActiveDoc, adapterFactory);
+      const tools = new WorkspaceTools(
+        makeRef([]),
+        noActiveDoc,
+        adapterFactory,
+      );
       expect(JSON.parse(tools.list_workspace_docs())).toEqual([]);
     });
   });
@@ -84,13 +100,21 @@ describe("WorkspaceTools", () => {
         title: "My Doc",
         content: "content here",
       });
-      const tools = new WorkspaceTools(makeRef([doc]), noActiveDoc, adapterFactory);
+      const tools = new WorkspaceTools(
+        makeRef([doc]),
+        noActiveDoc,
+        adapterFactory,
+      );
       const result = JSON.parse(tools.read_workspace_doc({ id: "x" }));
       expect(result).toEqual({ title: "My Doc", content: "content here" });
     });
 
     it("returns error for an unknown id", () => {
-      const tools = new WorkspaceTools(makeRef([makeDoc()]), noActiveDoc, adapterFactory);
+      const tools = new WorkspaceTools(
+        makeRef([makeDoc()]),
+        noActiveDoc,
+        adapterFactory,
+      );
       const result = JSON.parse(tools.read_workspace_doc({ id: "unknown" }));
       expect(result).toEqual({ error: "Document not found" });
     });

--- a/src/lib/WorkspaceTools.test.ts
+++ b/src/lib/WorkspaceTools.test.ts
@@ -1,0 +1,235 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WorkspaceTools } from "./WorkspaceTools";
+import type { AdapterFactory, SubAgentFactory } from "./WorkspaceTools";
+import type { WorkspaceDocument } from "./workspace";
+import type { LlmAdapter } from "@mast-ai/core";
+
+function makeDoc(
+  overrides: Partial<WorkspaceDocument> = {},
+): WorkspaceDocument {
+  return {
+    id: "doc-1",
+    title: "Test Doc",
+    content: "Hello world",
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeRef(docs: WorkspaceDocument[]): { current: WorkspaceDocument[] } {
+  return { current: docs };
+}
+
+function makeActiveDocRef(
+  doc: { id: string; title: string } | null,
+): { current: { id: string; title: string } | null } {
+  return { current: doc };
+}
+
+const noActiveDoc = makeActiveDocRef(null);
+
+describe("WorkspaceTools", () => {
+  let mockRun: ReturnType<typeof vi.fn>;
+  let adapterFactory: AdapterFactory;
+  let runnerFactory: SubAgentFactory;
+
+  beforeEach(() => {
+    mockRun = vi.fn().mockResolvedValue({ output: "mock answer" });
+    adapterFactory = vi.fn().mockReturnValue({} as LlmAdapter) as AdapterFactory;
+    runnerFactory = vi.fn().mockReturnValue({ run: mockRun }) as SubAgentFactory;
+  });
+
+  describe("get_active_doc_info", () => {
+    it("returns id and title of the active document", () => {
+      const activeRef = makeActiveDocRef({ id: "x", title: "My Essay" });
+      const tools = new WorkspaceTools(makeRef([]), activeRef, adapterFactory);
+      const result = JSON.parse(tools.get_active_doc_info());
+      expect(result).toEqual({ id: "x", title: "My Essay" });
+    });
+
+    it("returns error when no document is active", () => {
+      const tools = new WorkspaceTools(makeRef([]), noActiveDoc, adapterFactory);
+      const result = JSON.parse(tools.get_active_doc_info());
+      expect(result).toEqual({ error: "No active document" });
+    });
+  });
+
+  describe("list_workspace_docs", () => {
+    it("returns id and title only — no content", () => {
+      const docs = [
+        makeDoc({ id: "a", title: "Alpha", content: "secret" }),
+        makeDoc({ id: "b", title: "Beta", content: "also secret" }),
+      ];
+      const tools = new WorkspaceTools(makeRef(docs), noActiveDoc, adapterFactory);
+      const result = JSON.parse(tools.list_workspace_docs());
+      expect(result).toEqual([
+        { id: "a", title: "Alpha" },
+        { id: "b", title: "Beta" },
+      ]);
+    });
+
+    it("returns empty array when workspace has no documents", () => {
+      const tools = new WorkspaceTools(makeRef([]), noActiveDoc, adapterFactory);
+      expect(JSON.parse(tools.list_workspace_docs())).toEqual([]);
+    });
+  });
+
+  describe("read_workspace_doc", () => {
+    it("returns title and content for a valid id", () => {
+      const doc = makeDoc({
+        id: "x",
+        title: "My Doc",
+        content: "content here",
+      });
+      const tools = new WorkspaceTools(makeRef([doc]), noActiveDoc, adapterFactory);
+      const result = JSON.parse(tools.read_workspace_doc({ id: "x" }));
+      expect(result).toEqual({ title: "My Doc", content: "content here" });
+    });
+
+    it("returns error for an unknown id", () => {
+      const tools = new WorkspaceTools(makeRef([makeDoc()]), noActiveDoc, adapterFactory);
+      const result = JSON.parse(tools.read_workspace_doc({ id: "unknown" }));
+      expect(result).toEqual({ error: "Document not found" });
+    });
+  });
+
+  describe("query_workspace_doc", () => {
+    it("returns error for unknown doc id", async () => {
+      const tools = new WorkspaceTools(
+        makeRef([]),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+      );
+      const result = JSON.parse(
+        await tools.query_workspace_doc({ id: "nope", query: "anything" }),
+      );
+      expect(result).toEqual({ error: "Document not found" });
+      expect(runnerFactory).not.toHaveBeenCalled();
+    });
+
+    it("creates a sub-agent runner with doc content and query, returns summary", async () => {
+      mockRun.mockResolvedValue({ output: "A concise summary." });
+      const doc = makeDoc({
+        id: "d1",
+        title: "Brief",
+        content: "The sky is blue.",
+      });
+      const tools = new WorkspaceTools(
+        makeRef([doc]),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+      );
+
+      const result = JSON.parse(
+        await tools.query_workspace_doc({
+          id: "d1",
+          query: "What color is the sky?",
+        }),
+      );
+
+      expect(result).toEqual({ summary: "A concise summary." });
+      expect(runnerFactory).toHaveBeenCalledOnce();
+
+      const [agentConfig, input] = mockRun.mock.calls[0];
+      expect(agentConfig.name).toBe("DocQuerier");
+      expect(input).toContain("Brief");
+      expect(input).toContain("The sky is blue.");
+      expect(input).toContain("What color is the sky?");
+    });
+
+    it("calls adapterFactory to create the sub-agent adapter", async () => {
+      const doc = makeDoc();
+      const tools = new WorkspaceTools(
+        makeRef([doc]),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+      );
+      await tools.query_workspace_doc({ id: "doc-1", query: "q" });
+      expect(adapterFactory).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("query_workspace", () => {
+    it("calls query_workspace_doc for each document and passes summaries to synthesizer", async () => {
+      const docs = [
+        makeDoc({ id: "d1", title: "Doc 1", content: "content 1" }),
+        makeDoc({ id: "d2", title: "Doc 2", content: "content 2" }),
+      ];
+
+      mockRun
+        .mockResolvedValueOnce({ output: "Summary of doc 1." })
+        .mockResolvedValueOnce({ output: "Summary of doc 2." })
+        .mockResolvedValueOnce({ output: "Final synthesized answer." });
+
+      const tools = new WorkspaceTools(
+        makeRef(docs),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+      );
+      const result = JSON.parse(
+        await tools.query_workspace({ query: "What do the docs say?" }),
+      );
+
+      expect(result).toEqual({ answer: "Final synthesized answer." });
+      expect(mockRun).toHaveBeenCalledTimes(3);
+
+      const [synthAgent, synthInput] = mockRun.mock.calls[2];
+      expect(synthAgent.name).toBe("WorkspaceSynthesizer");
+      expect(synthInput).toContain("Summary of doc 1.");
+      expect(synthInput).toContain("Summary of doc 2.");
+      expect(synthInput).toContain("What do the docs say?");
+    });
+
+    it("returns an answer even with a single document", async () => {
+      mockRun
+        .mockResolvedValueOnce({ output: "Single doc summary." })
+        .mockResolvedValueOnce({ output: "Final answer." });
+
+      const tools = new WorkspaceTools(
+        makeRef([makeDoc()]),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+      );
+      const result = JSON.parse(await tools.query_workspace({ query: "q" }));
+      expect(result).toEqual({ answer: "Final answer." });
+    });
+
+    it("skips docs that return an error from query_workspace_doc", async () => {
+      const docs = [
+        makeDoc({ id: "d1", title: "Good", content: "good content" }),
+        makeDoc({ id: "d2", title: "Bad", content: "" }),
+      ];
+
+      const spy = vi.spyOn(WorkspaceTools.prototype, "query_workspace_doc");
+      spy.mockImplementation(async ({ id }) => {
+        if (id === "d2") return JSON.stringify({ error: "Document not found" });
+        return JSON.stringify({ summary: "Good summary." });
+      });
+
+      mockRun.mockResolvedValueOnce({ output: "Only good doc answer." });
+
+      const tools = new WorkspaceTools(
+        makeRef(docs),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+      );
+      const result = JSON.parse(await tools.query_workspace({ query: "q" }));
+
+      const [, synthInput] = mockRun.mock.calls[0];
+      expect(synthInput).toContain("Good summary.");
+      expect(synthInput).not.toContain("Document not found");
+      expect(result).toEqual({ answer: "Only good doc answer." });
+
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/lib/WorkspaceTools.ts
+++ b/src/lib/WorkspaceTools.ts
@@ -1,0 +1,188 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { AgentRunner, LlmAdapter, ToolRegistry } from "@mast-ai/core";
+import type { AgentConfig } from "@mast-ai/core";
+import { WorkspaceDocument } from "./workspace";
+
+type RunnerLike = {
+  run: (agent: AgentConfig, input: string) => Promise<{ output: string }>;
+};
+
+export type AdapterFactory = () => LlmAdapter;
+export type SubAgentFactory = (adapter: LlmAdapter) => RunnerLike;
+
+/** Accepts any object with a `current` array — compatible with React.MutableRefObject. */
+export interface DocsRef {
+  current: WorkspaceDocument[];
+}
+
+export interface ActiveDocRef {
+  current: { id: string; title: string } | null;
+}
+
+const defaultRunnerFactory: SubAgentFactory = (adapter) =>
+  new AgentRunner(adapter);
+
+export class WorkspaceTools {
+  constructor(
+    private docsRef: DocsRef,
+    private activeDocRef: ActiveDocRef,
+    private adapterFactory: AdapterFactory,
+    private runnerFactory: SubAgentFactory = defaultRunnerFactory,
+  ) {}
+
+  get_active_doc_info(): string {
+    const doc = this.activeDocRef.current;
+    if (!doc) return JSON.stringify({ error: "No active document" });
+    return JSON.stringify({ id: doc.id, title: doc.title });
+  }
+
+  list_workspace_docs(): string {
+    const docs = this.docsRef.current;
+    return JSON.stringify(docs.map((d) => ({ id: d.id, title: d.title })));
+  }
+
+  read_workspace_doc({ id }: { id: string }): string {
+    const doc = this.docsRef.current.find((d) => d.id === id);
+    if (!doc) return JSON.stringify({ error: "Document not found" });
+    return JSON.stringify({ title: doc.title, content: doc.content });
+  }
+
+  async query_workspace_doc({
+    id,
+    query,
+  }: {
+    id: string;
+    query: string;
+  }): Promise<string> {
+    const doc = this.docsRef.current.find((d) => d.id === id);
+    if (!doc) return JSON.stringify({ error: "Document not found" });
+
+    const adapter = this.adapterFactory();
+    const runner = this.runnerFactory(adapter);
+    const agent: AgentConfig = {
+      name: "DocQuerier",
+      instructions:
+        "You are a helpful assistant. Answer the user's question based solely on the provided document. Reply with a concise summary or direct answer.",
+      tools: [],
+    };
+    const input = `Document title: ${doc.title}\n\nDocument content:\n${doc.content}\n\nQuestion: ${query}`;
+    const result = await runner.run(agent, input);
+    return JSON.stringify({ summary: result.output });
+  }
+
+  async query_workspace({ query }: { query: string }): Promise<string> {
+    const docs = this.docsRef.current;
+    const summaries: string[] = [];
+
+    for (const doc of docs) {
+      const raw = await this.query_workspace_doc({ id: doc.id, query });
+      const parsed: { summary?: string; error?: string } = JSON.parse(raw);
+      if (parsed.summary) {
+        summaries.push(`Document "${doc.title}": ${parsed.summary}`);
+      }
+    }
+
+    const adapter = this.adapterFactory();
+    const runner = this.runnerFactory(adapter);
+    const agent: AgentConfig = {
+      name: "WorkspaceSynthesizer",
+      instructions:
+        "You are a helpful assistant. Synthesize the provided per-document summaries to give a comprehensive answer to the user's question.",
+      tools: [],
+    };
+    const input = `Summaries from workspace documents:\n\n${summaries.join("\n\n")}\n\nQuestion: ${query}`;
+    const result = await runner.run(agent, input);
+    return JSON.stringify({ answer: result.output });
+  }
+}
+
+export function registerWorkspaceTools(
+  registry: ToolRegistry,
+  tools: WorkspaceTools,
+): void {
+  registry.register({
+    definition: () => ({
+      name: "get_active_doc_info",
+      description:
+        "Returns the id and title of the document currently open in the editor. Use this when the user references 'this document', 'the current document', or a document by name without specifying an id.",
+      parameters: { type: "object", properties: {} },
+    }),
+    call: async () => tools.get_active_doc_info(),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "list_workspace_docs",
+      description:
+        "Lists all documents in the current workspace. Returns an array of { id, title } objects. Use this to discover what documents exist before reading or querying them.",
+      parameters: { type: "object", properties: {} },
+    }),
+    call: async () => tools.list_workspace_docs(),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "read_workspace_doc",
+      description:
+        "Reads the full content of a specific document in the workspace. Returns { title, content } or { error } if not found.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description:
+              "The document ID to read. Use list_workspace_docs first to get IDs.",
+          },
+        },
+        required: ["id"],
+      },
+    }),
+    call: async (args: { id: string }) => tools.read_workspace_doc(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "query_workspace_doc",
+      description:
+        "Asks a question about a specific document in the workspace using a sub-agent. Returns { summary } with a concise answer. Prefer this over read_workspace_doc when you need a targeted answer rather than raw content.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description: "The document ID to query.",
+          },
+          query: {
+            type: "string",
+            description: "The question or query about the document.",
+          },
+        },
+        required: ["id", "query"],
+      },
+    }),
+    call: async (args: { id: string; query: string }) =>
+      tools.query_workspace_doc(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "query_workspace",
+      description:
+        "Asks a question that spans all documents in the workspace. Queries each document individually then synthesizes the results. Returns { answer }.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "The question to answer across all workspace documents.",
+          },
+        },
+        required: ["query"],
+      },
+    }),
+    call: async (args: { query: string }) => tools.query_workspace(args),
+  });
+}

--- a/src/lib/WorkspacesContext.test.tsx
+++ b/src/lib/WorkspacesContext.test.tsx
@@ -318,6 +318,44 @@ describe("WorkspacesContext — localStorage persistence", () => {
   });
 });
 
+describe("WorkspacesContext — renameWorkspace / closeWorkspace", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("renameWorkspace updates name in index", () => {
+    const getCtx = renderWithProvider();
+    const id = getCtx().activeWorkspaceId!;
+    act(() => {
+      getCtx().renameWorkspace(id, "Renamed");
+    });
+    expect(getCtx().index.find((m) => m.id === id)?.name).toBe("Renamed");
+    expect(getIndex().find((m) => m.id === id)?.name).toBe("Renamed");
+  });
+
+  it("renameWorkspace bumps updatedAt", () => {
+    const getCtx = renderWithProvider();
+    const id = getCtx().activeWorkspaceId!;
+    const before = getCtx().index.find((m) => m.id === id)!.updatedAt;
+    act(() => {
+      getCtx().renameWorkspace(id, "New Name");
+    });
+    expect(
+      getCtx().index.find((m) => m.id === id)!.updatedAt,
+    ).toBeGreaterThanOrEqual(before);
+  });
+
+  it("closeWorkspace sets activeWorkspaceId to null", () => {
+    const getCtx = renderWithProvider();
+    expect(getCtx().activeWorkspaceId).not.toBeNull();
+    act(() => {
+      getCtx().closeWorkspace();
+    });
+    expect(getCtx().activeWorkspaceId).toBeNull();
+    expect(getCtx().activeWorkspace).toBeNull();
+    expect(localStorage.getItem("active_workspace_id")).toBeNull();
+  });
+});
+
 describe("WorkspacesContext — error guard", () => {
   it("useWorkspaces throws when used outside provider", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/lib/WorkspacesContext.test.tsx
+++ b/src/lib/WorkspacesContext.test.tsx
@@ -1,0 +1,329 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import React from "react";
+import { WorkspacesProvider, useWorkspaces } from "./WorkspacesContext";
+import { WorkspaceMeta, WorkspaceData } from "./workspace";
+
+function Consumer({
+  onRender,
+}: {
+  onRender: (value: ReturnType<typeof useWorkspaces>) => void;
+}) {
+  const ctx = useWorkspaces();
+  onRender(ctx);
+  return null;
+}
+
+function renderWithProvider() {
+  let ctx!: ReturnType<typeof useWorkspaces>;
+  render(
+    <WorkspacesProvider>
+      <Consumer onRender={(v) => (ctx = v)} />
+    </WorkspacesProvider>,
+  );
+  return () => ctx;
+}
+
+function getWorkspaceData(id: string): WorkspaceData {
+  return JSON.parse(localStorage.getItem(`workspace_${id}`)!);
+}
+
+function getIndex(): WorkspaceMeta[] {
+  return JSON.parse(localStorage.getItem("workspaces_index")!);
+}
+
+describe("WorkspacesContext — migration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("creates a default workspace on first load (no prior data)", () => {
+    const getCtx = renderWithProvider();
+    const ctx = getCtx();
+    expect(ctx.index).toHaveLength(1);
+    expect(ctx.index[0].name).toBe("My Workspace");
+    expect(ctx.activeWorkspaceId).toBe(ctx.index[0].id);
+    expect(ctx.activeWorkspace).not.toBeNull();
+  });
+
+  it("creates an Untitled Document as the active doc on first load", () => {
+    const getCtx = renderWithProvider();
+    const ctx = getCtx();
+    const docs = ctx.activeWorkspace!.documents;
+    expect(docs).toHaveLength(1);
+    expect(docs[0].title).toBe("Untitled Document");
+    expect(ctx.activeDocument?.id).toBe(docs[0].id);
+  });
+
+  it("imports supporting_docs entries during migration", () => {
+    localStorage.setItem(
+      "supporting_docs",
+      JSON.stringify([
+        { id: "d1", title: "Notes", content: "hello", updatedAt: 1000 },
+      ]),
+    );
+    const getCtx = renderWithProvider();
+    const docs = getCtx().activeWorkspace!.documents;
+    // imported doc + "Untitled Document"
+    expect(docs).toHaveLength(2);
+    expect(docs.find((d) => d.title === "Notes")).toBeTruthy();
+  });
+
+  it("removes supporting_docs from localStorage after migration", () => {
+    localStorage.setItem(
+      "supporting_docs",
+      JSON.stringify([{ id: "d1", title: "A", content: "", updatedAt: 1 }]),
+    );
+    renderWithProvider();
+    expect(localStorage.getItem("supporting_docs")).toBeNull();
+  });
+
+  it("skips migration when workspaces_index already exists", () => {
+    // Pre-populate workspace storage
+    const meta: WorkspaceMeta = {
+      id: "ws1",
+      name: "Existing",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    localStorage.setItem("workspaces_index", JSON.stringify([meta]));
+    localStorage.setItem("active_workspace_id", "ws1");
+    const data: WorkspaceData = {
+      documents: [{ id: "d1", title: "Doc", content: "hi", updatedAt: 1 }],
+      activeDocumentId: "d1",
+    };
+    localStorage.setItem("workspace_ws1", JSON.stringify(data));
+
+    const getCtx = renderWithProvider();
+    expect(getCtx().index[0].name).toBe("Existing");
+    expect(getCtx().activeWorkspace!.documents[0].title).toBe("Doc");
+  });
+});
+
+describe("WorkspacesContext — workspace CRUD", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("createWorkspace adds to index and opens the new workspace", () => {
+    const getCtx = renderWithProvider();
+    act(() => {
+      getCtx().createWorkspace("Project Alpha");
+    });
+    expect(getCtx().index).toHaveLength(2);
+    const newMeta = getCtx().index.find((m) => m.name === "Project Alpha")!;
+    expect(newMeta).toBeTruthy();
+    expect(getCtx().activeWorkspaceId).toBe(newMeta.id);
+    expect(getCtx().activeWorkspace!.documents).toHaveLength(1);
+  });
+
+  it("createWorkspace persists to localStorage", () => {
+    const getCtx = renderWithProvider();
+    act(() => {
+      getCtx().createWorkspace("Alpha");
+    });
+    const stored = getIndex();
+    expect(stored.find((m) => m.name === "Alpha")).toBeTruthy();
+  });
+
+  it("openWorkspace loads the correct workspace data", () => {
+    const getCtx = renderWithProvider();
+    let ws2Id!: string;
+    act(() => {
+      ws2Id = getCtx().createWorkspace("Second").id;
+    });
+    // Go back to first workspace
+    const firstId = getCtx().index.find((m) => m.name === "My Workspace")!.id;
+    act(() => {
+      getCtx().openWorkspace(firstId);
+    });
+    expect(getCtx().activeWorkspaceId).toBe(firstId);
+    // Go to second
+    act(() => {
+      getCtx().openWorkspace(ws2Id);
+    });
+    expect(getCtx().activeWorkspaceId).toBe(ws2Id);
+  });
+
+  it("deleteWorkspace removes it from index and localStorage", () => {
+    const getCtx = renderWithProvider();
+    let ws2Id!: string;
+    act(() => {
+      ws2Id = getCtx().createWorkspace("ToDelete").id;
+    });
+    act(() => {
+      getCtx().deleteWorkspace(ws2Id);
+    });
+    expect(getCtx().index.find((m) => m.id === ws2Id)).toBeUndefined();
+    expect(localStorage.getItem(`workspace_${ws2Id}`)).toBeNull();
+  });
+
+  it("deleteWorkspace on active workspace switches to another", () => {
+    const getCtx = renderWithProvider();
+    const firstId = getCtx().activeWorkspaceId!;
+    act(() => {
+      getCtx().createWorkspace("Second");
+    });
+    act(() => {
+      getCtx().deleteWorkspace(firstId);
+    });
+    expect(getCtx().activeWorkspaceId).not.toBe(firstId);
+    expect(getCtx().activeWorkspaceId).not.toBeNull();
+  });
+
+  it("deleteWorkspace on last workspace sets activeWorkspaceId to null", () => {
+    const getCtx = renderWithProvider();
+    const onlyId = getCtx().activeWorkspaceId!;
+    act(() => {
+      getCtx().deleteWorkspace(onlyId);
+    });
+    expect(getCtx().activeWorkspaceId).toBeNull();
+    expect(getCtx().activeWorkspace).toBeNull();
+    expect(localStorage.getItem("active_workspace_id")).toBeNull();
+  });
+});
+
+describe("WorkspacesContext — document CRUD", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("addDocument creates a new doc and makes it active", () => {
+    const getCtx = renderWithProvider();
+    act(() => {
+      getCtx().addDocument();
+    });
+    const docs = getCtx().activeWorkspace!.documents;
+    expect(docs).toHaveLength(2);
+    const newDoc = docs[docs.length - 1];
+    expect(newDoc.title).toBe("Untitled Document");
+    expect(getCtx().activeWorkspace!.activeDocumentId).toBe(newDoc.id);
+  });
+
+  it("updateDocument changes title and content", () => {
+    const getCtx = renderWithProvider();
+    const docId = getCtx().activeDocument!.id;
+    act(() => {
+      getCtx().updateDocument(docId, { title: "My Doc", content: "# Hi" });
+    });
+    const doc = getCtx().activeWorkspace!.documents.find(
+      (d) => d.id === docId,
+    )!;
+    expect(doc.title).toBe("My Doc");
+    expect(doc.content).toBe("# Hi");
+  });
+
+  it("updateDocument bumps updatedAt", () => {
+    const getCtx = renderWithProvider();
+    const docId = getCtx().activeDocument!.id;
+    const before = getCtx().activeDocument!.updatedAt;
+    act(() => {
+      getCtx().updateDocument(docId, { title: "Changed" });
+    });
+    expect(getCtx().activeDocument!.updatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("deleteDocument removes the document", () => {
+    const getCtx = renderWithProvider();
+    act(() => {
+      getCtx().addDocument();
+    });
+    expect(getCtx().activeWorkspace!.documents).toHaveLength(2);
+    const firstId = getCtx().activeWorkspace!.documents[0].id;
+    act(() => {
+      getCtx().deleteDocument(firstId);
+    });
+    expect(getCtx().activeWorkspace!.documents).toHaveLength(1);
+    expect(getCtx().activeWorkspace!.documents[0].id).not.toBe(firstId);
+  });
+
+  it("deleteDocument on active doc reassigns activeDocumentId", () => {
+    const getCtx = renderWithProvider();
+    act(() => {
+      getCtx().addDocument();
+    });
+    const activeId = getCtx().activeWorkspace!.activeDocumentId!;
+    act(() => {
+      getCtx().deleteDocument(activeId);
+    });
+    const newActiveId = getCtx().activeWorkspace!.activeDocumentId;
+    expect(newActiveId).not.toBe(activeId);
+  });
+
+  it("setActiveDocumentId changes the active doc", () => {
+    const getCtx = renderWithProvider();
+    act(() => {
+      getCtx().addDocument();
+    });
+    const firstId = getCtx().activeWorkspace!.documents[0].id;
+    act(() => {
+      getCtx().setActiveDocumentId(firstId);
+    });
+    expect(getCtx().activeWorkspace!.activeDocumentId).toBe(firstId);
+  });
+
+  it("activeDocument reflects activeDocumentId", () => {
+    const getCtx = renderWithProvider();
+    act(() => {
+      getCtx().addDocument();
+    });
+    const firstId = getCtx().activeWorkspace!.documents[0].id;
+    act(() => {
+      getCtx().setActiveDocumentId(firstId);
+    });
+    expect(getCtx().activeDocument?.id).toBe(firstId);
+  });
+});
+
+describe("WorkspacesContext — localStorage persistence", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("persists workspace data after updateDocument", () => {
+    const getCtx = renderWithProvider();
+    const workspaceId = getCtx().activeWorkspaceId!;
+    const docId = getCtx().activeDocument!.id;
+    act(() => {
+      getCtx().updateDocument(docId, { title: "Saved" });
+    });
+    const data = getWorkspaceData(workspaceId);
+    expect(data.documents.find((d) => d.id === docId)?.title).toBe("Saved");
+  });
+
+  it("persists index after createWorkspace", () => {
+    const getCtx = renderWithProvider();
+    act(() => {
+      getCtx().createWorkspace("New WS");
+    });
+    const stored = getIndex();
+    expect(stored.find((m) => m.name === "New WS")).toBeTruthy();
+  });
+
+  it("active_workspace_id is updated when opening a workspace", () => {
+    const getCtx = renderWithProvider();
+    let secondId!: string;
+    act(() => {
+      secondId = getCtx().createWorkspace("Second").id;
+    });
+    act(() => {
+      getCtx().openWorkspace(secondId);
+    });
+    expect(localStorage.getItem("active_workspace_id")).toBe(secondId);
+  });
+});
+
+describe("WorkspacesContext — error guard", () => {
+  it("useWorkspaces throws when used outside provider", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Consumer onRender={() => {}} />)).toThrow(
+      "useWorkspaces must be used within a WorkspacesProvider",
+    );
+    spy.mockRestore();
+  });
+});

--- a/src/lib/WorkspacesContext.tsx
+++ b/src/lib/WorkspacesContext.tsx
@@ -127,6 +127,8 @@ interface WorkspacesContextValue {
   createWorkspace: (name: string) => WorkspaceMeta;
   openWorkspace: (id: string) => void;
   deleteWorkspace: (id: string) => void;
+  renameWorkspace: (id: string, newName: string) => void;
+  closeWorkspace: () => void;
 
   addDocument: () => void;
   updateDocument: (
@@ -194,6 +196,20 @@ export function WorkspacesProvider({
     setActiveWorkspaceId(id);
     setActiveWorkspace(data);
     localStorage.setItem(ACTIVE_WORKSPACE_KEY, id);
+  };
+
+  const closeWorkspace = () => {
+    setActiveWorkspaceId(null);
+    setActiveWorkspace(null);
+    localStorage.removeItem(ACTIVE_WORKSPACE_KEY);
+  };
+
+  const renameWorkspace = (id: string, newName: string) => {
+    const newIndex = index.map((m) =>
+      m.id === id ? { ...m, name: newName, updatedAt: Date.now() } : m,
+    );
+    setIndex(newIndex);
+    saveIndex(newIndex);
   };
 
   const deleteWorkspace = (id: string) => {
@@ -279,6 +295,8 @@ export function WorkspacesProvider({
         createWorkspace,
         openWorkspace,
         deleteWorkspace,
+        renameWorkspace,
+        closeWorkspace,
         addDocument,
         updateDocument,
         deleteDocument,

--- a/src/lib/WorkspacesContext.tsx
+++ b/src/lib/WorkspacesContext.tsx
@@ -1,0 +1,298 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { createContext, useContext, useState } from "react";
+import { WorkspaceDocument, WorkspaceMeta, WorkspaceData } from "./workspace";
+
+const WORKSPACES_INDEX_KEY = "workspaces_index";
+const ACTIVE_WORKSPACE_KEY = "active_workspace_id";
+
+function workspaceKey(id: string) {
+  return `workspace_${id}`;
+}
+
+function saveIndex(index: WorkspaceMeta[]) {
+  localStorage.setItem(WORKSPACES_INDEX_KEY, JSON.stringify(index));
+}
+
+function saveWorkspaceData(id: string, data: WorkspaceData) {
+  localStorage.setItem(workspaceKey(id), JSON.stringify(data));
+}
+
+function loadWorkspaceData(id: string): WorkspaceData | null {
+  try {
+    const raw = localStorage.getItem(workspaceKey(id));
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+interface SupportingDocLike {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+}
+
+function runMigration(): {
+  index: WorkspaceMeta[];
+  activeId: string;
+  workspaceData: WorkspaceData;
+} {
+  const workspaceId = crypto.randomUUID();
+  const now = Date.now();
+
+  const meta: WorkspaceMeta = {
+    id: workspaceId,
+    name: "My Workspace",
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  let supportingDocs: SupportingDocLike[] = [];
+  try {
+    supportingDocs = JSON.parse(
+      localStorage.getItem("supporting_docs") ?? "[]",
+    );
+  } catch {
+    // keep the empty array default
+  }
+
+  const importedDocs: WorkspaceDocument[] = supportingDocs.map((doc) => ({
+    id: doc.id,
+    title: doc.title,
+    content: doc.content,
+    updatedAt: doc.updatedAt,
+  }));
+
+  const untitledDoc: WorkspaceDocument = {
+    id: crypto.randomUUID(),
+    title: "Untitled Document",
+    content: "",
+    updatedAt: now,
+  };
+
+  const documents = [...importedDocs, untitledDoc];
+  const workspaceData: WorkspaceData = {
+    documents,
+    activeDocumentId: untitledDoc.id,
+  };
+
+  const index = [meta];
+  saveIndex(index);
+  saveWorkspaceData(workspaceId, workspaceData);
+  localStorage.setItem(ACTIVE_WORKSPACE_KEY, workspaceId);
+  localStorage.removeItem("supporting_docs");
+
+  return { index, activeId: workspaceId, workspaceData };
+}
+
+function initState(): {
+  index: WorkspaceMeta[];
+  activeWorkspaceId: string | null;
+  activeWorkspace: WorkspaceData | null;
+} {
+  const raw = localStorage.getItem(WORKSPACES_INDEX_KEY);
+  if (!raw) {
+    const { index, activeId, workspaceData } = runMigration();
+    return {
+      index,
+      activeWorkspaceId: activeId,
+      activeWorkspace: workspaceData,
+    };
+  }
+
+  let index: WorkspaceMeta[] = [];
+  try {
+    index = JSON.parse(raw);
+  } catch {
+    // keep the empty array default
+  }
+
+  const activeWorkspaceId = localStorage.getItem(ACTIVE_WORKSPACE_KEY);
+  const activeWorkspace = activeWorkspaceId
+    ? loadWorkspaceData(activeWorkspaceId)
+    : null;
+
+  return { index, activeWorkspaceId, activeWorkspace };
+}
+
+interface WorkspacesContextValue {
+  index: WorkspaceMeta[];
+  activeWorkspaceId: string | null;
+  activeWorkspace: WorkspaceData | null;
+  activeDocument: WorkspaceDocument | null;
+
+  createWorkspace: (name: string) => WorkspaceMeta;
+  openWorkspace: (id: string) => void;
+  deleteWorkspace: (id: string) => void;
+
+  addDocument: () => void;
+  updateDocument: (
+    id: string,
+    patch: Partial<Pick<WorkspaceDocument, "title" | "content">>,
+  ) => void;
+  deleteDocument: (id: string) => void;
+  setActiveDocumentId: (id: string) => void;
+}
+
+const WorkspacesContext = createContext<WorkspacesContextValue | undefined>(
+  undefined,
+);
+
+export function WorkspacesProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const initial = initState();
+  const [index, setIndex] = useState<WorkspaceMeta[]>(initial.index);
+  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(
+    initial.activeWorkspaceId,
+  );
+  const [activeWorkspace, setActiveWorkspace] = useState<WorkspaceData | null>(
+    initial.activeWorkspace,
+  );
+
+  const activeDocument =
+    activeWorkspace?.documents.find(
+      (d) => d.id === activeWorkspace.activeDocumentId,
+    ) ?? null;
+
+  const createWorkspace = (name: string): WorkspaceMeta => {
+    const now = Date.now();
+    const meta: WorkspaceMeta = {
+      id: crypto.randomUUID(),
+      name,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const untitled: WorkspaceDocument = {
+      id: crypto.randomUUID(),
+      title: "Untitled Document",
+      content: "",
+      updatedAt: now,
+    };
+    const data: WorkspaceData = {
+      documents: [untitled],
+      activeDocumentId: untitled.id,
+    };
+
+    const newIndex = [...index, meta];
+    setIndex(newIndex);
+    saveIndex(newIndex);
+    saveWorkspaceData(meta.id, data);
+    setActiveWorkspaceId(meta.id);
+    setActiveWorkspace(data);
+    localStorage.setItem(ACTIVE_WORKSPACE_KEY, meta.id);
+    return meta;
+  };
+
+  const openWorkspace = (id: string) => {
+    const data = loadWorkspaceData(id);
+    setActiveWorkspaceId(id);
+    setActiveWorkspace(data);
+    localStorage.setItem(ACTIVE_WORKSPACE_KEY, id);
+  };
+
+  const deleteWorkspace = (id: string) => {
+    const newIndex = index.filter((m) => m.id !== id);
+    setIndex(newIndex);
+    saveIndex(newIndex);
+    localStorage.removeItem(workspaceKey(id));
+
+    if (activeWorkspaceId === id) {
+      const next = newIndex[0] ?? null;
+      if (next) {
+        openWorkspace(next.id);
+      } else {
+        setActiveWorkspaceId(null);
+        setActiveWorkspace(null);
+        localStorage.removeItem(ACTIVE_WORKSPACE_KEY);
+      }
+    }
+  };
+
+  function mutateActiveWorkspace(fn: (data: WorkspaceData) => WorkspaceData) {
+    if (!activeWorkspaceId || !activeWorkspace) return;
+    const updated = fn(activeWorkspace);
+    setActiveWorkspace(updated);
+    saveWorkspaceData(activeWorkspaceId, updated);
+
+    const now = Date.now();
+    const newIndex = index.map((m) =>
+      m.id === activeWorkspaceId ? { ...m, updatedAt: now } : m,
+    );
+    setIndex(newIndex);
+    saveIndex(newIndex);
+  }
+
+  const addDocument = () => {
+    const doc: WorkspaceDocument = {
+      id: crypto.randomUUID(),
+      title: "Untitled Document",
+      content: "",
+      updatedAt: Date.now(),
+    };
+    mutateActiveWorkspace((data) => ({
+      ...data,
+      documents: [...data.documents, doc],
+      activeDocumentId: doc.id,
+    }));
+  };
+
+  const updateDocument = (
+    id: string,
+    patch: Partial<Pick<WorkspaceDocument, "title" | "content">>,
+  ) => {
+    mutateActiveWorkspace((data) => ({
+      ...data,
+      documents: data.documents.map((d) =>
+        d.id === id ? { ...d, ...patch, updatedAt: Date.now() } : d,
+      ),
+    }));
+  };
+
+  const deleteDocument = (id: string) => {
+    mutateActiveWorkspace((data) => {
+      const remaining = data.documents.filter((d) => d.id !== id);
+      let newActiveId = data.activeDocumentId;
+      if (newActiveId === id) {
+        newActiveId = remaining[0]?.id ?? null;
+      }
+      return { documents: remaining, activeDocumentId: newActiveId };
+    });
+  };
+
+  const setActiveDocumentId = (id: string) => {
+    mutateActiveWorkspace((data) => ({ ...data, activeDocumentId: id }));
+  };
+
+  return (
+    <WorkspacesContext.Provider
+      value={{
+        index,
+        activeWorkspaceId,
+        activeWorkspace,
+        activeDocument,
+        createWorkspace,
+        openWorkspace,
+        deleteWorkspace,
+        addDocument,
+        updateDocument,
+        deleteDocument,
+        setActiveDocumentId,
+      }}
+    >
+      {children}
+    </WorkspacesContext.Provider>
+  );
+}
+
+export function useWorkspaces(): WorkspacesContextValue {
+  const ctx = useContext(WorkspacesContext);
+  if (!ctx)
+    throw new Error("useWorkspaces must be used within a WorkspacesProvider");
+  return ctx;
+}

--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -21,8 +21,6 @@ interface AppState {
   setModelName: (name: string) => void;
   totalTokens: number;
   setTotalTokens: (tokens: number | ((prev: number) => number)) => void;
-  editorContent: string;
-  setEditorContent: (content: string) => void;
   suggestions: Suggestion[];
   setSuggestions: (
     suggestions: Suggestion[] | ((prev: Suggestion[]) => Suggestion[]),
@@ -51,7 +49,6 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
     return saved || "gemini-3.1-flash-lite-preview";
   });
   const [totalTokens, setTotalTokens] = useState<number>(0);
-  const [editorContent, setEditorContent] = useState("");
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [editorInstance, setEditorInstance] =
     useState<monaco.editor.IStandaloneCodeEditor | null>(null);
@@ -84,8 +81,6 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
         setModelName,
         totalTokens,
         setTotalTokens,
-        editorContent,
-        setEditorContent,
         suggestions,
         setSuggestions,
         editorInstance,

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -1,0 +1,21 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export interface WorkspaceDocument {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+}
+
+export interface WorkspaceMeta {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface WorkspaceData {
+  documents: WorkspaceDocument[];
+  activeDocumentId: string | null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,12 +6,15 @@ import App from "./App";
 import "./index.css";
 import { AppProvider } from "./lib/store";
 import { ThemeProvider } from "./lib/ThemeProvider";
+import { SupportingDocsProvider } from "./lib/SupportingDocsContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ThemeProvider>
       <AppProvider>
-        <App />
+        <SupportingDocsProvider>
+          <App />
+        </SupportingDocsProvider>
       </AppProvider>
     </ThemeProvider>
   </React.StrictMode>,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,15 +6,15 @@ import App from "./App";
 import "./index.css";
 import { AppProvider } from "./lib/store";
 import { ThemeProvider } from "./lib/ThemeProvider";
-import { SupportingDocsProvider } from "./lib/SupportingDocsContext";
+import { WorkspacesProvider } from "./lib/WorkspacesContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ThemeProvider>
       <AppProvider>
-        <SupportingDocsProvider>
+        <WorkspacesProvider>
           <App />
-        </SupportingDocsProvider>
+        </WorkspacesProvider>
       </AppProvider>
     </ThemeProvider>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary

- Adds a `chatOpen` state (defaults to `true`) to `DesktopLayout`
- Wraps the right `aside` with `transition-[width] duration-300 ease-in-out`, animating between `w-[400px]` (expanded) and `w-10` (collapsed)
- Toggle button uses `PanelRightClose` / `PanelRightOpen` icons, matching the existing left reference drawer pattern
- Header shows "AI Assistant" label when expanded, only the icon when collapsed

Closes #2

## Test plan

- [ ] Click the toggle button to collapse the sidebar — editor expands smoothly
- [ ] Click again to expand — sidebar returns to 400px with animation
- [ ] Verify the conversation is preserved across collapse/expand cycles
- [ ] Verify mobile layout is unaffected