### PR TITLE
fix: stop Enter key propagation when committing document rename

### DIFF
--- a/src/components/WorkspacePanel.tsx
+++ b/src/components/WorkspacePanel.tsx
@@ -44,7 +44,10 @@ function DocRow({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") commitEdit();
+    if (e.key === "Enter") {
+      e.stopPropagation();
+      commitEdit();
+    }
     if (e.key === "Escape") setEditing(false);
   };
 


### PR DESCRIPTION
## Summary

- Pressing Enter to confirm a document rename in `WorkspacePanel` was silently failing because the keydown event bubbled up to the parent `div`, which also handled Enter to trigger `onSelect()`, interfering with `commitEdit()`
- Added `e.stopPropagation()` in `handleKeyDown` so Enter correctly commits the rename without triggering the parent handler

## Test plan

- [ ] Rename a document and press Enter — title should update
- [ ] Rename a document and press Escape — edit should cancel
- [ ] Click elsewhere while renaming — title should update (blur/onBlur path unaffected)