### PR TITLE
feat: @-mention documents in chat input

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -58,7 +58,7 @@ describe("App", () => {
     expect(screen.getByTestId("mock-monaco-editor")).toBeInTheDocument();
     expect(screen.getAllByText("AI Assistant").length).toBeGreaterThan(0);
     expect(
-      screen.getByPlaceholderText("Ask the editor..."),
+      screen.getByRole("textbox", { name: "Chat input" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
   });
@@ -115,7 +115,7 @@ describe("App responsive layout", () => {
 
     await user.click(screen.getByRole("button", { name: "Open chat" }));
     expect(
-      screen.getByPlaceholderText("Ask the editor..."),
+      screen.getByRole("textbox", { name: "Chat input" }),
     ).toBeInTheDocument();
   });
 

--- a/src/components/ChatSidebar.test.tsx
+++ b/src/components/ChatSidebar.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ChatSidebar } from "./ChatSidebar";
 import { AppProvider } from "@/lib/store";
 import { ThemeProvider } from "@/lib/ThemeProvider";
+import { WorkspacesProvider } from "@/lib/WorkspacesContext";
 import type { Conversation } from "@mast-ai/core";
 
 vi.mock("@tanstack/react-virtual", () => ({
@@ -44,11 +45,17 @@ function makeConversation(
 function renderSidebar(conversation: Conversation | null = null) {
   return render(
     <ThemeProvider>
-      <AppProvider>
-        <ChatSidebar conversation={conversation} />
-      </AppProvider>
+      <WorkspacesProvider>
+        <AppProvider>
+          <ChatSidebar conversation={conversation} />
+        </AppProvider>
+      </WorkspacesProvider>
     </ThemeProvider>,
   );
+}
+
+function getInput() {
+  return screen.getByRole("textbox", { name: "Chat input" });
 }
 
 describe("ChatSidebar", () => {
@@ -71,7 +78,7 @@ describe("ChatSidebar", () => {
   it("enables send button when input has text", async () => {
     const user = userEvent.setup();
     renderSidebar(makeConversation());
-    await user.type(screen.getByPlaceholderText("Ask the editor..."), "Hello");
+    await user.type(getInput(), "Hello");
     expect(screen.getByRole("button", { name: "Send" })).not.toBeDisabled();
   });
 
@@ -79,7 +86,7 @@ describe("ChatSidebar", () => {
     const user = userEvent.setup();
     renderSidebar(makeConversation([{ type: "done" }]));
     await user.type(
-      screen.getByPlaceholderText("Ask the editor..."),
+      getInput(),
       "Hello AI",
     );
     await user.click(screen.getByRole("button", { name: "Send" }));
@@ -96,7 +103,7 @@ describe("ChatSidebar", () => {
         { type: "done" },
       ]),
     );
-    await user.type(screen.getByPlaceholderText("Ask the editor..."), "test");
+    await user.type(getInput(), "test");
     await user.click(screen.getByRole("button", { name: "Send" }));
     await waitFor(() => {
       expect(screen.getByText("Thinking Process")).toBeInTheDocument();
@@ -112,7 +119,7 @@ describe("ChatSidebar", () => {
         { type: "done" },
       ]),
     );
-    await user.type(screen.getByPlaceholderText("Ask the editor..."), "test");
+    await user.type(getInput(), "test");
     await user.click(screen.getByRole("button", { name: "Send" }));
     await waitFor(() => {
       expect(screen.getByText("Hello world")).toBeInTheDocument();
@@ -128,7 +135,7 @@ describe("ChatSidebar", () => {
         { type: "done" },
       ]),
     );
-    await user.type(screen.getByPlaceholderText("Ask the editor..."), "test");
+    await user.type(getInput(), "test");
     await user.click(screen.getByRole("button", { name: "Send" }));
     await waitFor(() => {
       expect(screen.getByText("read")).toBeInTheDocument();
@@ -136,25 +143,31 @@ describe("ChatSidebar", () => {
   });
 
   it("reconstructs user and assistant messages from conversation history", () => {
-    const conversation = makeConversation([], [
-      { role: "user", content: { type: "text", text: "Hello from history" } },
-      { role: "assistant", content: { type: "text", text: "Hi there" } },
-    ]);
+    const conversation = makeConversation(
+      [],
+      [
+        { role: "user", content: { type: "text", text: "Hello from history" } },
+        { role: "assistant", content: { type: "text", text: "Hi there" } },
+      ],
+    );
     renderSidebar(conversation);
     expect(screen.getByText("Hello from history")).toBeInTheDocument();
     expect(screen.getByText("Hi there")).toBeInTheDocument();
   });
 
   it("reconstructs tool call items from conversation history", () => {
-    const conversation = makeConversation([], [
-      {
-        role: "assistant",
-        content: {
-          type: "tool_calls",
-          calls: [{ id: "1", name: "edit", args: {} }],
+    const conversation = makeConversation(
+      [],
+      [
+        {
+          role: "assistant",
+          content: {
+            type: "tool_calls",
+            calls: [{ id: "1", name: "edit", args: {} }],
+          },
         },
-      },
-    ]);
+      ],
+    );
     renderSidebar(conversation);
     expect(screen.getByText("edit")).toBeInTheDocument();
   });

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -3,21 +3,22 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Button } from "./ui/button";
-import { Input } from "./ui/input";
 import { Switch } from "./ui/switch";
 import { Label } from "./ui/label";
 import { Conversation } from "@mast-ai/core";
-import {
-  Settings,
-  Wand2,
-  Sun,
-  Moon,
-} from "lucide-react";
+import { Settings, Wand2, Sun, Moon, X } from "lucide-react";
 import { useApp } from "@/lib/store";
 import { useTheme } from "@/lib/ThemeProvider";
+import { useWorkspaces } from "@/lib/WorkspacesContext";
 import { SettingsDialog } from "./SettingsDialog";
 import { SkillsDialog } from "./SkillsDialog";
 import { ChatItem, StreamItem } from "./ChatItem";
+import {
+  DocRef,
+  buildPromptWithMentions,
+  extractMentionQuery,
+  removeMentionTrigger,
+} from "@/lib/mentionUtils";
 
 interface ChatSidebarProps {
   conversation: Conversation | null;
@@ -33,11 +34,27 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
   const [prevConversation, setPrevConversation] = useState<Conversation | null>(
     null,
   );
+  const [mentionedDocs, setMentionedDocs] = useState<DocRef[]>([]);
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [pickerIndex, setPickerIndex] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [skillsOpen, setSkillsOpen] = useState(false);
   const { approveAll, setApproveAll } = useApp();
   const { theme, toggleTheme } = useTheme();
+  const { activeWorkspace } = useWorkspaces();
+
+  const workspaceDocs = activeWorkspace?.documents ?? [];
+
+  const filteredDocs =
+    mentionQuery !== null
+      ? workspaceDocs.filter(
+          (d) =>
+            !mentionedDocs.some((m) => m.id === d.id) &&
+            d.title.toLowerCase().includes(mentionQuery.toLowerCase()),
+        )
+      : [];
 
   // Rebuild display items when the conversation instance changes (e.g. new session)
   if (conversation !== prevConversation) {
@@ -98,16 +115,79 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
     });
   };
 
-  const handleSend = async () => {
-    if (!input.trim() || !conversation || isLoading) return;
+  const selectDoc = (doc: DocRef) => {
+    setMentionedDocs((prev) =>
+      prev.some((d) => d.id === doc.id) ? prev : [...prev, doc],
+    );
+    setInput((prev) => removeMentionTrigger(prev));
+    setMentionQuery(null);
+    setPickerIndex(0);
+    inputRef.current?.focus();
+  };
 
-    const userText = input.trim();
+  const removeChip = (id: string) => {
+    setMentionedDocs((prev) => prev.filter((d) => d.id !== id));
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setInput(value);
+    const query = extractMentionQuery(value);
+    setMentionQuery(query);
+    setPickerIndex(0);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (mentionQuery !== null && filteredDocs.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setPickerIndex((i) => (i + 1) % filteredDocs.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setPickerIndex((i) => (i === 0 ? filteredDocs.length - 1 : i - 1));
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        selectDoc(filteredDocs[pickerIndex]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setMentionQuery(null);
+        return;
+      }
+    }
+    if (e.key === "Enter") {
+      handleSend();
+    }
+  };
+
+  const handleSend = async () => {
+    const trimmed = input.trim();
+    if ((!trimmed && mentionedDocs.length === 0) || !conversation || isLoading)
+      return;
+
+    const userText = trimmed || "(no message)";
+    const prompt = buildPromptWithMentions(userText, mentionedDocs);
+
     setInput("");
+    setMentionedDocs([]);
+    setMentionQuery(null);
     setIsLoading(true);
 
     setItems((prev) => [
       ...prev,
-      { kind: "user", id: `user-${crypto.randomUUID()}`, text: userText },
+      {
+        kind: "user",
+        id: `user-${crypto.randomUUID()}`,
+        text:
+          mentionedDocs.length > 0
+            ? `[Referenced: ${mentionedDocs.map((d) => d.title).join(", ")}] ${userText}`
+            : userText,
+      },
     ]);
 
     // IDs of in-flight items — local vars are sufficient since this all runs
@@ -128,7 +208,7 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
     };
 
     try {
-      for await (const event of conversation.runStream(userText)) {
+      for await (const event of conversation.runStream(prompt)) {
         if (event.type === "thinking") {
           const id = ensureAssistant();
           const delta = event.delta;
@@ -214,6 +294,9 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
       setIsLoading(false);
     }
   };
+
+  const canSend =
+    (input.trim().length > 0 || mentionedDocs.length > 0) && !isLoading;
 
   return (
     <div className="flex flex-col h-full bg-muted/20 border-l">
@@ -307,19 +390,70 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
       </div>
 
       <div className="p-4 border-t bg-background/50 backdrop-blur-sm flex gap-2">
-        <Input
-          placeholder="Ask the editor..."
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && handleSend()}
-          disabled={isLoading}
-          className="bg-background"
-        />
-        <Button
-          onClick={handleSend}
-          disabled={isLoading || !input.trim()}
-          className="min-h-11"
-        >
+        <div className="relative flex-1">
+          {/* Document picker dropdown */}
+          {mentionQuery !== null && filteredDocs.length > 0 && (
+            <div
+              className="absolute bottom-full mb-1 left-0 right-0 z-50 bg-popover border rounded-md shadow-md overflow-hidden"
+              role="listbox"
+              aria-label="Document picker"
+            >
+              {filteredDocs.map((doc, idx) => (
+                <button
+                  key={doc.id}
+                  role="option"
+                  aria-selected={idx === pickerIndex}
+                  className={`w-full text-left px-3 py-2 text-sm truncate ${
+                    idx === pickerIndex
+                      ? "bg-accent text-accent-foreground"
+                      : "hover:bg-muted"
+                  }`}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    selectDoc(doc);
+                  }}
+                >
+                  {doc.title}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Compound input: chips + text field */}
+          <div className="flex flex-wrap items-center gap-1 border rounded-md bg-background px-3 py-2 min-h-11 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-0">
+            {mentionedDocs.map((doc) => (
+              <span
+                key={doc.id}
+                className="inline-flex items-center gap-1 bg-primary/10 text-primary text-xs font-medium rounded px-2 py-0.5"
+              >
+                @{doc.title}
+                <button
+                  type="button"
+                  aria-label={`Remove reference to ${doc.title}`}
+                  onClick={() => removeChip(doc.id)}
+                  className="hover:text-destructive"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </span>
+            ))}
+            <input
+              ref={inputRef}
+              placeholder={
+                mentionedDocs.length === 0
+                  ? "Ask the editor... (@ to reference a doc)"
+                  : ""
+              }
+              value={input}
+              onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
+              disabled={isLoading}
+              className="flex-1 min-w-0 bg-transparent outline-none text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Chat input"
+            />
+          </div>
+        </div>
+        <Button onClick={handleSend} disabled={!canSend} className="min-h-11">
           Send
         </Button>
       </div>

--- a/src/lib/mentionUtils.test.ts
+++ b/src/lib/mentionUtils.test.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import {
+  buildPromptWithMentions,
+  extractMentionQuery,
+  removeMentionTrigger,
+} from "./mentionUtils";
+
+describe("buildPromptWithMentions", () => {
+  it("returns the input unchanged when no docs are mentioned", () => {
+    expect(buildPromptWithMentions("Hello", [])).toBe("Hello");
+  });
+
+  it("prepends document context when one doc is mentioned", () => {
+    const result = buildPromptWithMentions("Compare these", [
+      { id: "abc-123", title: "My Notes" },
+    ]);
+    expect(result).toContain('"My Notes"');
+    expect(result).toContain("abc-123");
+    expect(result).toContain("Compare these");
+  });
+
+  it("includes all mentioned documents in the preamble", () => {
+    const result = buildPromptWithMentions("text", [
+      { id: "1", title: "Doc A" },
+      { id: "2", title: "Doc B" },
+    ]);
+    expect(result).toContain('"Doc A"');
+    expect(result).toContain('"Doc B"');
+    expect(result).toContain("id: 1");
+    expect(result).toContain("id: 2");
+  });
+
+  it("places user text after the preamble", () => {
+    const result = buildPromptWithMentions("do the thing", [
+      { id: "x", title: "Notes" },
+    ]);
+    const preambleEnd = result.indexOf("\n\n");
+    expect(preambleEnd).toBeGreaterThan(0);
+    expect(result.slice(preambleEnd + 2)).toBe("do the thing");
+  });
+});
+
+describe("extractMentionQuery", () => {
+  it("returns null when no @ is present", () => {
+    expect(extractMentionQuery("hello world")).toBeNull();
+  });
+
+  it("returns empty string immediately after @", () => {
+    expect(extractMentionQuery("hello @")).toBe("");
+  });
+
+  it("returns the partial query after @", () => {
+    expect(extractMentionQuery("hello @notes")).toBe("notes");
+  });
+
+  it("returns null when @ is followed by a space (mention not active)", () => {
+    expect(extractMentionQuery("hello @ world")).toBeNull();
+  });
+
+  it("matches the last @ when multiple exist", () => {
+    expect(extractMentionQuery("email user@example.com and @doc")).toBe("doc");
+  });
+});
+
+describe("removeMentionTrigger", () => {
+  it("removes trailing @query from input", () => {
+    expect(removeMentionTrigger("hello @no")).toBe("hello");
+  });
+
+  it("removes bare @ at end of input", () => {
+    expect(removeMentionTrigger("hello @")).toBe("hello");
+  });
+
+  it("leaves input unchanged when no trailing mention", () => {
+    expect(removeMentionTrigger("hello world")).toBe("hello world");
+  });
+
+  it("trims trailing whitespace after removal", () => {
+    expect(removeMentionTrigger("hello  @query")).toBe("hello");
+  });
+});

--- a/src/lib/mentionUtils.ts
+++ b/src/lib/mentionUtils.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export interface DocRef {
+  id: string;
+  title: string;
+}
+
+/**
+ * Builds the final prompt string by prepending referenced document context
+ * so the agent can use document IDs directly without calling list_workspace_docs.
+ */
+export function buildPromptWithMentions(
+  userText: string,
+  mentionedDocs: DocRef[],
+): string {
+  if (mentionedDocs.length === 0) return userText;
+  const docList = mentionedDocs
+    .map((d) => `"${d.title}" (id: ${d.id})`)
+    .join(", ");
+  return `The user has referenced the following documents: ${docList}.\n\n${userText}`;
+}
+
+/**
+ * Returns the query string after the last '@' if the input ends with an
+ * in-progress mention (no space after @). Returns null if no active mention.
+ */
+export function extractMentionQuery(input: string): string | null {
+  const match = input.match(/@([^\s]*)$/);
+  if (!match) return null;
+  return match[1];
+}
+
+/**
+ * Removes the trailing '@query' trigger from the input string after a
+ * document is selected from the picker.
+ */
+export function removeMentionTrigger(input: string): string {
+  return input.replace(/@[^\s]*$/, "").trimEnd();
+}


### PR DESCRIPTION
## Summary

- Typing `@` in the chat input opens an autocomplete dropdown listing workspace documents, filtered by what the user types after `@`
- Selected documents appear as styled chip tokens (`@Title ×`) inside the input area; clicking `×` removes them
- On send, referenced `{id, title}` pairs are injected as a preamble into the prompt so the agent can call `read_workspace_doc` directly without a prior `list_workspace_docs` call
- Arrow keys navigate the picker; Enter selects; Escape closes it
- New `src/lib/mentionUtils.ts` module encapsulates the prompt-building and mention-extraction logic with full Vitest test coverage

Closes #36

## Test plan

- [x] Type `@` in the chat input and verify the document picker appears
- [x] Type letters after `@` and verify the list filters by title
- [x] Select a document with mouse click and verify it appears as a chip
- [x] Select a document with keyboard (arrow + Enter) and verify chip appears
- [x] Remove a chip with the `×` button and verify it disappears
- [x] Send a message with referenced docs and verify the agent can use the doc ID directly
- [x] Verify all 233 tests pass (`npm run test`)