### PR TITLE
test: improve coverage for ChatSidebar, GoogleGenAIAdapter, EditorPanel, and EditorTools

### DIFF
--- a/src/adapters/GoogleGenAIAdapter.test.ts
+++ b/src/adapters/GoogleGenAIAdapter.test.ts
@@ -19,6 +19,12 @@ vi.mock("@google/genai", () => {
     },
   });
 
+  // Default: empty async generator
+  const generateContentStream = vi.fn().mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (async function* (): AsyncGenerator<any> {})(),
+  );
+
   return {
     ThinkingLevel: {
       HIGH: "HIGH",
@@ -27,6 +33,7 @@ vi.mock("@google/genai", () => {
     GoogleGenAI: vi.fn().mockImplementation(function (this: any) {
       this.models = {
         generateContent,
+        generateContentStream,
       };
     }),
   };
@@ -149,5 +156,174 @@ describe("GoogleGenAIAdapter", () => {
     });
 
     expect(response.text).toBe("Thinking... and also responding");
+  });
+
+  it("should throw when no candidate is returned from generate", async () => {
+    const { GoogleGenAI } = await import("@google/genai");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockClient = new (GoogleGenAI as any)();
+    mockClient.models.generateContent.mockResolvedValueOnce({
+      candidates: [],
+      usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 0 },
+    });
+
+    await expect(
+      adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [],
+      }),
+    ).rejects.toThrow("No candidate returned from Gemini");
+  });
+
+  describe("generateStream", () => {
+    async function collectChunks(
+      request: Parameters<GoogleGenAIAdapter["generateStream"]>[0],
+    ) {
+      const chunks: { type: string; delta?: string; toolCall?: unknown }[] = [];
+      for await (const chunk of adapter.generateStream(request)) {
+        chunks.push(chunk as never);
+      }
+      return chunks;
+    }
+
+    it("should yield thinking chunk for thought parts", async () => {
+      const { GoogleGenAI } = await import("@google/genai");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockClient = new (GoogleGenAI as any)();
+      mockClient.models.generateContentStream.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            candidates: [
+              { content: { parts: [{ thought: true, text: "hmm..." }] } },
+            ],
+            usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [],
+      });
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].type).toBe("thinking");
+      expect(chunks[0].delta).toBe("hmm...");
+    });
+
+    it("should yield text_delta for text parts", async () => {
+      const { GoogleGenAI } = await import("@google/genai");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockClient = new (GoogleGenAI as any)();
+      mockClient.models.generateContentStream.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: "Hello " }, { text: "world" }],
+                },
+              },
+            ],
+            usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 5 },
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [],
+      });
+
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0]).toEqual({ type: "text_delta", delta: "Hello " });
+      expect(chunks[1]).toEqual({ type: "text_delta", delta: "world" });
+    });
+
+    it("should yield tool_call chunk for function call parts", async () => {
+      const { GoogleGenAI } = await import("@google/genai");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockClient = new (GoogleGenAI as any)();
+      mockClient.models.generateContentStream.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: {
+                        id: "call-1",
+                        name: "read",
+                        args: {},
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 3 },
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [{ name: "read", description: "reads", parameters: {} }],
+      });
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].type).toBe("tool_call");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((chunks[0] as any).toolCall.name).toBe("read");
+    });
+
+    it("should call onUsageUpdate for each chunk with usage metadata", async () => {
+      const { GoogleGenAI } = await import("@google/genai");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockClient = new (GoogleGenAI as any)();
+      mockClient.models.generateContentStream.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            candidates: [{ content: { parts: [{ text: "hi" }] } }],
+            usageMetadata: { promptTokenCount: 3, candidatesTokenCount: 2 },
+          };
+        })(),
+      );
+
+      await collectChunks({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [],
+      });
+
+      expect(mockUsageUpdate).toHaveBeenCalledWith({
+        promptTokenCount: 3,
+        candidatesTokenCount: 2,
+        totalTokenCount: 5,
+      });
+    });
+
+    it("should skip chunks with no candidates", async () => {
+      const { GoogleGenAI } = await import("@google/genai");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockClient = new (GoogleGenAI as any)();
+      mockClient.models.generateContentStream.mockResolvedValueOnce(
+        (async function* () {
+          yield { candidates: [], usageMetadata: {} };
+          yield {
+            candidates: [{ content: { parts: [{ text: "hello" }] } }],
+            usageMetadata: {},
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [],
+      });
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].type).toBe("text_delta");
+    });
   });
 });

--- a/src/components/ChatSidebar.test.tsx
+++ b/src/components/ChatSidebar.test.tsx
@@ -1,0 +1,161 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ChatSidebar } from "./ChatSidebar";
+import { AppProvider } from "@/lib/store";
+import { ThemeProvider } from "@/lib/ThemeProvider";
+import type { Conversation } from "@mast-ai/core";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: (opts: {
+    count: number;
+    estimateSize: () => number;
+    overscan?: number;
+    getScrollElement: () => HTMLElement | null;
+  }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: opts.count }, (_, i) => ({
+        key: i,
+        index: i,
+        start: i * (opts.estimateSize?.() ?? 80),
+      })),
+    getTotalSize: () => opts.count * (opts.estimateSize?.() ?? 80),
+    scrollToIndex: vi.fn(),
+    measureElement: vi.fn(),
+  }),
+}));
+
+function makeConversation(
+  events: object[] = [],
+  history: object[] = [],
+): Conversation {
+  return {
+    history: history as Conversation["history"],
+    runStream: async function* () {
+      for (const event of events) {
+        yield event as never;
+      }
+    },
+  } as unknown as Conversation;
+}
+
+function renderSidebar(conversation: Conversation | null = null) {
+  return render(
+    <ThemeProvider>
+      <AppProvider>
+        <ChatSidebar conversation={conversation} />
+      </AppProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe("ChatSidebar", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows empty state when there are no messages", () => {
+    renderSidebar();
+    expect(
+      screen.getByText("Start a conversation with the editor assistant."),
+    ).toBeInTheDocument();
+  });
+
+  it("disables send button when input is empty", () => {
+    renderSidebar(makeConversation());
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
+  it("enables send button when input has text", async () => {
+    const user = userEvent.setup();
+    renderSidebar(makeConversation());
+    await user.type(screen.getByPlaceholderText("Ask the editor..."), "Hello");
+    expect(screen.getByRole("button", { name: "Send" })).not.toBeDisabled();
+  });
+
+  it("renders user message after send", async () => {
+    const user = userEvent.setup();
+    renderSidebar(makeConversation([{ type: "done" }]));
+    await user.type(
+      screen.getByPlaceholderText("Ask the editor..."),
+      "Hello AI",
+    );
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => {
+      expect(screen.getByText("Hello AI")).toBeInTheDocument();
+    });
+  });
+
+  it("renders thinking section from thinking events", async () => {
+    const user = userEvent.setup();
+    renderSidebar(
+      makeConversation([
+        { type: "thinking", delta: "Thinking hard..." },
+        { type: "done" },
+      ]),
+    );
+    await user.type(screen.getByPlaceholderText("Ask the editor..."), "test");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => {
+      expect(screen.getByText("Thinking Process")).toBeInTheDocument();
+    });
+  });
+
+  it("renders accumulated assistant text from text_delta events", async () => {
+    const user = userEvent.setup();
+    renderSidebar(
+      makeConversation([
+        { type: "text_delta", delta: "Hello " },
+        { type: "text_delta", delta: "world" },
+        { type: "done" },
+      ]),
+    );
+    await user.type(screen.getByPlaceholderText("Ask the editor..."), "test");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => {
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+  });
+
+  it("renders tool item for tool_call_started events", async () => {
+    const user = userEvent.setup();
+    renderSidebar(
+      makeConversation([
+        { type: "tool_call_started", name: "read" },
+        { type: "tool_call_completed" },
+        { type: "done" },
+      ]),
+    );
+    await user.type(screen.getByPlaceholderText("Ask the editor..."), "test");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => {
+      expect(screen.getByText("read")).toBeInTheDocument();
+    });
+  });
+
+  it("reconstructs user and assistant messages from conversation history", () => {
+    const conversation = makeConversation([], [
+      { role: "user", content: { type: "text", text: "Hello from history" } },
+      { role: "assistant", content: { type: "text", text: "Hi there" } },
+    ]);
+    renderSidebar(conversation);
+    expect(screen.getByText("Hello from history")).toBeInTheDocument();
+    expect(screen.getByText("Hi there")).toBeInTheDocument();
+  });
+
+  it("reconstructs tool call items from conversation history", () => {
+    const conversation = makeConversation([], [
+      {
+        role: "assistant",
+        content: {
+          type: "tool_calls",
+          calls: [{ id: "1", name: "edit", args: {} }],
+        },
+      },
+    ]);
+    renderSidebar(conversation);
+    expect(screen.getByText("edit")).toBeInTheDocument();
+  });
+});

--- a/src/components/EditorPanel.test.tsx
+++ b/src/components/EditorPanel.test.tsx
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useEffect } from "react";
 import { EditorPanel } from "./EditorPanel";
-import { AppProvider } from "@/lib/store";
+import { SuggestionWidget } from "./SuggestionWidget";
+import { AppProvider, useApp } from "@/lib/store";
 import { ThemeProvider } from "@/lib/ThemeProvider";
 import { WorkspacesProvider } from "@/lib/WorkspacesContext";
+import type { Suggestion } from "@/lib/store";
 
 function renderEditor() {
   return render(
@@ -59,5 +62,118 @@ describe("EditorPanel", () => {
     expect(
       await screen.findByRole("heading", { name: "New Markdown Heading" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("SuggestionWidget", () => {
+  function makeSuggestion(overrides?: Partial<Suggestion>): Suggestion {
+    return {
+      id: "test-id",
+      originalText: "old text",
+      replacementText: "new text",
+      status: "pending",
+      range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 8 },
+      resolve: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it("renders accept and reject buttons", () => {
+    const suggestion = makeSuggestion();
+    render(
+      <SuggestionWidget
+        suggestion={suggestion}
+        onAccept={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+    expect(screen.getByTitle("Accept")).toBeInTheDocument();
+    expect(screen.getByTitle("Reject")).toBeInTheDocument();
+  });
+
+  it("calls onAccept with suggestion id when accept is clicked", async () => {
+    const user = userEvent.setup();
+    const suggestion = makeSuggestion();
+    const onAccept = vi.fn();
+    render(
+      <SuggestionWidget
+        suggestion={suggestion}
+        onAccept={onAccept}
+        onReject={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByTitle("Accept"));
+    expect(onAccept).toHaveBeenCalledWith("test-id");
+  });
+
+  it("calls onReject with suggestion id when reject is clicked", async () => {
+    const user = userEvent.setup();
+    const suggestion = makeSuggestion();
+    const onReject = vi.fn();
+    render(
+      <SuggestionWidget
+        suggestion={suggestion}
+        onAccept={vi.fn()}
+        onReject={onReject}
+      />,
+    );
+    await user.click(screen.getByTitle("Reject"));
+    expect(onReject).toHaveBeenCalledWith("test-id");
+  });
+});
+
+describe("EditorPanel tab switch dialog", () => {
+  function SetTabSwitchRequest({
+    resolve,
+  }: {
+    resolve: (accepted: boolean) => void;
+  }) {
+    const { setPendingTabSwitchRequest } = useApp();
+    useEffect(() => {
+      setPendingTabSwitchRequest({ resolve });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return null;
+  }
+
+  function renderEditorWithTabSwitch(resolve: (accepted: boolean) => void) {
+    return render(
+      <ThemeProvider>
+        <AppProvider>
+          <WorkspacesProvider>
+            <SetTabSwitchRequest resolve={resolve} />
+            <EditorPanel />
+          </WorkspacesProvider>
+        </AppProvider>
+      </ThemeProvider>,
+    );
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows the tab switch dialog when pendingTabSwitchRequest is set", async () => {
+    const resolve = vi.fn();
+    renderEditorWithTabSwitch(resolve);
+    expect(await screen.findByText("Switch to Editor?")).toBeInTheDocument();
+  });
+
+  it("calls resolve(true) and closes dialog when Switch to Editor is clicked", async () => {
+    const user = userEvent.setup();
+    const resolve = vi.fn();
+    renderEditorWithTabSwitch(resolve);
+    await screen.findByText("Switch to Editor?");
+    await user.click(screen.getByRole("button", { name: "Switch to Editor" }));
+    expect(resolve).toHaveBeenCalledWith(true);
+  });
+
+  it("calls resolve(false) when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const resolve = vi.fn();
+    renderEditorWithTabSwitch(resolve);
+    await screen.findByText("Switch to Editor?");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(resolve).toHaveBeenCalledWith(false);
   });
 });

--- a/src/lib/EditorTools.test.ts
+++ b/src/lib/EditorTools.test.ts
@@ -208,6 +208,44 @@ describe("EditorTools", () => {
     });
   });
 
+  describe("read_selection", () => {
+    it("should return empty string if editor is not initialized", () => {
+      const tools = new EditorTools(null, setSuggestions, false);
+      expect(tools.read_selection()).toBe("");
+    });
+
+    it("should return empty string when selection is null", () => {
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      expect(tools.read_selection()).toBe("");
+    });
+
+    it("should return the selected text", () => {
+      const selection = {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 6,
+      };
+      mockEditor.getSelection.mockReturnValue(selection);
+      mockModel.getValueInRange = vi.fn().mockReturnValue("hello");
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      expect(tools.read_selection()).toBe("hello");
+      expect(mockModel.getValueInRange).toHaveBeenCalledWith(selection);
+    });
+
+    it("should return empty string when model is not available", () => {
+      mockEditor.getModel.mockReturnValue(null);
+      mockEditor.getSelection.mockReturnValue({
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 6,
+      });
+      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      expect(tools.read_selection()).toBe("");
+    });
+  });
+
   describe("get_metadata", () => {
     it("should return error if editor is not initialized", () => {
       const tools = new EditorTools(null, setSuggestions, false);


### PR DESCRIPTION
## Summary

- **`ChatSidebar.test.tsx`** (new): covers empty state, send button state, user message rendering, streaming events (`thinking`, `text_delta`, `tool_call_started`/`completed`), and history reconstruction from `conversation.history`
- **`GoogleGenAIAdapter.test.ts`**: adds `generateStream` tests for `thinking`, `text_delta`, and `tool_call` chunk types, usage metadata updates, empty-candidate skipping, and a `generate()` error test for the no-candidate path
- **`EditorPanel.test.tsx`**: adds `SuggestionWidget` render/accept/reject tests and tab-switch dialog tests (dialog appears, resolves `true` on accept, `false` on cancel)
- **`EditorTools.test.ts`**: adds `read_selection()` tests for null editor, null selection, successful text retrieval, and null model

Fixes #15.

## Test plan

- [x] `npm run test` — all 202 tests pass
- [x] `npm run lint` — no new errors or warnings