### PR TITLE
feat: add built-in Create Skill skill

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -414,7 +414,12 @@ function App() {
           required: ["skillName", "task"],
         },
       }),
-      call: createDelegateToSkillHandler(apiKey!, adapter, editorTools),
+      call: createDelegateToSkillHandler(
+        apiKey!,
+        adapter,
+        editorTools,
+        workspaceTools,
+      ),
     });
 
     return new AgentRunner(adapter, registry);

--- a/src/lib/EditorTools.test.ts
+++ b/src/lib/EditorTools.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EditorTools, createDelegateToSkillHandler } from "./EditorTools";
+import { WorkspaceTools } from "./WorkspaceTools";
 import { saveSkills } from "./skills";
 import type { LlmAdapter } from "@mast-ai/core";
 
@@ -372,6 +373,7 @@ describe("EditorTools", () => {
         "test-api-key",
         parentAdapter,
         editorToolsInstance,
+        null,
         adapterFactory,
         () => ({
           run: mockRun as unknown as (
@@ -438,6 +440,35 @@ describe("EditorTools", () => {
         task: "t",
       });
       expect(adapterFactory).not.toHaveBeenCalled();
+    });
+
+    it("includes workspace tools in child agent when workspaceTools is provided", async () => {
+      saveSkills([
+        { id: "1", name: "Create Skill", description: "d", instructions: "i" },
+      ]);
+      const mockWorkspaceTools = new WorkspaceTools(
+        { current: [] },
+        { current: null },
+        vi.fn(),
+      );
+      const handler = createDelegateToSkillHandler(
+        "test-api-key",
+        parentAdapter,
+        editorToolsInstance,
+        mockWorkspaceTools,
+        vi.fn(),
+        () => ({
+          run: mockRun as unknown as (
+            agent: import("@mast-ai/core").AgentConfig,
+            input: string,
+          ) => Promise<{ output: string }>,
+        }),
+      );
+      await handler({ skillName: "Create Skill", task: "create a skill" });
+      const [agentConfig] = mockRun.mock.calls[0];
+      expect(agentConfig.tools).toContain("create_document");
+      expect(agentConfig.tools).toContain("list_workspace_docs");
+      expect(agentConfig.tools).toContain("switch_active_document");
     });
 
     it("calls adapterFactory when skill specifies a model", async () => {

--- a/src/lib/EditorTools.ts
+++ b/src/lib/EditorTools.ts
@@ -5,6 +5,7 @@ import * as monaco from "monaco-editor";
 import { AgentRunner, LlmAdapter, ToolRegistry } from "@mast-ai/core";
 import { Suggestion } from "./store";
 import { loadSkills } from "./skills";
+import { WorkspaceTools, registerWorkspaceTools } from "./WorkspaceTools";
 import { v4 as uuidv4 } from "uuid";
 
 export class EditorTools {
@@ -310,6 +311,7 @@ export function createDelegateToSkillHandler(
   apiKey: string,
   parentAdapter: LlmAdapter,
   editorTools: EditorTools,
+  workspaceTools: WorkspaceTools | null = null,
   adapterFactory: (key: string, model: string) => LlmAdapter = (key, model) => {
     // Lazily imported to avoid a hard dep on the concrete adapter in this module.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -335,6 +337,9 @@ export function createDelegateToSkillHandler(
 
     const childRegistry = new ToolRegistry();
     registerEditorTools(childRegistry, editorTools);
+    if (workspaceTools) {
+      registerWorkspaceTools(childRegistry, workspaceTools);
+    }
 
     const childRunner = runnerFactory(childAdapter, childRegistry);
     const result = await childRunner.run(
@@ -348,6 +353,13 @@ export function createDelegateToSkillHandler(
           "get_metadata",
           "edit",
           "write",
+          ...(workspaceTools
+            ? [
+                "create_document",
+                "list_workspace_docs",
+                "switch_active_document",
+              ]
+            : []),
         ],
       },
       task,

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -8,6 +8,7 @@ import {
   initializeSkills,
   DEFAULT_SKILLS,
   Skill,
+  CREATE_SKILL_ID,
 } from "./skills";
 
 describe("skills storage", () => {
@@ -49,6 +50,14 @@ describe("skills storage", () => {
     saveSkills(custom);
     const result = initializeSkills();
     expect(result).toEqual(custom);
+  });
+
+  it("Create Skill is included in DEFAULT_SKILLS and uses only standard editor tools", () => {
+    const createSkill = DEFAULT_SKILLS.find((s) => s.id === CREATE_SKILL_ID);
+    expect(createSkill).toBeDefined();
+    expect(createSkill!.name).toBe("Create Skill");
+    expect(createSkill!.instructions).toContain("write");
+    expect(createSkill!.instructions).not.toContain("create_skill");
   });
 
   it("model field is optional and preserved when set", () => {

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -9,7 +9,30 @@ export interface Skill {
   model?: string;
 }
 
+export const CREATE_SKILL_ID = "default-create-skill";
+
 export const DEFAULT_SKILLS: Skill[] = [
+  {
+    id: CREATE_SKILL_ID,
+    name: "Create Skill",
+    description:
+      "Drafts a new skill definition and writes it to the current document.",
+    instructions:
+      "You are a skill author. Given a description of what a new skill should do, draft a complete skill definition and save it as a new workspace document.\n\n" +
+      "A skill definition uses this format:\n\n" +
+      "---\n" +
+      "name: <skill name>\n" +
+      "description: <one-line description>\n" +
+      "---\n\n" +
+      "<step-by-step instructions for the skill's sub-agent>\n\n" +
+      "Steps:\n" +
+      "1. From the task, decide on a short name, a one-line description, and detailed step-by-step instructions the sub-agent should follow.\n" +
+      "2. Call `create_document` with the skill name as the title.\n" +
+      "3. Call `list_workspace_docs` to find the new document's ID by matching the title.\n" +
+      "4. Call `switch_active_document` with that ID to open it.\n" +
+      "5. Call `write` to fill the document with the complete skill definition.\n" +
+      "6. Report the skill name and a brief summary of what it does.",
+  },
   {
     id: "default-proofreader",
     name: "Proofreader",


### PR DESCRIPTION
## Summary

- Adds a default **Create Skill** skill to `DEFAULT_SKILLS` that drafts a new skill definition and saves it as a new workspace document
- The skill instructs the sub-agent to call `create_document`, then `list_workspace_docs` (to retrieve the new doc's ID), `switch_active_document`, and finally `write` to populate the document with the skill definition in a frontmatter format
- `createDelegateToSkillHandler` now accepts an optional `workspaceTools` parameter; when provided, workspace tools are registered in the child registry and `create_document`, `list_workspace_docs`, `switch_active_document` are added to the child agent's allowed tool list
- `App.tsx` passes `workspaceTools` to the delegate handler so all skill sub-agents can use them

Closes #39

## Test plan

- [ ] Ask the assistant to "use the Create Skill skill to create a skill that summarises in bullet points" — confirm it creates a new workspace document containing a valid skill definition
- [ ] Verify the new document title matches the skill name and content includes frontmatter + instructions
- [ ] `npm run test` passes (242 tests)
- [ ] `npm run lint` passes (no new errors)