### PR TITLE
fix: add HTML sanitization to markdown rendering to prevent XSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-markdown": "^10.1.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "uuid": "^14.0.0"
@@ -3830,6 +3831,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -6284,6 +6300,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
     "uuid": "^14.0.0"

--- a/src/components/MarkdownContent.test.tsx
+++ b/src/components/MarkdownContent.test.tsx
@@ -1,0 +1,28 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import { MarkdownContent } from "./MarkdownContent";
+
+describe("MarkdownContent", () => {
+  it("renders markdown content", () => {
+    const { container } = render(<MarkdownContent content="**bold text**" />);
+    expect(container.querySelector("strong")).toBeTruthy();
+  });
+
+  it("strips script tags to prevent XSS", () => {
+    const malicious = '<script>alert("xss")</script>Hello';
+    const { container } = render(<MarkdownContent content={malicious} />);
+    expect(container.querySelector("script")).toBeNull();
+  });
+
+  it("strips onclick attributes to prevent XSS", () => {
+    const malicious = '<a href="#" onclick="alert(1)">click</a>';
+    const { container } = render(<MarkdownContent content={malicious} />);
+    const link = container.querySelector("a");
+    // rehype-sanitize either removes the element or strips the unsafe attribute
+    expect(link === null || link.getAttribute("onclick") === null).toBe(true);
+  });
+});

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 import ReactMarkdown from "react-markdown";
+import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 
 interface MarkdownContentProps {
@@ -13,6 +14,7 @@ export function MarkdownContent({ content, className }: MarkdownContentProps) {
     <div className={className}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeSanitize]}
         components={{
           h1: ({ ...props }) => (
             <h1


### PR DESCRIPTION
## Summary

- Adds `rehype-sanitize` to the `react-markdown` pipeline in `MarkdownContent.tsx` to strip unsafe HTML from LLM/user content
- Adds `MarkdownContent.test.tsx` with tests covering normal rendering and XSS prevention (script tags, event handler attributes)

Closes #8