### PR TITLE
fix: harden WebMCP tool registration against old API shapes

### DIFF
--- a/src/lib/WebMCPTools.test.ts
+++ b/src/lib/WebMCPTools.test.ts
@@ -67,6 +67,23 @@ describe("registerWebMCPTools", () => {
     delete (navigator as any).modelContext;
   });
 
+  it("returns a no-op cleanup and warns when registerTool throws (old API shape)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (navigator as any).modelContext = {
+      registerTool: vi.fn(() => {
+        throw new TypeError("unregisterTool is not a function");
+      }),
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cleanup = registerWebMCPTools(makeEditorTools(), makeWorkspaceTools());
+    expect(warnSpy).toHaveBeenCalledWith(
+      "WebMCP tool registration failed:",
+      expect.any(TypeError),
+    );
+    expect(() => cleanup()).not.toThrow();
+    warnSpy.mockRestore();
+  });
+
   it("returns a no-op cleanup when navigator.modelContext is undefined", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (navigator as any).modelContext;

--- a/src/lib/WebMCPTools.ts
+++ b/src/lib/WebMCPTools.ts
@@ -34,6 +34,7 @@ export function registerWebMCPTools(
   const { signal } = controller;
   const mc = navigator.modelContext;
 
+  try {
   mc.registerTool(
     {
       name: "read",
@@ -242,6 +243,10 @@ export function registerWebMCPTools(
     },
     { signal },
   );
+  } catch (err) {
+    console.warn("WebMCP tool registration failed:", err);
+    return () => {};
+  }
 
   return () => controller.abort();
 }


### PR DESCRIPTION
## Summary

- Wraps all `registerTool` calls in `registerWebMCPTools` in a try-catch so that browsers using the old WebMCP API shape (which used `unregisterTool` rather than `AbortController`) no longer crash the application on load
- Logs a `console.warn` with the caught error so the failure is still observable
- Adds a test covering the throw-on-registration path