### PR TITLE
fix: pass user-selected model to WorkspaceTools

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -322,7 +322,7 @@ function App() {
     const workspaceTools = new WorkspaceTools(
       docsRef,
       activeDocRef,
-      () => new GoogleGenAIAdapter(apiKey, "gemini-2.5-flash"),
+      () => new GoogleGenAIAdapter(apiKey, modelName),
     );
     registerWorkspaceTools(registry, workspaceTools);
 


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `"gemini-2.5-flash"` string at `App.tsx:325` with the `modelName` value from state, so workspace tools respect the model selected in the UI.

Closes #9

## Test plan

- [ ] Select a non-default model in Settings, trigger a workspace tool, and verify it uses the selected model