### PR TITLE
fix: resolve TypeScript errors in test mocks after workspace action PR

### DIFF
--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -30,6 +30,8 @@ function mockStore(apiKey: string | null, modelName: string) {
     setEditorContent: vi.fn(),
     pendingTabSwitchRequest: null,
     setPendingTabSwitchRequest: vi.fn(),
+    pendingWorkspaceAction: null,
+    setPendingWorkspaceAction: vi.fn(),
     approveAll: false,
     setApproveAll: vi.fn(),
     skills: [],

--- a/src/components/SkillsDialog.test.tsx
+++ b/src/components/SkillsDialog.test.tsx
@@ -38,6 +38,8 @@ function mockStore(skills: Skill[]) {
     setEditorContent: vi.fn(),
     pendingTabSwitchRequest: null,
     setPendingTabSwitchRequest: vi.fn(),
+    pendingWorkspaceAction: null,
+    setPendingWorkspaceAction: vi.fn(),
     approveAll: false,
     setApproveAll: vi.fn(),
     skills,

--- a/src/lib/WorkspaceTools.test.ts
+++ b/src/lib/WorkspaceTools.test.ts
@@ -195,8 +195,8 @@ describe("WorkspaceTools", () => {
       SetPendingWorkspaceActionFn;
 
     beforeEach(() => {
-      createDocumentFn = vi.fn().mockReturnValue("new-doc-id");
-      setPendingWorkspaceAction = vi.fn();
+      createDocumentFn = vi.fn().mockReturnValue("new-doc-id") as unknown as typeof createDocumentFn;
+      setPendingWorkspaceAction = vi.fn() as unknown as typeof setPendingWorkspaceAction;
     });
 
     function makeTools(approveAll = false) {
@@ -263,8 +263,8 @@ describe("WorkspaceTools", () => {
       SetPendingWorkspaceActionFn;
 
     beforeEach(() => {
-      renameDocumentFn = vi.fn();
-      setPendingWorkspaceAction = vi.fn();
+      renameDocumentFn = vi.fn() as unknown as typeof renameDocumentFn;
+      setPendingWorkspaceAction = vi.fn() as unknown as typeof setPendingWorkspaceAction;
     });
 
     function makeTools(docs: WorkspaceDocument[], approveAll = false) {
@@ -336,8 +336,8 @@ describe("WorkspaceTools", () => {
       SetPendingWorkspaceActionFn;
 
     beforeEach(() => {
-      deleteDocumentFn = vi.fn();
-      setPendingWorkspaceAction = vi.fn();
+      deleteDocumentFn = vi.fn() as unknown as typeof deleteDocumentFn;
+      setPendingWorkspaceAction = vi.fn() as unknown as typeof setPendingWorkspaceAction;
     });
 
     function makeTools(docs: WorkspaceDocument[], approveAll = false) {
@@ -398,9 +398,9 @@ describe("WorkspaceTools", () => {
     let getEditorContent: ReturnType<typeof vi.fn> & GetEditorContentFn;
 
     beforeEach(() => {
-      setActiveDocumentIdFn = vi.fn();
-      saveDocContentFn = vi.fn();
-      getEditorContent = vi.fn().mockReturnValue("editor content");
+      setActiveDocumentIdFn = vi.fn() as unknown as typeof setActiveDocumentIdFn;
+      saveDocContentFn = vi.fn() as unknown as typeof saveDocContentFn;
+      getEditorContent = vi.fn().mockReturnValue("editor content") as unknown as typeof getEditorContent;
     });
 
     function makeTools(


### PR DESCRIPTION
## Summary

- Add missing `pendingWorkspaceAction` and `setPendingWorkspaceAction` fields to `useApp` mock objects in `SettingsDialog.test.tsx` and `SkillsDialog.test.tsx` — these were introduced in the workspace management PR but not back-filled into existing tests
- Cast `vi.fn()` assignments to `as unknown as typeof variable` in `WorkspaceTools.test.ts` for void-function mock variables declared with intersection types — TypeScript cannot infer that an untyped `vi.fn()` satisfies a specific function signature

## Test plan

- [x] `npm run build` passes with zero TypeScript errors