### PR TITLE
feat: integrate built-in AI summarize tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@google/genai": "^1.50.1",
+        "@mast-ai/built-in-ai": "file:../mast-ai/packages/built-in-ai",
         "@mast-ai/core": "file:../mast-ai/packages/core",
         "@mast-ai/google-genai": "file:../mast-ai/packages/google-genai",
         "@monaco-editor/react": "^4.7.0",
@@ -59,6 +60,19 @@
       "optionalDependencies": {
         "@rollup/rollup-win32-arm64-msvc": "^4.60.2",
         "@rollup/rollup-win32-x64-msvc": "^4.60.2"
+      }
+    },
+    "../mast-ai/packages/built-in-ai": {
+      "name": "@mast-ai/built-in-ai",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mast-ai/core": "*"
+      },
+      "devDependencies": {
+        "tsup": "^8.0.0",
+        "typescript": "~6.0.2",
+        "vitest": "^4.1.4"
       }
     },
     "../mast-ai/packages/core": {
@@ -186,6 +200,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -506,6 +521,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -554,33 +570,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -878,6 +870,10 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mast-ai/built-in-ai": {
+      "resolved": "../mast-ai/packages/built-in-ai",
+      "link": true
     },
     "node_modules/@mast-ai/core": {
       "resolved": "../mast-ai/packages/core",
@@ -2089,8 +2085,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2193,6 +2188,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2203,6 +2199,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2218,8 +2215,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2279,6 +2275,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -2628,6 +2625,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2677,7 +2675,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2688,7 +2685,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2924,6 +2920,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3306,15 +3303,13 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -3393,6 +3388,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4314,6 +4310,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4815,7 +4812,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4845,7 +4841,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -6091,6 +6086,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6266,7 +6262,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6346,6 +6341,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6355,6 +6351,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6367,8 +6364,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7051,6 +7047,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7192,6 +7189,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7479,6 +7477,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7841,6 +7840,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
+    "@mast-ai/built-in-ai": "file:../mast-ai/packages/built-in-ai",
     "@mast-ai/core": "file:../mast-ai/packages/core",
     "@mast-ai/google-genai": "file:../mast-ai/packages/google-genai",
     "@monaco-editor/react": "^4.7.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/lib/EditorTools";
 import { WorkspaceTools, registerWorkspaceTools } from "@/lib/WorkspaceTools";
 import { registerWebMCPTools } from "@/lib/WebMCPTools";
+import { addAllBuiltInAITools } from "@mast-ai/built-in-ai";
 
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(
@@ -260,24 +261,11 @@ function MobileLayout({ conversation }: LayoutProps) {
 
 const BASE_INSTRUCTIONS =
   "You are a helpful senior editorial assistant. Help the user refine their text. " +
-  "You MUST use the provided tools to interact with the editor. " +
-  "Always use `read()` or `read_selection()` before suggesting changes. " +
-  "Use `search()` to locate specific text before editing it. " +
-  "Use `get_metadata()` to answer questions about document length or word count without reading the full content. " +
-  "CRITICAL: Prefer small, surgical edits using `edit()`. Do not rewrite the entire document unless explicitly asked to. " +
-  "When using `edit()`, the `originalText` should be as short as possible (just the sentence or words changing), not the whole file. " +
-  "When you call `edit()` or `write()`, the execution will PAUSE until the user manually Accepts or Rejects the change. " +
-  "You will then receive the user's decision (and feedback if any) as the tool result. " +
-  "Use `get_current_mode()` to check whether the UI is in 'editor' or 'preview' mode before making edits. " +
-  "If in 'preview' mode and you need to edit, call `request_switch_to_editor()` first — this prompts the user to switch tabs. " +
-  "The workspace may contain multiple documents. Use `get_active_doc_info()` to get the id and title of the currently open document. " +
-  "Use `list_workspace_docs()` to discover all documents. " +
-  "Use `read_workspace_doc(id)` to read another document in full, or `query_workspace_doc(id, query)` for a targeted question. " +
-  "Use `query_workspace(query)` to synthesize an answer that draws from all workspace documents. " +
-  "Use `create_document(title)` to create a new blank document — pauses for user authorization. " +
-  "Use `rename_document(id, title)` to rename a document — pauses for user authorization. " +
-  "Use `delete_document(id)` to delete a document — pauses for user authorization. " +
-  "Use `switch_active_document(id)` to switch to a different document — saves current content first, no authorization needed.";
+  "Always read the document or selection before suggesting changes. " +
+  "Prefer small, surgical edits — do not rewrite the entire document unless explicitly asked. " +
+  "When editing, keep the original text span as short as possible (just the words changing). " +
+  "When an edit or write is submitted, execution pauses until the user accepts or rejects it; " +
+  "you will receive their decision (and any feedback) as the tool result.";
 
 function App() {
   const {
@@ -392,6 +380,7 @@ function App() {
 
     registerEditorTools(registry, editorTools);
     registerWorkspaceTools(registry, workspaceTools);
+    addAllBuiltInAITools(registry).catch(() => {});
 
     registry.register({
       definition: () => ({
@@ -435,26 +424,6 @@ function App() {
     const agent: AgentConfig = {
       name: "EditorAssistant",
       instructions: BASE_INSTRUCTIONS + skillsSection,
-      tools: [
-        "read",
-        "read_selection",
-        "search",
-        "get_metadata",
-        "edit",
-        "write",
-        "get_current_mode",
-        "request_switch_to_editor",
-        "delegate_to_skill",
-        "get_active_doc_info",
-        "list_workspace_docs",
-        "read_workspace_doc",
-        "query_workspace_doc",
-        "query_workspace",
-        "create_document",
-        "rename_document",
-        "delete_document",
-        "switch_active_document",
-      ],
     };
     return runner.conversation(agent);
   }, [runner, skills]);

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -52,7 +52,9 @@ export const DEFAULT_SKILLS: Skill[] = [
     instructions:
       "You are a summarizer. Produce a concise, accurate summary of the document.\n\n" +
       "1. Use the `read` tool to read the full document.\n" +
-      "2. Return a concise summary in plain prose. Do NOT edit the document.",
+      "2. If the `summarize` tool is available, pass the text to it and return its output. " +
+      "Otherwise, write a concise summary in plain prose yourself.\n" +
+      "Do NOT edit the document.",
   },
   {
     id: "default-markdown-formatter",


### PR DESCRIPTION
## Summary

- Add `@mast-ai/built-in-ai` dependency and register all built-in AI tools on the runner registry; the browser Summarizer API becomes available as a `summarize` tool once its session initialises
- Remove the explicit `tools` list from `AgentConfig` — relies on the updated `@mast-ai/core` runner which now exposes all registered tools automatically when no list is given (see andreban/mast-ai#14)
- Trim `BASE_INSTRUCTIONS` to behavioural guidance only; per-tool documentation belongs in each tool's description
- Update the Summarizer skill to delegate to the `summarize` tool when available, falling back to LLM-generated prose otherwise

## Test plan

- [x] Ask the agent to edit text — confirm it calls `read` then `edit` without the tool list in the prompt
- [x] Ask the Summarizer skill to summarise a document in a browser that supports the Summarizer API — confirm it uses the `summarize` tool
- [x] Confirm the app loads without errors in a browser that does not support the Summarizer API