### PR TITLE
refactor: extract duplicate system instruction mapping in GoogleGenAIAdapter

### DIFF
--- a/src/adapters/GoogleGenAIAdapter.test.ts
+++ b/src/adapters/GoogleGenAIAdapter.test.ts
@@ -97,6 +97,37 @@ describe("GoogleGenAIAdapter", () => {
     expect(response.toolCalls[0].args).toEqual({ arg1: "val1" });
   });
 
+  it("should forward a system instruction when provided", async () => {
+    const { GoogleGenAI } = await import("@google/genai");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockClient = new (GoogleGenAI as any)();
+
+    await adapter.generate({
+      system: "You are terse.",
+      messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+      tools: [],
+    });
+
+    const call = mockClient.models.generateContent.mock.calls.at(-1)?.[0];
+    expect(call.config.systemInstruction).toEqual({
+      parts: [{ text: "You are terse." }],
+    });
+  });
+
+  it("should omit the system instruction when not provided", async () => {
+    const { GoogleGenAI } = await import("@google/genai");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockClient = new (GoogleGenAI as any)();
+
+    await adapter.generate({
+      messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+      tools: [],
+    });
+
+    const call = mockClient.models.generateContent.mock.calls.at(-1)?.[0];
+    expect(call.config.systemInstruction).toBeUndefined();
+  });
+
   it("should not drop text when a part has both thought and text set", async () => {
     const { GoogleGenAI } = await import("@google/genai");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/adapters/GoogleGenAIAdapter.ts
+++ b/src/adapters/GoogleGenAIAdapter.ts
@@ -40,11 +40,7 @@ export class GoogleGenAIAdapter implements LlmAdapter {
   async generate(request: AdapterRequest): Promise<AdapterResponse> {
     const contents = this.mapMessages(request.messages);
 
-    const systemInstruction: Content | undefined = request.system
-      ? {
-          parts: [{ text: request.system }],
-        }
-      : undefined;
+    const systemInstruction = this.mapSystemInstruction(request.system);
 
     const tools =
       request.tools.length > 0
@@ -117,11 +113,7 @@ export class GoogleGenAIAdapter implements LlmAdapter {
   ): AsyncIterable<AdapterStreamChunk> {
     const contents = this.mapMessages(request.messages);
 
-    const systemInstruction: Content | undefined = request.system
-      ? {
-          parts: [{ text: request.system }],
-        }
-      : undefined;
+    const systemInstruction = this.mapSystemInstruction(request.system);
 
     const tools =
       request.tools.length > 0
@@ -175,8 +167,7 @@ export class GoogleGenAIAdapter implements LlmAdapter {
             toolCall: {
               id:
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (part.functionCall as any).id ||
-                crypto.randomUUID(),
+                (part.functionCall as any).id || crypto.randomUUID(),
               name: part.functionCall.name!,
               args: part.functionCall.args,
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -187,6 +178,11 @@ export class GoogleGenAIAdapter implements LlmAdapter {
         }
       }
     }
+  }
+
+  private mapSystemInstruction(system?: string): Content | undefined {
+    if (!system) return undefined;
+    return { parts: [{ text: system }] };
   }
 
   private mapMessages(messages: Message[]): Content[] {


### PR DESCRIPTION
## Summary
- Extracts the `request.system` → `Content | undefined` mapping duplicated between `generate()` and `generateStream()` in `GoogleGenAIAdapter` into a private `mapSystemInstruction()` helper.
- Both call sites now read `const systemInstruction = this.mapSystemInstruction(request.system);`.
- Adds two Vitest cases in `GoogleGenAIAdapter.test.ts` verifying that the helper forwards a provided system string as `{ parts: [{ text }] }` and omits it (undefined) when not provided.

Closes #12.

## Test plan
- [x] `npm run lint` — no new errors (only pre-existing warnings)
- [x] `npm run test` — 160 passing (up from 158; the two new cases)
- [x] `npm run build` — successful
- [x] Manual smoke test in the browser (I wasn't able to run this from the sandbox; please verify the chat still streams as expected before merging)

Closes #12

https://claude.ai/code/session_015vMAFHQs2f65JcKvi8WYD4