### PR TITLE
fix: inline @mention positioning and auto-grow chat input

### DIFF
--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -1,6 +1,6 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, Fragment } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Button } from "./ui/button";
 import { Switch } from "./ui/switch";
@@ -15,9 +15,9 @@ import { SkillsDialog } from "./SkillsDialog";
 import { ChatItem, StreamItem } from "./ChatItem";
 import {
   DocRef,
+  Segment,
   buildPromptWithMentions,
   extractMentionQuery,
-  removeMentionTrigger,
 } from "@/lib/mentionUtils";
 
 interface ChatSidebarProps {
@@ -25,7 +25,8 @@ interface ChatSidebarProps {
 }
 
 export function ChatSidebar({ conversation }: ChatSidebarProps) {
-  const [input, setInput] = useState("");
+  const [trailingInput, setTrailingInput] = useState("");
+  const [segments, setSegments] = useState<Segment[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [items, setItems] = useState<StreamItem[]>([]);
   const [expandedThoughts, setExpandedThoughts] = useState<Set<string>>(
@@ -34,11 +35,10 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
   const [prevConversation, setPrevConversation] = useState<Conversation | null>(
     null,
   );
-  const [mentionedDocs, setMentionedDocs] = useState<DocRef[]>([]);
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [pickerIndex, setPickerIndex] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [skillsOpen, setSkillsOpen] = useState(false);
   const { approveAll, setApproveAll } = useApp();
@@ -51,7 +51,7 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
     mentionQuery !== null
       ? workspaceDocs.filter(
           (d) =>
-            !mentionedDocs.some((m) => m.id === d.id) &&
+            !segments.some((s) => s.doc.id === d.id) &&
             d.title.toLowerCase().includes(mentionQuery.toLowerCase()),
         )
       : [];
@@ -116,28 +116,47 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
   };
 
   const selectDoc = (doc: DocRef) => {
-    setMentionedDocs((prev) =>
-      prev.some((d) => d.id === doc.id) ? prev : [...prev, doc],
-    );
-    setInput((prev) => removeMentionTrigger(prev));
+    if (segments.some((s) => s.doc.id === doc.id)) return;
+    const atIdx = trailingInput.lastIndexOf("@");
+    const textBefore = atIdx >= 0 ? trailingInput.slice(0, atIdx) : trailingInput;
+    setSegments((prev) => [...prev, { text: textBefore, doc }]);
+    setTrailingInput("");
     setMentionQuery(null);
     setPickerIndex(0);
     inputRef.current?.focus();
   };
 
   const removeChip = (id: string) => {
-    setMentionedDocs((prev) => prev.filter((d) => d.id !== id));
+    const idx = segments.findIndex((s) => s.doc.id === id);
+    if (idx === -1) return;
+    const removedText = segments[idx].text;
+    const without = [...segments.slice(0, idx), ...segments.slice(idx + 1)];
+    if (idx < without.length) {
+      without[idx] = { ...without[idx], text: removedText + without[idx].text };
+      setSegments(without);
+    } else {
+      setSegments(without);
+      setTrailingInput((t) => removedText + t);
+    }
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const resizeTextarea = useCallback(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = "";
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
-    setInput(value);
+    setTrailingInput(value);
     const query = extractMentionQuery(value);
     setMentionQuery(query);
     setPickerIndex(0);
+    resizeTextarea();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (mentionQuery !== null && filteredDocs.length > 0) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -160,33 +179,31 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
         return;
       }
     }
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
       handleSend();
     }
   };
 
   const handleSend = async () => {
-    const trimmed = input.trim();
-    if ((!trimmed && mentionedDocs.length === 0) || !conversation || isLoading)
-      return;
+    const displayText =
+      segments.map((s) => `${s.text}@${s.doc.title}`).join("") + trailingInput;
+    if (!displayText.trim() || !conversation || isLoading) return;
 
-    const userText = trimmed || "(no message)";
-    const prompt = buildPromptWithMentions(userText, mentionedDocs);
+    const prompt = buildPromptWithMentions(segments, trailingInput);
 
-    setInput("");
-    setMentionedDocs([]);
+    setTrailingInput("");
+    setSegments([]);
     setMentionQuery(null);
     setIsLoading(true);
+    if (inputRef.current) inputRef.current.style.height = "";
 
     setItems((prev) => [
       ...prev,
       {
         kind: "user",
         id: `user-${crypto.randomUUID()}`,
-        text:
-          mentionedDocs.length > 0
-            ? `[Referenced: ${mentionedDocs.map((d) => d.title).join(", ")}] ${userText}`
-            : userText,
+        text: displayText.trim(),
       },
     ]);
 
@@ -298,7 +315,7 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
   };
 
   const canSend =
-    (input.trim().length > 0 || mentionedDocs.length > 0) && !isLoading;
+    (trailingInput.trim().length > 0 || segments.length > 0) && !isLoading;
 
   return (
     <div className="flex flex-col h-full bg-muted/20 border-l">
@@ -391,7 +408,7 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
         )}
       </div>
 
-      <div className="p-4 border-t bg-background/50 backdrop-blur-sm flex gap-2">
+      <div className="p-4 border-t bg-background/50 backdrop-blur-sm flex items-end gap-2">
         <div className="relative flex-1">
           {/* Document picker dropdown */}
           {mentionQuery !== null && filteredDocs.length > 0 && (
@@ -421,36 +438,39 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
             </div>
           )}
 
-          {/* Compound input: chips + text field */}
-          <div className="flex flex-wrap items-center gap-1 border rounded-md bg-background px-3 py-2 min-h-11 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-0">
-            {mentionedDocs.map((doc) => (
-              <span
-                key={doc.id}
-                className="inline-flex items-center gap-1 bg-primary/10 text-primary text-xs font-medium rounded px-2 py-0.5"
-              >
-                @{doc.title}
-                <button
-                  type="button"
-                  aria-label={`Remove reference to ${doc.title}`}
-                  onClick={() => removeChip(doc.id)}
-                  className="hover:text-destructive"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </span>
+          {/* Compound input: inline segment chips + trailing text field */}
+          <div className="flex flex-wrap items-start gap-1 border rounded-md bg-background px-3 py-2 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-0">
+            {segments.map((seg) => (
+              <Fragment key={seg.doc.id}>
+                {seg.text && (
+                  <span className="text-sm">{seg.text}</span>
+                )}
+                <span className="inline-flex items-center gap-1 bg-primary/10 text-primary text-xs font-medium rounded px-2 py-0.5">
+                  @{seg.doc.title}
+                  <button
+                    type="button"
+                    aria-label={`Remove reference to ${seg.doc.title}`}
+                    onClick={() => removeChip(seg.doc.id)}
+                    className="hover:text-destructive"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              </Fragment>
             ))}
-            <input
+            <textarea
               ref={inputRef}
+              rows={4}
               placeholder={
-                mentionedDocs.length === 0
+                segments.length === 0
                   ? "Ask the editor... (@ to reference a doc)"
                   : ""
               }
-              value={input}
+              value={trailingInput}
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
               disabled={isLoading}
-              className="flex-1 min-w-0 bg-transparent outline-none text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex-1 min-w-0 bg-transparent outline-none text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 resize-none overflow-hidden"
               aria-label="Chat input"
             />
           </div>

--- a/src/lib/mentionUtils.test.ts
+++ b/src/lib/mentionUtils.test.ts
@@ -9,37 +9,51 @@ import {
 } from "./mentionUtils";
 
 describe("buildPromptWithMentions", () => {
-  it("returns the input unchanged when no docs are mentioned", () => {
-    expect(buildPromptWithMentions("Hello", [])).toBe("Hello");
+  it("returns trailing text unchanged when no segments", () => {
+    expect(buildPromptWithMentions([], "Hello")).toBe("Hello");
   });
 
   it("prepends document context when one doc is mentioned", () => {
-    const result = buildPromptWithMentions("Compare these", [
-      { id: "abc-123", title: "My Notes" },
-    ]);
+    const result = buildPromptWithMentions(
+      [{ text: "", doc: { id: "abc-123", title: "My Notes" } }],
+      " Compare these",
+    );
     expect(result).toContain('"My Notes"');
     expect(result).toContain("abc-123");
     expect(result).toContain("Compare these");
   });
 
   it("includes all mentioned documents in the preamble", () => {
-    const result = buildPromptWithMentions("text", [
-      { id: "1", title: "Doc A" },
-      { id: "2", title: "Doc B" },
-    ]);
+    const result = buildPromptWithMentions(
+      [
+        { text: "", doc: { id: "1", title: "Doc A" } },
+        { text: " and ", doc: { id: "2", title: "Doc B" } },
+      ],
+      " text",
+    );
     expect(result).toContain('"Doc A"');
     expect(result).toContain('"Doc B"');
     expect(result).toContain("id: 1");
     expect(result).toContain("id: 2");
   });
 
-  it("places user text after the preamble", () => {
-    const result = buildPromptWithMentions("do the thing", [
-      { id: "x", title: "Notes" },
-    ]);
+  it("places inline user text (with @mentions) after the preamble", () => {
+    const result = buildPromptWithMentions(
+      [{ text: "do the thing ", doc: { id: "x", title: "Notes" } }],
+      "",
+    );
     const preambleEnd = result.indexOf("\n\n");
     expect(preambleEnd).toBeGreaterThan(0);
-    expect(result.slice(preambleEnd + 2)).toBe("do the thing");
+    expect(result.slice(preambleEnd + 2)).toBe("do the thing @Notes");
+  });
+
+  it("preserves inline position of mentions relative to surrounding text", () => {
+    const result = buildPromptWithMentions(
+      [{ text: "before ", doc: { id: "1", title: "Doc" } }],
+      " after",
+    );
+    const preambleEnd = result.indexOf("\n\n");
+    expect(result.slice(preambleEnd + 2)).toBe("before @Doc after");
   });
 });
 

--- a/src/lib/mentionUtils.ts
+++ b/src/lib/mentionUtils.ts
@@ -6,19 +6,27 @@ export interface DocRef {
   title: string;
 }
 
+export interface Segment {
+  text: string;
+  doc: DocRef;
+}
+
 /**
  * Builds the final prompt string by prepending referenced document context
  * so the agent can use document IDs directly without calling list_workspace_docs.
+ * The inline user text preserves @mentions at their original positions.
  */
 export function buildPromptWithMentions(
-  userText: string,
-  mentionedDocs: DocRef[],
+  segments: Segment[],
+  trailingText: string,
 ): string {
-  if (mentionedDocs.length === 0) return userText;
-  const docList = mentionedDocs
-    .map((d) => `"${d.title}" (id: ${d.id})`)
+  const inlineText =
+    segments.map((s) => `${s.text}@${s.doc.title}`).join("") + trailingText;
+  if (segments.length === 0) return inlineText;
+  const docList = segments
+    .map((s) => `"${s.doc.title}" (id: ${s.doc.id})`)
     .join(", ");
-  return `The user has referenced the following documents: ${docList}.\n\n${userText}`;
+  return `The user has referenced the following documents: ${docList}.\n\n${inlineText}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Refactors the chat input from a flat `input + mentionedDocs[]` model to a `segments[] + trailingInput` model so `@doc` references render at the position they were typed rather than jumping to the start of the text
- Adds a `Segment` type to `mentionUtils` and updates `buildPromptWithMentions` to accept segments, preserving inline `@mentions` in both the prompt sent to the LLM and the chat history display
- Replaces the single-line `<input>` with a `<textarea>` that defaults to 4 rows and auto-grows when content exceeds that height; Shift+Enter inserts a newline, Enter sends

## Test plan

- [ ] Type text, add an `@` mention mid-sentence — chip should appear inline at the typed position, not at the start
- [ ] Add multiple `@` mentions — each chip appears after its preceding text
- [ ] Remove a chip with ✕ — its preceding text is restored to the input
- [ ] Input defaults to 4 rows; typing beyond 4 rows causes it to grow
- [ ] Shift+Enter inserts a newline; Enter sends the message
- [ ] Sending resets the textarea back to 4 rows
- [ ] All 232 existing tests pass (`npm run test`)