### PR TITLE
fix: make editor tools work correctly in Preview mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -267,6 +267,8 @@ const BASE_INSTRUCTIONS =
   "When using `edit()`, the `originalText` should be as short as possible (just the sentence or words changing), not the whole file. " +
   "When you call `edit()` or `write()`, the execution will PAUSE until the user manually Accepts or Rejects the change. " +
   "You will then receive the user's decision (and feedback if any) as the tool result. " +
+  "Use `get_current_mode()` to check whether the UI is in 'editor' or 'preview' mode before making edits. " +
+  "If in 'preview' mode and you need to edit, call `request_switch_to_editor()` first — this prompts the user to switch tabs. " +
   "The workspace may contain multiple documents. Use `get_active_doc_info()` to get the id and title of the currently open document. " +
   "Use `list_workspace_docs()` to discover all documents. " +
   "Use `read_workspace_doc(id)` to read another document in full, or `query_workspace_doc(id, query)` for a targeted question. " +
@@ -284,6 +286,9 @@ function App() {
     setSuggestions,
     approveAll,
     skills,
+    activeTab,
+    editorContent,
+    setPendingTabSwitchRequest,
   } = useApp();
   const [tempKey, setTempKey] = useState("");
   const [showKeyDialog, setShowKeyDialog] = useState(!apiKey);
@@ -315,6 +320,12 @@ function App() {
       editorInstance,
       setSuggestions,
       approveAll,
+      () => editorContent,
+      () => activeTab,
+      () =>
+        new Promise<boolean>((resolve) => {
+          setPendingTabSwitchRequest({ resolve });
+        }),
     );
 
     registerEditorTools(registry, editorTools);
@@ -360,6 +371,9 @@ function App() {
     approveAll,
     docsRef,
     activeDocRef,
+    activeTab,
+    editorContent,
+    setPendingTabSwitchRequest,
   ]);
 
   const conversation = useMemo(() => {
@@ -379,6 +393,8 @@ function App() {
         "get_metadata",
         "edit",
         "write",
+        "get_current_mode",
+        "request_switch_to_editor",
         "delegate_to_skill",
         "get_active_doc_info",
         "list_workspace_docs",

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -4,6 +4,14 @@ import { useEffect, useRef, useState } from "react";
 import { Editor, OnMount } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { MarkdownContent } from "./MarkdownContent";
 import { useApp } from "@/lib/store";
 import { useTheme } from "@/lib/ThemeProvider";
@@ -33,8 +41,17 @@ Switch to the **Preview** tab to see the rendered Markdown.
 const DEBOUNCE_MS = 500;
 
 export function EditorPanel() {
-  const { setEditorInstance, suggestions, setSuggestions, editorInstance } =
-    useApp();
+  const {
+    setEditorInstance,
+    suggestions,
+    setSuggestions,
+    editorInstance,
+    activeTab,
+    setActiveTab,
+    setEditorContent,
+    pendingTabSwitchRequest,
+    setPendingTabSwitchRequest,
+  } = useApp();
   const { activeDocument, updateDocument } = useWorkspaces();
 
   const { theme } = useTheme();
@@ -65,6 +82,16 @@ export function EditorPanel() {
   const handleEditorDidMount: OnMount = (editor) => {
     setEditorInstance(editor);
   };
+
+  useEffect(() => {
+    setEditorContent(localContent);
+  }, [localContent, setEditorContent]);
+
+  useEffect(() => {
+    if (activeTab === "editor" && editorInstance) {
+      editorInstance.layout();
+    }
+  }, [activeTab, editorInstance]);
 
   const handleChange = (value: string | undefined) => {
     const content = value || "";
@@ -190,9 +217,50 @@ export function EditorPanel() {
     }
   };
 
+  const handleTabSwitchAccept = () => {
+    if (pendingTabSwitchRequest) {
+      setActiveTab("editor");
+      pendingTabSwitchRequest.resolve(true);
+      setPendingTabSwitchRequest(null);
+    }
+  };
+
+  const handleTabSwitchDecline = () => {
+    if (pendingTabSwitchRequest) {
+      pendingTabSwitchRequest.resolve(false);
+      setPendingTabSwitchRequest(null);
+    }
+  };
+
   return (
     <div className="flex h-full w-full flex-col bg-background relative">
-      <Tabs defaultValue="editor" className="flex h-full w-full flex-col">
+      <Dialog
+        open={!!pendingTabSwitchRequest}
+        onOpenChange={(open) => {
+          if (!open) handleTabSwitchDecline();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Switch to Editor?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            The AI assistant needs to edit the document, but you are currently
+            in Preview mode. Switch to the Editor tab to allow changes?
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleTabSwitchDecline}>
+              Cancel
+            </Button>
+            <Button onClick={handleTabSwitchAccept}>Switch to Editor</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as "editor" | "preview")}
+        className="flex h-full w-full flex-col"
+      >
         <div className="border-b px-4 py-2">
           <TabsList>
             <TabsTrigger value="editor">Editor</TabsTrigger>
@@ -202,7 +270,8 @@ export function EditorPanel() {
 
         <TabsContent
           value="editor"
-          className="m-0 flex-1 border-0 p-0 outline-none data-[state=active]:flex data-[state=active]:flex-col relative"
+          forceMount
+          className="hidden m-0 flex-1 border-0 p-0 outline-none data-[state=active]:flex data-[state=active]:flex-col relative"
         >
           <div className="flex-1 relative">
             <Editor

--- a/src/lib/EditorTools.test.ts
+++ b/src/lib/EditorTools.test.ts
@@ -12,8 +12,6 @@ describe("EditorTools", () => {
   let mockModel: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let setSuggestions: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let setEditorContent: any;
 
   beforeEach(() => {
     mockModel = {
@@ -35,7 +33,6 @@ describe("EditorTools", () => {
     };
 
     setSuggestions = vi.fn();
-    setEditorContent = vi.fn();
   });
 
   describe("read", () => {
@@ -44,9 +41,104 @@ describe("EditorTools", () => {
       expect(tools.read()).toBe("Initial content");
     });
 
-    it("should return empty string if editor is not initialized", () => {
+    it("should return empty string if editor is not initialized and no fallback", () => {
       const tools = new EditorTools(null, setSuggestions, false);
       expect(tools.read()).toBe("");
+    });
+
+    it("should fall back to getEditorContent when editor is not initialized", () => {
+      const tools = new EditorTools(
+        null,
+        setSuggestions,
+        false,
+        () => "fallback content",
+      );
+      expect(tools.read()).toBe("fallback content");
+    });
+
+    it("should fall back to getEditorContent when editor returns empty string", () => {
+      mockEditor.getValue.mockReturnValue("");
+      const tools = new EditorTools(
+        mockEditor,
+        setSuggestions,
+        false,
+        () => "fallback content",
+      );
+      expect(tools.read()).toBe("fallback content");
+    });
+
+    it("should prefer editor content over fallback when editor has content", () => {
+      const tools = new EditorTools(
+        mockEditor,
+        setSuggestions,
+        false,
+        () => "fallback content",
+      );
+      expect(tools.read()).toBe("Initial content");
+    });
+  });
+
+  describe("get_current_mode", () => {
+    it("should return editor mode by default", () => {
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      expect(tools.get_current_mode()).toBe("editor");
+    });
+
+    it("should return the mode from getActiveTab", () => {
+      const tools = new EditorTools(
+        mockEditor,
+        setSuggestions,
+        false,
+        () => "",
+        () => "preview",
+      );
+      expect(tools.get_current_mode()).toBe("preview");
+    });
+  });
+
+  describe("request_switch_to_editor", () => {
+    it("should return already-in-editor message when already in editor mode", async () => {
+      const tools = new EditorTools(
+        mockEditor,
+        setSuggestions,
+        false,
+        () => "",
+        () => "editor",
+      );
+      expect(await tools.request_switch_to_editor()).toBe(
+        "Already in editor mode.",
+      );
+    });
+
+    it("should return success message when user accepts the switch", async () => {
+      const requestTabSwitch = vi.fn().mockResolvedValue(true);
+      const tools = new EditorTools(
+        mockEditor,
+        setSuggestions,
+        false,
+        () => "",
+        () => "preview",
+        requestTabSwitch,
+      );
+      expect(await tools.request_switch_to_editor()).toBe(
+        "Switched to editor mode.",
+      );
+      expect(requestTabSwitch).toHaveBeenCalledOnce();
+    });
+
+    it("should return declined message when user rejects the switch", async () => {
+      const requestTabSwitch = vi.fn().mockResolvedValue(false);
+      const tools = new EditorTools(
+        mockEditor,
+        setSuggestions,
+        false,
+        () => "",
+        () => "preview",
+        requestTabSwitch,
+      );
+      expect(await tools.request_switch_to_editor()).toBe(
+        "User declined to switch to editor mode.",
+      );
     });
   });
 

--- a/src/lib/EditorTools.ts
+++ b/src/lib/EditorTools.ts
@@ -12,11 +12,31 @@ export class EditorTools {
     private editor: monaco.editor.IStandaloneCodeEditor | null,
     private setSuggestions: (fn: (prev: Suggestion[]) => Suggestion[]) => void,
     private approveAll: boolean,
+    private getEditorContent: () => string = () => "",
+    private getActiveTab: () => "editor" | "preview" = () => "editor",
+    private requestTabSwitch: () => Promise<boolean> = () =>
+      Promise.resolve(false),
   ) {}
 
   read(): string {
-    if (!this.editor) return "";
-    return this.editor.getValue();
+    if (!this.editor) return this.getEditorContent();
+    const value = this.editor.getValue();
+    return value || this.getEditorContent();
+  }
+
+  get_current_mode(): string {
+    return this.getActiveTab();
+  }
+
+  async request_switch_to_editor(): Promise<string> {
+    if (this.getActiveTab() === "editor") {
+      return "Already in editor mode.";
+    }
+    const accepted = await this.requestTabSwitch();
+    if (accepted) {
+      return "Switched to editor mode.";
+    }
+    return "User declined to switch to editor mode.";
   }
 
   read_selection(): string {
@@ -256,6 +276,26 @@ export function registerEditorTools(
       },
     }),
     call: async (args: { content: string }) => tools.write(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "get_current_mode",
+      description:
+        "Returns the current UI mode: 'editor' (Monaco editor is visible) or 'preview' (Markdown preview is visible). Check this before making edits to ensure the editor is accessible.",
+      parameters: { type: "object", properties: {} },
+    }),
+    call: async () => tools.get_current_mode(),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "request_switch_to_editor",
+      description:
+        "Requests the user to switch from Preview mode to Editor mode. This will display a prompt to the user and pause until they accept or decline. Call this before attempting edits when in preview mode.",
+      parameters: { type: "object", properties: {} },
+    }),
+    call: async () => tools.request_switch_to_editor(),
   });
 }
 

--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -14,6 +14,10 @@ export interface Suggestion {
   resolve: (value: string) => void;
 }
 
+export interface TabSwitchRequest {
+  resolve: (accepted: boolean) => void;
+}
+
 interface AppState {
   apiKey: string | null;
   setApiKey: (key: string | null) => void;
@@ -29,6 +33,12 @@ interface AppState {
   setEditorInstance: (
     editor: monaco.editor.IStandaloneCodeEditor | null,
   ) => void;
+  activeTab: "editor" | "preview";
+  setActiveTab: (tab: "editor" | "preview") => void;
+  editorContent: string;
+  setEditorContent: (content: string) => void;
+  pendingTabSwitchRequest: TabSwitchRequest | null;
+  setPendingTabSwitchRequest: (req: TabSwitchRequest | null) => void;
   approveAll: boolean;
   setApproveAll: (approve: boolean) => void;
   skills: Skill[];
@@ -52,6 +62,10 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [editorInstance, setEditorInstance] =
     useState<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const [activeTab, setActiveTab] = useState<"editor" | "preview">("editor");
+  const [editorContent, setEditorContent] = useState<string>("");
+  const [pendingTabSwitchRequest, setPendingTabSwitchRequest] =
+    useState<TabSwitchRequest | null>(null);
   const [approveAll, setApproveAll] = useState(false);
   const [skills, setSkillsState] = useState<Skill[]>(() => initializeSkills());
 
@@ -85,6 +99,12 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
         setSuggestions,
         editorInstance,
         setEditorInstance,
+        activeTab,
+        setActiveTab,
+        editorContent,
+        setEditorContent,
+        pendingTabSwitchRequest,
+        setPendingTabSwitchRequest,
         approveAll,
         setApproveAll,
         skills,


### PR DESCRIPTION
Fixes #4

## Summary
- Added `get_current_mode` and `request_switch_to_editor` tools so the agent can detect and recover from Preview mode before attempting edits; a dialog prompts the user to switch tabs
- `EditorTools.read()` now falls back to a store-synced content string when Monaco returns empty
- Added `forceMount` to the editor `TabsContent` so the Monaco instance is never unmounted on tab switch, preventing stale editor references and "Model not found" errors on return
- `editor.layout()` is called when switching back to the editor tab to restore correct Monaco dimensions after `display:none`

## Test plan
- [ ] Switch to Preview mode, ask the agent to make an edit — verify the switch-to-editor dialog appears
- [ ] Accept the dialog — verify the tab switches and the edit is applied correctly
- [ ] Decline the dialog — verify the agent receives a declined message and stops
- [ ] Ask the agent to `read()` while in Preview — verify it returns the correct document content
- [ ] All existing tests pass (2 pre-existing failures in `App.test.tsx` are unrelated to this PR)