### PR TITLE
feat: show collapsible params and result in tool call bubbles

### DIFF
--- a/src/components/ChatItem.tsx
+++ b/src/components/ChatItem.tsx
@@ -1,5 +1,6 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
 import { Brain, Check, ChevronDown, ChevronUp, Wrench } from "lucide-react";
 import { MarkdownContent } from "./MarkdownContent";
 
@@ -12,7 +13,76 @@ export type StreamItem =
       thought: string;
       isStreaming: boolean;
     }
-  | { kind: "tool"; id: string; name: string; pending: boolean };
+  | {
+      kind: "tool";
+      id: string;
+      name: string;
+      pending: boolean;
+      params?: unknown;
+      result?: unknown;
+    };
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value, null, 2);
+}
+
+type ToolItem = Extract<StreamItem, { kind: "tool" }>;
+
+function ToolItem({ item }: { item: ToolItem }) {
+  const [open, setOpen] = useState(false);
+  const hasDetails = item.params !== undefined || item.result !== undefined;
+
+  return (
+    <div className="self-start border border-border rounded-lg bg-muted/40 overflow-hidden text-xs text-muted-foreground">
+      <button
+        className="flex items-center gap-2 px-2 py-1 w-full hover:bg-accent disabled:cursor-default"
+        onClick={() => hasDetails && setOpen((v) => !v)}
+        disabled={!hasDetails}
+      >
+        {item.pending ? (
+          <Wrench className="w-3 h-3 animate-pulse text-primary shrink-0" />
+        ) : (
+          <Check className="w-3 h-3 text-green-500 shrink-0" />
+        )}
+        <code className="font-mono">{item.name}</code>
+        {hasDetails && (
+          <span className="ml-auto">
+            {open ? (
+              <ChevronUp className="w-3 h-3" />
+            ) : (
+              <ChevronDown className="w-3 h-3" />
+            )}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="border-t border-border divide-y divide-border">
+          {item.params !== undefined && (
+            <div className="p-2">
+              <div className="text-[10px] uppercase tracking-wider font-bold mb-1">
+                Parameters
+              </div>
+              <pre className="whitespace-pre-wrap break-all leading-relaxed">
+                {formatValue(item.params)}
+              </pre>
+            </div>
+          )}
+          {item.result !== undefined && (
+            <div className="p-2">
+              <div className="text-[10px] uppercase tracking-wider font-bold mb-1">
+                Result
+              </div>
+              <pre className="whitespace-pre-wrap break-all leading-relaxed">
+                {formatValue(item.result)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 interface ChatItemProps {
   item: StreamItem;
@@ -32,18 +102,7 @@ export function ChatItem({ item, isExpanded, onToggle }: ChatItemProps) {
   }
 
   if (item.kind === "tool") {
-    return (
-      <div className="flex items-center gap-2 text-xs text-muted-foreground self-start px-2 py-1 rounded-full border border-border bg-muted/40">
-        {item.pending ? (
-          <Wrench className="w-3 h-3 animate-pulse text-primary" />
-        ) : (
-          <Check className="w-3 h-3 text-green-500" />
-        )}
-        <span>
-          <code className="font-mono">{item.name}</code>
-        </span>
-      </div>
-    );
+    return <ToolItem item={item} />;
   }
 
   // assistant

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -245,18 +245,20 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
           const tid = `tool-${crypto.randomUUID()}`;
           toolId = tid;
           const name = event.name;
+          const params = event.args;
           setItems((prev) => [
             ...prev,
-            { kind: "tool", id: tid, name, pending: true },
+            { kind: "tool", id: tid, name, pending: true, params },
           ]);
         } else if (event.type === "tool_call_completed") {
           // Mark the tool as done. Next content will lazily open a new assistant bubble.
           if (toolId) {
             const closeToolId = toolId;
+            const toolResult = event.result;
             setItems((prev) =>
               prev.map((it) =>
                 it.kind === "tool" && it.id === closeToolId
-                  ? { ...it, pending: false }
+                  ? { ...it, pending: false, result: toolResult }
                   : it,
               ),
             );


### PR DESCRIPTION
## Summary

- Tool call bubbles now display a chevron toggle when params or result data is available
- Clicking the header expands a panel showing parameters (captured at `tool_call_started`) and result (captured at `tool_call_completed`)
- Details are collapsed by default; string values render as-is, objects are pretty-printed as JSON

## Test plan

- [x] Trigger a tool call (e.g. ask the assistant to read or edit a file)
- [x] Verify the tool bubble shows a chevron and is collapsed by default
- [x] Click to expand and verify params are shown
- [x] After the tool completes, verify the result section appears
- [x] Confirm string results (file content) render without extra quotes