### PR TITLE
feat: expose editor and workspace tools to browser agents via WebMCP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import {
   createDelegateToSkillHandler,
 } from "@/lib/EditorTools";
 import { WorkspaceTools, registerWorkspaceTools } from "@/lib/WorkspaceTools";
+import { registerWebMCPTools } from "@/lib/WebMCPTools";
 
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(
@@ -309,6 +310,44 @@ function App() {
       : null;
   }, [activeDocument]);
 
+  const editorTools = useMemo(
+    () =>
+      new EditorTools(
+        editorInstance,
+        setSuggestions,
+        approveAll,
+        () => editorContent,
+        () => activeTab,
+        () =>
+          new Promise<boolean>((resolve) => {
+            setPendingTabSwitchRequest({ resolve });
+          }),
+      ),
+    [
+      editorInstance,
+      setSuggestions,
+      approveAll,
+      editorContent,
+      activeTab,
+      setPendingTabSwitchRequest,
+    ],
+  );
+
+  const workspaceTools = useMemo(
+    () =>
+      new WorkspaceTools(
+        docsRef,
+        activeDocRef,
+        () => new GoogleGenAIAdapter(apiKey ?? "", modelName),
+      ),
+    [docsRef, activeDocRef, apiKey, modelName],
+  );
+
+  useEffect(
+    () => registerWebMCPTools(editorTools, workspaceTools),
+    [editorTools, workspaceTools],
+  );
+
   const runner = useMemo(() => {
     if (!apiKey) return null;
     const adapter = new GoogleGenAIAdapter(apiKey, modelName, (usage) => {
@@ -316,25 +355,7 @@ function App() {
     });
     const registry = new ToolRegistry();
 
-    const editorTools = new EditorTools(
-      editorInstance,
-      setSuggestions,
-      approveAll,
-      () => editorContent,
-      () => activeTab,
-      () =>
-        new Promise<boolean>((resolve) => {
-          setPendingTabSwitchRequest({ resolve });
-        }),
-    );
-
     registerEditorTools(registry, editorTools);
-
-    const workspaceTools = new WorkspaceTools(
-      docsRef,
-      activeDocRef,
-      () => new GoogleGenAIAdapter(apiKey, modelName),
-    );
     registerWorkspaceTools(registry, workspaceTools);
 
     registry.register({
@@ -362,19 +383,7 @@ function App() {
     });
 
     return new AgentRunner(adapter, registry);
-  }, [
-    apiKey,
-    modelName,
-    setTotalTokens,
-    editorInstance,
-    setSuggestions,
-    approveAll,
-    docsRef,
-    activeDocRef,
-    activeTab,
-    editorContent,
-    setPendingTabSwitchRequest,
-  ]);
+  }, [apiKey, modelName, setTotalTokens, editorTools, workspaceTools]);
 
   const conversation = useMemo(() => {
     if (!runner) return null;

--- a/src/lib/WebMCPTools.test.ts
+++ b/src/lib/WebMCPTools.test.ts
@@ -1,0 +1,276 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerWebMCPTools } from "./WebMCPTools";
+import { EditorTools } from "./EditorTools";
+import { WorkspaceTools } from "./WorkspaceTools";
+
+function makeEditorTools(): EditorTools {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockEditor: any = {
+    getValue: vi.fn().mockReturnValue("editor content"),
+    setValue: vi.fn(),
+    getModel: vi.fn().mockReturnValue({
+      findMatches: vi.fn().mockReturnValue([]),
+      pushEditOperations: vi.fn(),
+      getFullModelRange: vi
+        .fn()
+        .mockReturnValue({
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 1,
+          endColumn: 1,
+        }),
+    }),
+    getSelection: vi.fn().mockReturnValue(null),
+  };
+  return new EditorTools(mockEditor, vi.fn(), false);
+}
+
+function makeWorkspaceTools(): WorkspaceTools {
+  return new WorkspaceTools({ current: [] }, { current: null }, vi.fn());
+}
+
+describe("registerWebMCPTools", () => {
+  const registeredTools: Map<
+    string,
+    {
+      execute: (args: Record<string, unknown>) => unknown;
+      signal?: AbortSignal;
+    }
+  > = new Map();
+
+  beforeEach(() => {
+    registeredTools.clear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (navigator as any).modelContext = {
+      registerTool: vi.fn(
+        (
+          tool: {
+            name: string;
+            execute: (args: Record<string, unknown>) => unknown;
+          },
+          options?: { signal?: AbortSignal },
+        ) => {
+          registeredTools.set(tool.name, {
+            execute: tool.execute,
+            signal: options?.signal,
+          });
+        },
+      ),
+    };
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (navigator as any).modelContext;
+  });
+
+  it("returns a no-op cleanup when navigator.modelContext is undefined", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (navigator as any).modelContext;
+    const cleanup = registerWebMCPTools(
+      makeEditorTools(),
+      makeWorkspaceTools(),
+    );
+    expect(() => cleanup()).not.toThrow();
+  });
+
+  it("registers all expected tools", () => {
+    registerWebMCPTools(makeEditorTools(), makeWorkspaceTools());
+    const expected = [
+      "read",
+      "read_selection",
+      "search",
+      "get_metadata",
+      "get_current_mode",
+      "request_switch_to_editor",
+      "edit",
+      "write",
+      "get_active_doc_info",
+      "list_workspace_docs",
+      "read_workspace_doc",
+      "query_workspace_doc",
+      "query_workspace",
+    ];
+    for (const name of expected) {
+      expect(registeredTools.has(name), `missing tool: ${name}`).toBe(true);
+    }
+    expect(registeredTools.size).toBe(expected.length);
+  });
+
+  it("passes an AbortSignal to each registered tool", () => {
+    registerWebMCPTools(makeEditorTools(), makeWorkspaceTools());
+    for (const [, entry] of registeredTools) {
+      expect(entry.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it("cleanup aborts the shared signal", () => {
+    const cleanup = registerWebMCPTools(
+      makeEditorTools(),
+      makeWorkspaceTools(),
+    );
+    const signal = registeredTools.get("read")!.signal!;
+    expect(signal.aborted).toBe(false);
+    cleanup();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("read execute calls editorTools.read()", () => {
+    const tools = makeEditorTools();
+    vi.spyOn(tools, "read").mockReturnValue("document text");
+    registerWebMCPTools(tools, makeWorkspaceTools());
+
+    const result = registeredTools.get("read")!.execute({});
+    expect(result).toBe("document text");
+    expect(tools.read).toHaveBeenCalled();
+  });
+
+  it("read_selection execute calls editorTools.read_selection()", () => {
+    const tools = makeEditorTools();
+    vi.spyOn(tools, "read_selection").mockReturnValue("selected text");
+    registerWebMCPTools(tools, makeWorkspaceTools());
+
+    const result = registeredTools.get("read_selection")!.execute({});
+    expect(result).toBe("selected text");
+    expect(tools.read_selection).toHaveBeenCalled();
+  });
+
+  it("search execute calls editorTools.search() with args", () => {
+    const tools = makeEditorTools();
+    vi.spyOn(tools, "search").mockReturnValue("Found 1 occurrence(s)");
+    registerWebMCPTools(tools, makeWorkspaceTools());
+
+    const result = registeredTools.get("search")!.execute({ query: "hello" });
+    expect(result).toBe("Found 1 occurrence(s)");
+    expect(tools.search).toHaveBeenCalledWith({ query: "hello" });
+  });
+
+  it("get_metadata execute calls editorTools.get_metadata()", () => {
+    const tools = makeEditorTools();
+    vi.spyOn(tools, "get_metadata").mockReturnValue(
+      "Characters: 5, Words: 1, Lines: 1.",
+    );
+    registerWebMCPTools(tools, makeWorkspaceTools());
+
+    const result = registeredTools.get("get_metadata")!.execute({});
+    expect(result).toBe("Characters: 5, Words: 1, Lines: 1.");
+    expect(tools.get_metadata).toHaveBeenCalled();
+  });
+
+  it("get_current_mode execute calls editorTools.get_current_mode()", () => {
+    const tools = makeEditorTools();
+    vi.spyOn(tools, "get_current_mode").mockReturnValue("editor");
+    registerWebMCPTools(tools, makeWorkspaceTools());
+
+    const result = registeredTools.get("get_current_mode")!.execute({});
+    expect(result).toBe("editor");
+    expect(tools.get_current_mode).toHaveBeenCalled();
+  });
+
+  it("request_switch_to_editor execute calls editorTools.request_switch_to_editor()", async () => {
+    const tools = makeEditorTools();
+    vi.spyOn(tools, "request_switch_to_editor").mockResolvedValue(
+      "Switched to editor mode.",
+    );
+    registerWebMCPTools(tools, makeWorkspaceTools());
+
+    const result = await registeredTools
+      .get("request_switch_to_editor")!
+      .execute({});
+    expect(result).toBe("Switched to editor mode.");
+    expect(tools.request_switch_to_editor).toHaveBeenCalled();
+  });
+
+  it("edit execute calls editorTools.edit() with args", async () => {
+    const tools = makeEditorTools();
+    vi.spyOn(tools, "edit").mockResolvedValue("Change applied.");
+    registerWebMCPTools(tools, makeWorkspaceTools());
+
+    const result = await registeredTools
+      .get("edit")!
+      .execute({ originalText: "old", replacementText: "new" });
+    expect(result).toBe("Change applied.");
+    expect(tools.edit).toHaveBeenCalledWith({
+      originalText: "old",
+      replacementText: "new",
+    });
+  });
+
+  it("write execute calls editorTools.write() with args", async () => {
+    const tools = makeEditorTools();
+    vi.spyOn(tools, "write").mockResolvedValue("Document updated.");
+    registerWebMCPTools(tools, makeWorkspaceTools());
+
+    const result = await registeredTools
+      .get("write")!
+      .execute({ content: "new full content" });
+    expect(result).toBe("Document updated.");
+    expect(tools.write).toHaveBeenCalledWith({ content: "new full content" });
+  });
+
+  it("get_active_doc_info execute calls workspaceTools.get_active_doc_info()", () => {
+    const wt = makeWorkspaceTools();
+    vi.spyOn(wt, "get_active_doc_info").mockReturnValue(
+      '{"id":"1","title":"Doc"}',
+    );
+    registerWebMCPTools(makeEditorTools(), wt);
+
+    const result = registeredTools.get("get_active_doc_info")!.execute({});
+    expect(result).toBe('{"id":"1","title":"Doc"}');
+    expect(wt.get_active_doc_info).toHaveBeenCalled();
+  });
+
+  it("list_workspace_docs execute calls workspaceTools.list_workspace_docs()", () => {
+    const wt = makeWorkspaceTools();
+    vi.spyOn(wt, "list_workspace_docs").mockReturnValue("[]");
+    registerWebMCPTools(makeEditorTools(), wt);
+
+    const result = registeredTools.get("list_workspace_docs")!.execute({});
+    expect(result).toBe("[]");
+    expect(wt.list_workspace_docs).toHaveBeenCalled();
+  });
+
+  it("read_workspace_doc execute calls workspaceTools.read_workspace_doc() with args", () => {
+    const wt = makeWorkspaceTools();
+    vi.spyOn(wt, "read_workspace_doc").mockReturnValue(
+      '{"title":"T","content":"C"}',
+    );
+    registerWebMCPTools(makeEditorTools(), wt);
+
+    const result = registeredTools
+      .get("read_workspace_doc")!
+      .execute({ id: "abc" });
+    expect(result).toBe('{"title":"T","content":"C"}');
+    expect(wt.read_workspace_doc).toHaveBeenCalledWith({ id: "abc" });
+  });
+
+  it("query_workspace_doc execute calls workspaceTools.query_workspace_doc() with args", async () => {
+    const wt = makeWorkspaceTools();
+    vi.spyOn(wt, "query_workspace_doc").mockResolvedValue('{"summary":"s"}');
+    registerWebMCPTools(makeEditorTools(), wt);
+
+    const result = await registeredTools
+      .get("query_workspace_doc")!
+      .execute({ id: "abc", query: "what?" });
+    expect(result).toBe('{"summary":"s"}');
+    expect(wt.query_workspace_doc).toHaveBeenCalledWith({
+      id: "abc",
+      query: "what?",
+    });
+  });
+
+  it("query_workspace execute calls workspaceTools.query_workspace() with args", async () => {
+    const wt = makeWorkspaceTools();
+    vi.spyOn(wt, "query_workspace").mockResolvedValue('{"answer":"a"}');
+    registerWebMCPTools(makeEditorTools(), wt);
+
+    const result = await registeredTools
+      .get("query_workspace")!
+      .execute({ query: "summarize all" });
+    expect(result).toBe('{"answer":"a"}');
+    expect(wt.query_workspace).toHaveBeenCalledWith({ query: "summarize all" });
+  });
+});

--- a/src/lib/WebMCPTools.ts
+++ b/src/lib/WebMCPTools.ts
@@ -1,0 +1,247 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { EditorTools } from "./EditorTools";
+import { WorkspaceTools } from "./WorkspaceTools";
+
+interface WebMCPTool {
+  name: string;
+  description: string;
+  inputSchema: object;
+  execute: (args: Record<string, unknown>) => string | Promise<string>;
+}
+
+interface ModelContext {
+  registerTool(tool: WebMCPTool, options?: { signal?: AbortSignal }): void;
+}
+
+declare global {
+  interface Navigator {
+    modelContext?: ModelContext;
+  }
+}
+
+export function registerWebMCPTools(
+  editorTools: EditorTools,
+  workspaceTools: WorkspaceTools,
+): () => void {
+  if (!navigator.modelContext) {
+    console.warn("WebMCP not detected in this browser.");
+    return () => {};
+  }
+
+  const controller = new AbortController();
+  const { signal } = controller;
+  const mc = navigator.modelContext;
+
+  mc.registerTool(
+    {
+      name: "read",
+      description:
+        "Reads the complete current editor content and returns it as a string.",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => editorTools.read(),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "read_selection",
+      description: "Reads the currently selected text in the editor.",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => editorTools.read_selection(),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "search",
+      description:
+        "Finds all occurrences of a query string in the document. Returns the line and column of each match.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "The text to search for." },
+        },
+        required: ["query"],
+      },
+      execute: (args) => editorTools.search(args as { query: string }),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "get_metadata",
+      description:
+        "Returns metadata about the current document: character count, word count, and line count.",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => editorTools.get_metadata(),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "get_current_mode",
+      description:
+        "Returns the current UI mode: 'editor' (Monaco editor is visible) or 'preview' (Markdown preview is visible).",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => editorTools.get_current_mode(),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "request_switch_to_editor",
+      description:
+        "Requests the user to switch from Preview mode to Editor mode. Displays a prompt to the user and waits for them to accept or decline. Call this before attempting edits when in preview mode.",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => editorTools.request_switch_to_editor(),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "edit",
+      description:
+        "Proposes a targeted edit by replacing a specific piece of text. The user must approve or reject the change before it is applied. Use for small, localized changes only — do not pass the entire document.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          originalText: {
+            type: "string",
+            description:
+              "The exact, minimal text to replace. Must be short and unique in the document.",
+          },
+          replacementText: {
+            type: "string",
+            description: "The new text to replace the originalText with.",
+          },
+        },
+        required: ["originalText", "replacementText"],
+      },
+      execute: (args) =>
+        editorTools.edit(
+          args as { originalText: string; replacementText: string },
+        ),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "write",
+      description:
+        "Proposes a complete rewrite of the entire document. The user must approve or reject the change before it is applied. Use only when a full document rewrite is explicitly requested.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          content: {
+            type: "string",
+            description: "The full new document content.",
+          },
+        },
+        required: ["content"],
+      },
+      execute: (args) => editorTools.write(args as { content: string }),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "get_active_doc_info",
+      description:
+        "Returns the id and title of the document currently open in the editor.",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => workspaceTools.get_active_doc_info(),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "list_workspace_docs",
+      description:
+        "Lists all documents in the current workspace. Returns an array of { id, title } objects.",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => workspaceTools.list_workspace_docs(),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "read_workspace_doc",
+      description:
+        "Reads the full content of a specific document in the workspace. Returns { title, content } or { error } if not found.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description:
+              "The document ID to read. Use list_workspace_docs first to get IDs.",
+          },
+        },
+        required: ["id"],
+      },
+      execute: (args) =>
+        workspaceTools.read_workspace_doc(args as { id: string }),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "query_workspace_doc",
+      description:
+        "Asks a question about a specific document in the workspace. Returns { summary } with a concise answer.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "The document ID to query." },
+          query: {
+            type: "string",
+            description: "The question or query about the document.",
+          },
+        },
+        required: ["id", "query"],
+      },
+      execute: (args) =>
+        workspaceTools.query_workspace_doc(
+          args as { id: string; query: string },
+        ),
+    },
+    { signal },
+  );
+
+  mc.registerTool(
+    {
+      name: "query_workspace",
+      description:
+        "Asks a question that spans all documents in the workspace. Queries each document individually then synthesizes the results. Returns { answer }.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "The question to answer across all workspace documents.",
+          },
+        },
+        required: ["query"],
+      },
+      execute: (args) =>
+        workspaceTools.query_workspace(args as { query: string }),
+    },
+    { signal },
+  );
+
+  return () => controller.abort();
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/WebMCPTools.ts` with `registerWebMCPTools(editorTools, workspaceTools)`, which registers all 13 editor and workspace tools with `navigator.modelContext` so browser-based AI agents (e.g. Chrome's WebMCP Tool Inspector) can interact with the editor without DOM scraping
- Mutating tools (`edit`, `write`) continue to go through the existing user-approval workflow — the suggestion/accept/reject flow is unchanged
- Feature-checks for `navigator.modelContext` before registering; logs a warning and is a no-op on unsupported browsers
- Extracts `editorTools` and `workspaceTools` into their own `useMemo` hooks in `App.tsx` and wires up registration via `useEffect` with automatic cleanup via `AbortController`
- Uses the current WebMCP API (`registerTool` with `signal` option) rather than the deprecated `unregisterTool()` approach

## Test plan

- [x] 17 Vitest tests covering: feature detection fallback, all 13 tools registered, AbortSignal passed to each, cleanup aborts signal, and each tool's `execute` delegates to the correct underlying method
- [ ] Open in Chrome 146+ with the WebMCP flag enabled and verify all tools appear in the Model Context Tool Inspector extension
- [ ] Invoke `edit` or `write` via the extension and confirm the suggestion approval UI still appears
- [ ] Open in a browser without WebMCP support and confirm no errors are thrown