### PR TITLE
fix: replace Date.now() and Math.random() with crypto.randomUUID() for ID generation

### DIFF
--- a/src/adapters/GoogleGenAIAdapter.ts
+++ b/src/adapters/GoogleGenAIAdapter.ts
@@ -102,7 +102,7 @@ export class GoogleGenAIAdapter implements LlmAdapter {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const fc = (p as any).functionCall;
         return {
-          id: fc.id || Math.random().toString(36).substring(7),
+          id: fc.id || crypto.randomUUID(),
           name: fc.name,
           args: fc.args,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -176,7 +176,7 @@ export class GoogleGenAIAdapter implements LlmAdapter {
               id:
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (part.functionCall as any).id ||
-                Math.random().toString(36).substring(7),
+                crypto.randomUUID(),
               name: part.functionCall.name!,
               args: part.functionCall.args,
               // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -115,7 +115,7 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
 
     setItems((prev) => [
       ...prev,
-      { kind: "user", id: `user-${Date.now()}`, text: userText },
+      { kind: "user", id: `user-${crypto.randomUUID()}`, text: userText },
     ]);
 
     // IDs of in-flight items — local vars are sufficient since this all runs
@@ -125,7 +125,7 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
 
     const ensureAssistant = (): string => {
       if (assistantId) return assistantId;
-      const id = `asst-${Date.now()}`;
+      const id = `asst-${crypto.randomUUID()}`;
       assistantId = id;
       setItems((prev) => [
         ...prev,
@@ -170,7 +170,7 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
             );
             assistantId = null;
           }
-          const tid = `tool-${Date.now()}`;
+          const tid = `tool-${crypto.randomUUID()}`;
           toolId = tid;
           const name = event.name;
           setItems((prev) => [


### PR DESCRIPTION
## Summary

- Replaces `Date.now()` ID generation in `ChatSidebar.tsx` (3 occurrences) with `crypto.randomUUID()` to avoid duplicate IDs in high-frequency calls
- Replaces `Math.random().toString(36)` fallback IDs in `GoogleGenAIAdapter.ts` (2 occurrences) with `crypto.randomUUID()` to avoid collisions

Fixes #10.