### PR TITLE
fix: preserve text when part has both thought and text set in GoogleGenAIAdapter

### DIFF
--- a/src/adapters/GoogleGenAIAdapter.test.ts
+++ b/src/adapters/GoogleGenAIAdapter.test.ts
@@ -96,4 +96,27 @@ describe("GoogleGenAIAdapter", () => {
     expect(response.toolCalls[0].name).toBe("testTool");
     expect(response.toolCalls[0].args).toEqual({ arg1: "val1" });
   });
+
+  it("should not drop text when a part has both thought and text set", async () => {
+    const { GoogleGenAI } = await import("@google/genai");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockClient = new (GoogleGenAI as any)();
+    mockClient.models.generateContent.mockResolvedValueOnce({
+      candidates: [
+        {
+          content: {
+            parts: [{ thought: true, text: "Thinking... and also responding" }],
+          },
+        },
+      ],
+      usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 5 },
+    });
+
+    const response = await adapter.generate({
+      messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+      tools: [],
+    });
+
+    expect(response.text).toBe("Thinking... and also responding");
+  });
 });

--- a/src/adapters/GoogleGenAIAdapter.ts
+++ b/src/adapters/GoogleGenAIAdapter.ts
@@ -88,7 +88,7 @@ export class GoogleGenAIAdapter implements LlmAdapter {
     }
 
     const textPart = candidate.content?.parts?.find(
-      (p) => "text" in p && typeof p.text === "string" && !p.thought,
+      (p) => "text" in p && typeof p.text === "string",
     );
     const toolCallParts =
       candidate.content?.parts?.filter(


### PR DESCRIPTION
## Summary

- Fixes #11
- Removes the `!p.thought` guard in `GoogleGenAIAdapter.ts` so text is not silently dropped when a response part has both `thought` and `text` set simultaneously
- Adds a test case covering this scenario

## Test plan

- [x] Run `npm run test` — all tests pass
- [x] Manually verify the editor receives text responses in cases where the model returns thinking + text in the same part