### PR TITLE
feat: add workspace management tools (create, rename, delete, switch document)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -273,11 +273,22 @@ const BASE_INSTRUCTIONS =
   "The workspace may contain multiple documents. Use `get_active_doc_info()` to get the id and title of the currently open document. " +
   "Use `list_workspace_docs()` to discover all documents. " +
   "Use `read_workspace_doc(id)` to read another document in full, or `query_workspace_doc(id, query)` for a targeted question. " +
-  "Use `query_workspace(query)` to synthesize an answer that draws from all workspace documents.";
+  "Use `query_workspace(query)` to synthesize an answer that draws from all workspace documents. " +
+  "Use `create_document(title)` to create a new blank document — pauses for user authorization. " +
+  "Use `rename_document(id, title)` to rename a document — pauses for user authorization. " +
+  "Use `delete_document(id)` to delete a document — pauses for user authorization. " +
+  "Use `switch_active_document(id)` to switch to a different document — saves current content first, no authorization needed.";
 
 function App() {
-  const { activeWorkspaceId, activeWorkspace, activeDocument } =
-    useWorkspaces();
+  const {
+    activeWorkspaceId,
+    activeWorkspace,
+    activeDocument,
+    createDocumentWithTitle,
+    updateDocument,
+    deleteDocument,
+    setActiveDocumentId,
+  } = useWorkspaces();
   const {
     apiKey,
     setApiKey,
@@ -290,6 +301,8 @@ function App() {
     activeTab,
     editorContent,
     setPendingTabSwitchRequest,
+    pendingWorkspaceAction,
+    setPendingWorkspaceAction,
   } = useApp();
   const [tempKey, setTempKey] = useState("");
   const [showKeyDialog, setShowKeyDialog] = useState(!apiKey);
@@ -339,8 +352,30 @@ function App() {
         docsRef,
         activeDocRef,
         () => new GoogleGenAIAdapter(apiKey ?? "", modelName),
+        undefined,
+        (title) => createDocumentWithTitle(title),
+        (id, title) => updateDocument(id, { title }),
+        (id) => deleteDocument(id),
+        (id) => setActiveDocumentId(id),
+        (id, content) => updateDocument(id, { content }),
+        () => editorInstance?.getValue() ?? editorContent,
+        setPendingWorkspaceAction,
+        approveAll,
       ),
-    [docsRef, activeDocRef, apiKey, modelName],
+    [
+      docsRef,
+      activeDocRef,
+      apiKey,
+      modelName,
+      createDocumentWithTitle,
+      updateDocument,
+      deleteDocument,
+      setActiveDocumentId,
+      editorInstance,
+      editorContent,
+      setPendingWorkspaceAction,
+      approveAll,
+    ],
   );
 
   useEffect(
@@ -410,6 +445,10 @@ function App() {
         "read_workspace_doc",
         "query_workspace_doc",
         "query_workspace",
+        "create_document",
+        "rename_document",
+        "delete_document",
+        "switch_active_document",
       ],
     };
     return runner.conversation(agent);
@@ -435,6 +474,47 @@ function App() {
       ) : (
         <DesktopLayout conversation={conversation} />
       )}
+
+      <Dialog
+        open={!!pendingWorkspaceAction}
+        onOpenChange={(open) => {
+          if (!open && pendingWorkspaceAction) {
+            pendingWorkspaceAction.resolve("Action rejected by user.");
+            setPendingWorkspaceAction(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Authorize Action</DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <p className="text-sm text-muted-foreground">
+              {pendingWorkspaceAction?.description}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                pendingWorkspaceAction?.resolve("Action rejected by user.");
+                setPendingWorkspaceAction(null);
+              }}
+            >
+              Reject
+            </Button>
+            <Button
+              onClick={() => {
+                pendingWorkspaceAction?.apply();
+                pendingWorkspaceAction?.resolve("Action applied successfully.");
+                setPendingWorkspaceAction(null);
+              }}
+            >
+              Accept
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={showKeyDialog} onOpenChange={setShowKeyDialog}>
         <DialogContent>

--- a/src/lib/WebMCPTools.test.ts
+++ b/src/lib/WebMCPTools.test.ts
@@ -14,14 +14,12 @@ function makeEditorTools(): EditorTools {
     getModel: vi.fn().mockReturnValue({
       findMatches: vi.fn().mockReturnValue([]),
       pushEditOperations: vi.fn(),
-      getFullModelRange: vi
-        .fn()
-        .mockReturnValue({
-          startLineNumber: 1,
-          startColumn: 1,
-          endLineNumber: 1,
-          endColumn: 1,
-        }),
+      getFullModelRange: vi.fn().mockReturnValue({
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 1,
+      }),
     }),
     getSelection: vi.fn().mockReturnValue(null),
   };
@@ -75,7 +73,10 @@ describe("registerWebMCPTools", () => {
       }),
     };
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const cleanup = registerWebMCPTools(makeEditorTools(), makeWorkspaceTools());
+    const cleanup = registerWebMCPTools(
+      makeEditorTools(),
+      makeWorkspaceTools(),
+    );
     expect(warnSpy).toHaveBeenCalledWith(
       "WebMCP tool registration failed:",
       expect.any(TypeError),
@@ -110,6 +111,10 @@ describe("registerWebMCPTools", () => {
       "read_workspace_doc",
       "query_workspace_doc",
       "query_workspace",
+      "create_document",
+      "rename_document",
+      "delete_document",
+      "switch_active_document",
     ];
     for (const name of expected) {
       expect(registeredTools.has(name), `missing tool: ${name}`).toBe(true);

--- a/src/lib/WebMCPTools.ts
+++ b/src/lib/WebMCPTools.ts
@@ -35,214 +35,296 @@ export function registerWebMCPTools(
   const mc = navigator.modelContext;
 
   try {
-  mc.registerTool(
-    {
-      name: "read",
-      description:
-        "Reads the complete current editor content and returns it as a string.",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => editorTools.read(),
-    },
-    { signal },
-  );
-
-  mc.registerTool(
-    {
-      name: "read_selection",
-      description: "Reads the currently selected text in the editor.",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => editorTools.read_selection(),
-    },
-    { signal },
-  );
-
-  mc.registerTool(
-    {
-      name: "search",
-      description:
-        "Finds all occurrences of a query string in the document. Returns the line and column of each match.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          query: { type: "string", description: "The text to search for." },
-        },
-        required: ["query"],
+    mc.registerTool(
+      {
+        name: "read",
+        description:
+          "Reads the complete current editor content and returns it as a string.",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => editorTools.read(),
       },
-      execute: (args) => editorTools.search(args as { query: string }),
-    },
-    { signal },
-  );
+      { signal },
+    );
 
-  mc.registerTool(
-    {
-      name: "get_metadata",
-      description:
-        "Returns metadata about the current document: character count, word count, and line count.",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => editorTools.get_metadata(),
-    },
-    { signal },
-  );
-
-  mc.registerTool(
-    {
-      name: "get_current_mode",
-      description:
-        "Returns the current UI mode: 'editor' (Monaco editor is visible) or 'preview' (Markdown preview is visible).",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => editorTools.get_current_mode(),
-    },
-    { signal },
-  );
-
-  mc.registerTool(
-    {
-      name: "request_switch_to_editor",
-      description:
-        "Requests the user to switch from Preview mode to Editor mode. Displays a prompt to the user and waits for them to accept or decline. Call this before attempting edits when in preview mode.",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => editorTools.request_switch_to_editor(),
-    },
-    { signal },
-  );
-
-  mc.registerTool(
-    {
-      name: "edit",
-      description:
-        "Proposes a targeted edit by replacing a specific piece of text. The user must approve or reject the change before it is applied. Use for small, localized changes only — do not pass the entire document.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          originalText: {
-            type: "string",
-            description:
-              "The exact, minimal text to replace. Must be short and unique in the document.",
-          },
-          replacementText: {
-            type: "string",
-            description: "The new text to replace the originalText with.",
-          },
-        },
-        required: ["originalText", "replacementText"],
+    mc.registerTool(
+      {
+        name: "read_selection",
+        description: "Reads the currently selected text in the editor.",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => editorTools.read_selection(),
       },
-      execute: (args) =>
-        editorTools.edit(
-          args as { originalText: string; replacementText: string },
-        ),
-    },
-    { signal },
-  );
+      { signal },
+    );
 
-  mc.registerTool(
-    {
-      name: "write",
-      description:
-        "Proposes a complete rewrite of the entire document. The user must approve or reject the change before it is applied. Use only when a full document rewrite is explicitly requested.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          content: {
-            type: "string",
-            description: "The full new document content.",
+    mc.registerTool(
+      {
+        name: "search",
+        description:
+          "Finds all occurrences of a query string in the document. Returns the line and column of each match.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string", description: "The text to search for." },
           },
+          required: ["query"],
         },
-        required: ["content"],
+        execute: (args) => editorTools.search(args as { query: string }),
       },
-      execute: (args) => editorTools.write(args as { content: string }),
-    },
-    { signal },
-  );
+      { signal },
+    );
 
-  mc.registerTool(
-    {
-      name: "get_active_doc_info",
-      description:
-        "Returns the id and title of the document currently open in the editor.",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => workspaceTools.get_active_doc_info(),
-    },
-    { signal },
-  );
+    mc.registerTool(
+      {
+        name: "get_metadata",
+        description:
+          "Returns metadata about the current document: character count, word count, and line count.",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => editorTools.get_metadata(),
+      },
+      { signal },
+    );
 
-  mc.registerTool(
-    {
-      name: "list_workspace_docs",
-      description:
-        "Lists all documents in the current workspace. Returns an array of { id, title } objects.",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => workspaceTools.list_workspace_docs(),
-    },
-    { signal },
-  );
+    mc.registerTool(
+      {
+        name: "get_current_mode",
+        description:
+          "Returns the current UI mode: 'editor' (Monaco editor is visible) or 'preview' (Markdown preview is visible).",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => editorTools.get_current_mode(),
+      },
+      { signal },
+    );
 
-  mc.registerTool(
-    {
-      name: "read_workspace_doc",
-      description:
-        "Reads the full content of a specific document in the workspace. Returns { title, content } or { error } if not found.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          id: {
-            type: "string",
-            description:
-              "The document ID to read. Use list_workspace_docs first to get IDs.",
+    mc.registerTool(
+      {
+        name: "request_switch_to_editor",
+        description:
+          "Requests the user to switch from Preview mode to Editor mode. Displays a prompt to the user and waits for them to accept or decline. Call this before attempting edits when in preview mode.",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => editorTools.request_switch_to_editor(),
+      },
+      { signal },
+    );
+
+    mc.registerTool(
+      {
+        name: "edit",
+        description:
+          "Proposes a targeted edit by replacing a specific piece of text. The user must approve or reject the change before it is applied. Use for small, localized changes only — do not pass the entire document.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            originalText: {
+              type: "string",
+              description:
+                "The exact, minimal text to replace. Must be short and unique in the document.",
+            },
+            replacementText: {
+              type: "string",
+              description: "The new text to replace the originalText with.",
+            },
           },
+          required: ["originalText", "replacementText"],
         },
-        required: ["id"],
+        execute: (args) =>
+          editorTools.edit(
+            args as { originalText: string; replacementText: string },
+          ),
       },
-      execute: (args) =>
-        workspaceTools.read_workspace_doc(args as { id: string }),
-    },
-    { signal },
-  );
+      { signal },
+    );
 
-  mc.registerTool(
-    {
-      name: "query_workspace_doc",
-      description:
-        "Asks a question about a specific document in the workspace. Returns { summary } with a concise answer.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          id: { type: "string", description: "The document ID to query." },
-          query: {
-            type: "string",
-            description: "The question or query about the document.",
+    mc.registerTool(
+      {
+        name: "write",
+        description:
+          "Proposes a complete rewrite of the entire document. The user must approve or reject the change before it is applied. Use only when a full document rewrite is explicitly requested.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            content: {
+              type: "string",
+              description: "The full new document content.",
+            },
           },
+          required: ["content"],
         },
-        required: ["id", "query"],
+        execute: (args) => editorTools.write(args as { content: string }),
       },
-      execute: (args) =>
-        workspaceTools.query_workspace_doc(
-          args as { id: string; query: string },
-        ),
-    },
-    { signal },
-  );
+      { signal },
+    );
 
-  mc.registerTool(
-    {
-      name: "query_workspace",
-      description:
-        "Asks a question that spans all documents in the workspace. Queries each document individually then synthesizes the results. Returns { answer }.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          query: {
-            type: "string",
-            description:
-              "The question to answer across all workspace documents.",
-          },
-        },
-        required: ["query"],
+    mc.registerTool(
+      {
+        name: "get_active_doc_info",
+        description:
+          "Returns the id and title of the document currently open in the editor.",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => workspaceTools.get_active_doc_info(),
       },
-      execute: (args) =>
-        workspaceTools.query_workspace(args as { query: string }),
-    },
-    { signal },
-  );
+      { signal },
+    );
+
+    mc.registerTool(
+      {
+        name: "list_workspace_docs",
+        description:
+          "Lists all documents in the current workspace. Returns an array of { id, title } objects.",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => workspaceTools.list_workspace_docs(),
+      },
+      { signal },
+    );
+
+    mc.registerTool(
+      {
+        name: "read_workspace_doc",
+        description:
+          "Reads the full content of a specific document in the workspace. Returns { title, content } or { error } if not found.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              description:
+                "The document ID to read. Use list_workspace_docs first to get IDs.",
+            },
+          },
+          required: ["id"],
+        },
+        execute: (args) =>
+          workspaceTools.read_workspace_doc(args as { id: string }),
+      },
+      { signal },
+    );
+
+    mc.registerTool(
+      {
+        name: "query_workspace_doc",
+        description:
+          "Asks a question about a specific document in the workspace. Returns { summary } with a concise answer.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "The document ID to query." },
+            query: {
+              type: "string",
+              description: "The question or query about the document.",
+            },
+          },
+          required: ["id", "query"],
+        },
+        execute: (args) =>
+          workspaceTools.query_workspace_doc(
+            args as { id: string; query: string },
+          ),
+      },
+      { signal },
+    );
+
+    mc.registerTool(
+      {
+        name: "query_workspace",
+        description:
+          "Asks a question that spans all documents in the workspace. Queries each document individually then synthesizes the results. Returns { answer }.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description:
+                "The question to answer across all workspace documents.",
+            },
+          },
+          required: ["query"],
+        },
+        execute: (args) =>
+          workspaceTools.query_workspace(args as { query: string }),
+      },
+      { signal },
+    );
+
+    mc.registerTool(
+      {
+        name: "create_document",
+        description:
+          "Creates a new blank document in the workspace with the given title. Pauses for user authorization before creating.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            title: {
+              type: "string",
+              description: "The title for the new document.",
+            },
+          },
+          required: ["title"],
+        },
+        execute: (args) =>
+          workspaceTools.create_document(args as { title: string }),
+      },
+      { signal },
+    );
+
+    mc.registerTool(
+      {
+        name: "rename_document",
+        description:
+          "Renames an existing document in the workspace. Pauses for user authorization before renaming.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "The document ID to rename." },
+            title: {
+              type: "string",
+              description: "The new title for the document.",
+            },
+          },
+          required: ["id", "title"],
+        },
+        execute: (args) =>
+          workspaceTools.rename_document(args as { id: string; title: string }),
+      },
+      { signal },
+    );
+
+    mc.registerTool(
+      {
+        name: "delete_document",
+        description:
+          "Deletes a document from the workspace. Pauses for user authorization before deleting.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "The document ID to delete." },
+          },
+          required: ["id"],
+        },
+        execute: (args) =>
+          workspaceTools.delete_document(args as { id: string }),
+      },
+      { signal },
+    );
+
+    mc.registerTool(
+      {
+        name: "switch_active_document",
+        description:
+          "Switches the active document in the editor. Saves the current document content before switching. Does not require user authorization.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              description: "The document ID to switch to.",
+            },
+          },
+          required: ["id"],
+        },
+        execute: (args) =>
+          workspaceTools.switch_active_document(args as { id: string }),
+      },
+      { signal },
+    );
   } catch (err) {
     console.warn("WebMCP tool registration failed:", err);
     return () => {};

--- a/src/lib/WorkspaceTools.test.ts
+++ b/src/lib/WorkspaceTools.test.ts
@@ -3,7 +3,17 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { WorkspaceTools } from "./WorkspaceTools";
-import type { AdapterFactory, SubAgentFactory } from "./WorkspaceTools";
+import type {
+  AdapterFactory,
+  SubAgentFactory,
+  CreateDocumentFn,
+  RenameDocumentFn,
+  DeleteDocumentFn,
+  SetActiveDocumentIdFn,
+  SaveDocContentFn,
+  GetEditorContentFn,
+  SetPendingWorkspaceActionFn,
+} from "./WorkspaceTools";
 import type { WorkspaceDocument } from "./workspace";
 import type { LlmAdapter } from "@mast-ai/core";
 
@@ -176,6 +186,274 @@ describe("WorkspaceTools", () => {
       );
       await tools.query_workspace_doc({ id: "doc-1", query: "q" });
       expect(adapterFactory).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("create_document", () => {
+    let createDocumentFn: ReturnType<typeof vi.fn> & CreateDocumentFn;
+    let setPendingWorkspaceAction: ReturnType<typeof vi.fn> &
+      SetPendingWorkspaceActionFn;
+
+    beforeEach(() => {
+      createDocumentFn = vi.fn().mockReturnValue("new-doc-id");
+      setPendingWorkspaceAction = vi.fn();
+    });
+
+    function makeTools(approveAll = false) {
+      return new WorkspaceTools(
+        makeRef([]),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+        createDocumentFn,
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        vi.fn().mockReturnValue(""),
+        setPendingWorkspaceAction,
+        approveAll,
+      );
+    }
+
+    it("returns error when title is empty", async () => {
+      const tools = makeTools();
+      const result = JSON.parse(await tools.create_document({ title: "" }));
+      expect(result).toEqual({ error: "title is required" });
+      expect(setPendingWorkspaceAction).not.toHaveBeenCalled();
+    });
+
+    it("creates document immediately when approveAll is true", async () => {
+      const tools = makeTools(true);
+      const result = await tools.create_document({ title: "My Doc" });
+      expect(createDocumentFn).toHaveBeenCalledWith("My Doc");
+      expect(result).toContain("Approve All");
+    });
+
+    it("sets pending workspace action when approveAll is false", async () => {
+      const tools = makeTools(false);
+      const promise = tools.create_document({ title: "Draft" });
+      expect(setPendingWorkspaceAction).toHaveBeenCalledOnce();
+
+      const request = setPendingWorkspaceAction.mock.calls[0][0];
+      expect(request.description).toContain("Draft");
+      expect(typeof request.apply).toBe("function");
+      expect(typeof request.resolve).toBe("function");
+
+      request.apply();
+      expect(createDocumentFn).toHaveBeenCalledWith("Draft");
+
+      request.resolve("Action applied successfully.");
+      expect(await promise).toBe("Action applied successfully.");
+    });
+
+    it("returns rejection message when user rejects", async () => {
+      const tools = makeTools(false);
+      const promise = tools.create_document({ title: "Draft" });
+      const request = setPendingWorkspaceAction.mock.calls[0][0];
+      request.resolve("Action rejected by user.");
+      expect(await promise).toBe("Action rejected by user.");
+      expect(createDocumentFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("rename_document", () => {
+    let renameDocumentFn: ReturnType<typeof vi.fn> & RenameDocumentFn;
+    let setPendingWorkspaceAction: ReturnType<typeof vi.fn> &
+      SetPendingWorkspaceActionFn;
+
+    beforeEach(() => {
+      renameDocumentFn = vi.fn();
+      setPendingWorkspaceAction = vi.fn();
+    });
+
+    function makeTools(docs: WorkspaceDocument[], approveAll = false) {
+      return new WorkspaceTools(
+        makeRef(docs),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+        vi.fn(),
+        renameDocumentFn,
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        vi.fn().mockReturnValue(""),
+        setPendingWorkspaceAction,
+        approveAll,
+      );
+    }
+
+    it("returns error when document is not found", async () => {
+      const tools = makeTools([]);
+      const result = JSON.parse(
+        await tools.rename_document({ id: "nope", title: "New" }),
+      );
+      expect(result).toEqual({ error: "Document not found" });
+    });
+
+    it("returns error when title is empty", async () => {
+      const tools = makeTools([makeDoc({ id: "d1" })]);
+      const result = JSON.parse(
+        await tools.rename_document({ id: "d1", title: "" }),
+      );
+      expect(result).toEqual({ error: "title is required" });
+    });
+
+    it("renames immediately when approveAll is true", async () => {
+      const tools = makeTools([makeDoc({ id: "d1", title: "Old" })], true);
+      await tools.rename_document({ id: "d1", title: "New" });
+      expect(renameDocumentFn).toHaveBeenCalledWith("d1", "New");
+    });
+
+    it("sets pending workspace action and renames on accept", async () => {
+      const tools = makeTools([makeDoc({ id: "d1", title: "Old" })]);
+      const promise = tools.rename_document({ id: "d1", title: "New" });
+      const request = setPendingWorkspaceAction.mock.calls[0][0];
+      expect(request.description).toContain("Old");
+      expect(request.description).toContain("New");
+
+      request.apply();
+      expect(renameDocumentFn).toHaveBeenCalledWith("d1", "New");
+
+      request.resolve("Action applied successfully.");
+      expect(await promise).toBe("Action applied successfully.");
+    });
+
+    it("does not rename on rejection", async () => {
+      const tools = makeTools([makeDoc({ id: "d1", title: "Old" })]);
+      const promise = tools.rename_document({ id: "d1", title: "New" });
+      const request = setPendingWorkspaceAction.mock.calls[0][0];
+      request.resolve("Action rejected by user.");
+      expect(await promise).toBe("Action rejected by user.");
+      expect(renameDocumentFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("delete_document", () => {
+    let deleteDocumentFn: ReturnType<typeof vi.fn> & DeleteDocumentFn;
+    let setPendingWorkspaceAction: ReturnType<typeof vi.fn> &
+      SetPendingWorkspaceActionFn;
+
+    beforeEach(() => {
+      deleteDocumentFn = vi.fn();
+      setPendingWorkspaceAction = vi.fn();
+    });
+
+    function makeTools(docs: WorkspaceDocument[], approveAll = false) {
+      return new WorkspaceTools(
+        makeRef(docs),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+        vi.fn(),
+        vi.fn(),
+        deleteDocumentFn,
+        vi.fn(),
+        vi.fn(),
+        vi.fn().mockReturnValue(""),
+        setPendingWorkspaceAction,
+        approveAll,
+      );
+    }
+
+    it("returns error when document is not found", async () => {
+      const tools = makeTools([]);
+      const result = JSON.parse(await tools.delete_document({ id: "nope" }));
+      expect(result).toEqual({ error: "Document not found" });
+    });
+
+    it("deletes immediately when approveAll is true", async () => {
+      const tools = makeTools([makeDoc({ id: "d1" })], true);
+      await tools.delete_document({ id: "d1" });
+      expect(deleteDocumentFn).toHaveBeenCalledWith("d1");
+    });
+
+    it("sets pending workspace action and deletes on accept", async () => {
+      const tools = makeTools([makeDoc({ id: "d1", title: "My Essay" })]);
+      const promise = tools.delete_document({ id: "d1" });
+      const request = setPendingWorkspaceAction.mock.calls[0][0];
+      expect(request.description).toContain("My Essay");
+
+      request.apply();
+      expect(deleteDocumentFn).toHaveBeenCalledWith("d1");
+
+      request.resolve("Action applied successfully.");
+      expect(await promise).toBe("Action applied successfully.");
+    });
+
+    it("does not delete on rejection", async () => {
+      const tools = makeTools([makeDoc({ id: "d1" })]);
+      const promise = tools.delete_document({ id: "d1" });
+      const request = setPendingWorkspaceAction.mock.calls[0][0];
+      request.resolve("Action rejected by user.");
+      expect(await promise).toBe("Action rejected by user.");
+      expect(deleteDocumentFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("switch_active_document", () => {
+    let setActiveDocumentIdFn: ReturnType<typeof vi.fn> & SetActiveDocumentIdFn;
+    let saveDocContentFn: ReturnType<typeof vi.fn> & SaveDocContentFn;
+    let getEditorContent: ReturnType<typeof vi.fn> & GetEditorContentFn;
+
+    beforeEach(() => {
+      setActiveDocumentIdFn = vi.fn();
+      saveDocContentFn = vi.fn();
+      getEditorContent = vi.fn().mockReturnValue("editor content");
+    });
+
+    function makeTools(
+      docs: WorkspaceDocument[],
+      activeDoc: { id: string; title: string } | null = null,
+    ) {
+      return new WorkspaceTools(
+        makeRef(docs),
+        makeActiveDocRef(activeDoc),
+        adapterFactory,
+        runnerFactory,
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        setActiveDocumentIdFn,
+        saveDocContentFn,
+        getEditorContent,
+        vi.fn(),
+        false,
+      );
+    }
+
+    it("returns error when document is not found", async () => {
+      const tools = makeTools([]);
+      const result = JSON.parse(
+        await tools.switch_active_document({ id: "nope" }),
+      );
+      expect(result).toEqual({ error: "Document not found" });
+    });
+
+    it("switches document without authorization", async () => {
+      const docs = [makeDoc({ id: "d1", title: "Doc 1" })];
+      const tools = makeTools(docs);
+      const result = JSON.parse(
+        await tools.switch_active_document({ id: "d1" }),
+      );
+      expect(result).toEqual({ switched: true, id: "d1", title: "Doc 1" });
+      expect(setActiveDocumentIdFn).toHaveBeenCalledWith("d1");
+    });
+
+    it("saves current document content before switching", async () => {
+      const docs = [makeDoc({ id: "d2", title: "Target" })];
+      const tools = makeTools(docs, { id: "d1", title: "Current" });
+      await tools.switch_active_document({ id: "d2" });
+      expect(saveDocContentFn).toHaveBeenCalledWith("d1", "editor content");
+      expect(setActiveDocumentIdFn).toHaveBeenCalledWith("d2");
+    });
+
+    it("does not save content when no active document", async () => {
+      const docs = [makeDoc({ id: "d1" })];
+      const tools = makeTools(docs, null);
+      await tools.switch_active_document({ id: "d1" });
+      expect(saveDocContentFn).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/WorkspaceTools.ts
+++ b/src/lib/WorkspaceTools.ts
@@ -3,7 +3,9 @@
 
 import { AgentRunner, LlmAdapter, ToolRegistry } from "@mast-ai/core";
 import type { AgentConfig } from "@mast-ai/core";
+import { v4 as uuidv4 } from "uuid";
 import { WorkspaceDocument } from "./workspace";
+import type { WorkspaceActionRequest } from "./store";
 
 type RunnerLike = {
   run: (agent: AgentConfig, input: string) => Promise<{ output: string }>;
@@ -11,6 +13,15 @@ type RunnerLike = {
 
 export type AdapterFactory = () => LlmAdapter;
 export type SubAgentFactory = (adapter: LlmAdapter) => RunnerLike;
+export type CreateDocumentFn = (title: string) => string;
+export type RenameDocumentFn = (id: string, title: string) => void;
+export type DeleteDocumentFn = (id: string) => void;
+export type SetActiveDocumentIdFn = (id: string) => void;
+export type SaveDocContentFn = (id: string, content: string) => void;
+export type GetEditorContentFn = () => string;
+export type SetPendingWorkspaceActionFn = (
+  action: WorkspaceActionRequest | null,
+) => void;
 
 /** Accepts any object with a `current` array — compatible with React.MutableRefObject. */
 export interface DocsRef {
@@ -30,6 +41,14 @@ export class WorkspaceTools {
     private activeDocRef: ActiveDocRef,
     private adapterFactory: AdapterFactory,
     private runnerFactory: SubAgentFactory = defaultRunnerFactory,
+    private createDocumentFn: CreateDocumentFn = () => "",
+    private renameDocumentFn: RenameDocumentFn = () => {},
+    private deleteDocumentFn: DeleteDocumentFn = () => {},
+    private setActiveDocumentIdFn: SetActiveDocumentIdFn = () => {},
+    private saveDocContentFn: SaveDocContentFn = () => {},
+    private getEditorContent: GetEditorContentFn = () => "",
+    private setPendingWorkspaceAction: SetPendingWorkspaceActionFn = () => {},
+    private approveAll: boolean = false,
   ) {}
 
   get_active_doc_info(): string {
@@ -70,6 +89,79 @@ export class WorkspaceTools {
     const input = `Document title: ${doc.title}\n\nDocument content:\n${doc.content}\n\nQuestion: ${query}`;
     const result = await runner.run(agent, input);
     return JSON.stringify({ summary: result.output });
+  }
+
+  create_document({ title }: { title: string }): Promise<string> {
+    if (!title?.trim()) {
+      return Promise.resolve(JSON.stringify({ error: "title is required" }));
+    }
+    return this.applyWorkspaceAction(
+      `Create document "${title}"`,
+      () => this.createDocumentFn(title),
+      `Document "${title}" created automatically (Approve All is ON).`,
+    );
+  }
+
+  rename_document({
+    id,
+    title,
+  }: {
+    id: string;
+    title: string;
+  }): Promise<string> {
+    const doc = this.docsRef.current.find((d) => d.id === id);
+    if (!doc)
+      return Promise.resolve(JSON.stringify({ error: "Document not found" }));
+    if (!title?.trim()) {
+      return Promise.resolve(JSON.stringify({ error: "title is required" }));
+    }
+    return this.applyWorkspaceAction(
+      `Rename document "${doc.title}" to "${title}"`,
+      () => this.renameDocumentFn(id, title),
+      `Document renamed to "${title}" automatically (Approve All is ON).`,
+    );
+  }
+
+  delete_document({ id }: { id: string }): Promise<string> {
+    const doc = this.docsRef.current.find((d) => d.id === id);
+    if (!doc)
+      return Promise.resolve(JSON.stringify({ error: "Document not found" }));
+    return this.applyWorkspaceAction(
+      `Delete document "${doc.title}"`,
+      () => this.deleteDocumentFn(id),
+      `Document "${doc.title}" deleted automatically (Approve All is ON).`,
+    );
+  }
+
+  async switch_active_document({ id }: { id: string }): Promise<string> {
+    const doc = this.docsRef.current.find((d) => d.id === id);
+    if (!doc) return JSON.stringify({ error: "Document not found" });
+    const currentDoc = this.activeDocRef.current;
+    if (currentDoc) {
+      this.saveDocContentFn(currentDoc.id, this.getEditorContent());
+    }
+    this.setActiveDocumentIdFn(id);
+    return JSON.stringify({ switched: true, id, title: doc.title });
+  }
+
+  private applyWorkspaceAction(
+    description: string,
+    apply: () => void,
+    autoMessage: string,
+  ): Promise<string> {
+    if (this.approveAll) {
+      apply();
+      return Promise.resolve(autoMessage);
+    }
+    return new Promise((resolve) => {
+      const request: WorkspaceActionRequest = {
+        id: uuidv4(),
+        description,
+        apply,
+        resolve,
+      };
+      this.setPendingWorkspaceAction(request);
+    });
   }
 
   async query_workspace({ query }: { query: string }): Promise<string> {
@@ -164,6 +256,87 @@ export function registerWorkspaceTools(
     }),
     call: async (args: { id: string; query: string }) =>
       tools.query_workspace_doc(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "create_document",
+      description:
+        "Creates a new blank document in the workspace with the given title. Pauses for user authorization before creating.",
+      parameters: {
+        type: "object",
+        properties: {
+          title: {
+            type: "string",
+            description: "The title for the new document.",
+          },
+        },
+        required: ["title"],
+      },
+    }),
+    call: async (args: { title: string }) => tools.create_document(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "rename_document",
+      description:
+        "Renames an existing document in the workspace. Pauses for user authorization before renaming.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description: "The document ID to rename.",
+          },
+          title: {
+            type: "string",
+            description: "The new title for the document.",
+          },
+        },
+        required: ["id", "title"],
+      },
+    }),
+    call: async (args: { id: string; title: string }) =>
+      tools.rename_document(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "delete_document",
+      description:
+        "Deletes a document from the workspace. Pauses for user authorization before deleting. If the deleted document was active, a different document becomes active.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description: "The document ID to delete.",
+          },
+        },
+        required: ["id"],
+      },
+    }),
+    call: async (args: { id: string }) => tools.delete_document(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "switch_active_document",
+      description:
+        "Switches the active document in the editor. Saves the current document content before switching. Does not require user authorization.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description: "The document ID to switch to.",
+          },
+        },
+        required: ["id"],
+      },
+    }),
+    call: async (args: { id: string }) => tools.switch_active_document(args),
   });
 
   registry.register({

--- a/src/lib/WorkspacesContext.tsx
+++ b/src/lib/WorkspacesContext.tsx
@@ -131,6 +131,7 @@ interface WorkspacesContextValue {
   closeWorkspace: () => void;
 
   addDocument: () => void;
+  createDocumentWithTitle: (title: string) => string;
   updateDocument: (
     id: string,
     patch: Partial<Pick<WorkspaceDocument, "title" | "content">>,
@@ -258,6 +259,21 @@ export function WorkspacesProvider({
     }));
   };
 
+  const createDocumentWithTitle = (title: string): string => {
+    const doc: WorkspaceDocument = {
+      id: crypto.randomUUID(),
+      title,
+      content: "",
+      updatedAt: Date.now(),
+    };
+    mutateActiveWorkspace((data) => ({
+      ...data,
+      documents: [...data.documents, doc],
+      activeDocumentId: doc.id,
+    }));
+    return doc.id;
+  };
+
   const updateDocument = (
     id: string,
     patch: Partial<Pick<WorkspaceDocument, "title" | "content">>,
@@ -298,6 +314,7 @@ export function WorkspacesProvider({
         renameWorkspace,
         closeWorkspace,
         addDocument,
+        createDocumentWithTitle,
         updateDocument,
         deleteDocument,
         setActiveDocumentId,

--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -18,6 +18,13 @@ export interface TabSwitchRequest {
   resolve: (accepted: boolean) => void;
 }
 
+export interface WorkspaceActionRequest {
+  id: string;
+  description: string;
+  apply: () => void;
+  resolve: (message: string) => void;
+}
+
 interface AppState {
   apiKey: string | null;
   setApiKey: (key: string | null) => void;
@@ -39,6 +46,8 @@ interface AppState {
   setEditorContent: (content: string) => void;
   pendingTabSwitchRequest: TabSwitchRequest | null;
   setPendingTabSwitchRequest: (req: TabSwitchRequest | null) => void;
+  pendingWorkspaceAction: WorkspaceActionRequest | null;
+  setPendingWorkspaceAction: (action: WorkspaceActionRequest | null) => void;
   approveAll: boolean;
   setApproveAll: (approve: boolean) => void;
   skills: Skill[];
@@ -66,6 +75,8 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
   const [editorContent, setEditorContent] = useState<string>("");
   const [pendingTabSwitchRequest, setPendingTabSwitchRequest] =
     useState<TabSwitchRequest | null>(null);
+  const [pendingWorkspaceAction, setPendingWorkspaceAction] =
+    useState<WorkspaceActionRequest | null>(null);
   const [approveAll, setApproveAll] = useState(false);
   const [skills, setSkillsState] = useState<Skill[]>(() => initializeSkills());
 
@@ -105,6 +116,8 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
         setEditorContent,
         pendingTabSwitchRequest,
         setPendingTabSwitchRequest,
+        pendingWorkspaceAction,
+        setPendingWorkspaceAction,
         approveAll,
         setApproveAll,
         skills,


### PR DESCRIPTION
## Summary

Closes #32.

- Adds `create_document`, `rename_document`, `delete_document` tools that pause for user authorization using a new `WorkspaceActionRequest` pattern (mirroring how `edit`/`write` use `Suggestion` in `EditorTools`)
- Adds `switch_active_document` that saves current editor content before switching, no authorization required
- All four tools registered in both `registerWorkspaceTools` (agent) and `registerWebMCPTools` (WebMCP)
- `WorkspacesContext` gains `createDocumentWithTitle(title): string`
- `store.tsx` gains `WorkspaceActionRequest` type and `pendingWorkspaceAction` state
- `App.tsx` renders an authorization `Dialog` for pending workspace actions

## Test plan

- [x] All 220 existing + new tests pass (`npm run test`)
- [x] `npm run lint` and `npm run format` pass
- [x] Ask the agent to create a new document — authorization dialog appears, accept creates it
- [x] Ask the agent to rename a document — authorization dialog appears, accept renames it
- [x] Ask the agent to delete a document — authorization dialog appears, accept deletes it; active doc pointer updates if needed
- [x] Ask the agent to switch to another document — switches immediately with no dialog, current doc content is preserved
- [x] Reject any of the mutating actions — agent receives rejection message, no change applied
- [x] With "Approve All" on, create/rename/delete execute immediately without showing a dialog