### PR TITLE
feat: show skill subagent execution in chat with live event streaming

### DIFF
--- a/docs/MAST_AI_CORE_TOOL_EVENT_STREAMING.md
+++ b/docs/MAST_AI_CORE_TOOL_EVENT_STREAMING.md
@@ -1,0 +1,174 @@
+# mast-ai/core: Tool Event Streaming
+
+## Context
+
+The agent-text-editor project has a `delegate_to_skill` tool that spins up a child `AgentRunner` to execute a named skill (e.g. Proofreader, Summarizer). The child runner produces its own `AgentEvent` stream — thinking chunks, tool calls, text deltas — but those events are currently invisible to the caller because `Tool.call` returns a plain `Promise<TResult>` with no channel to surface them.
+
+The goal is to let tools that internally run sub-agents forward child events back to the parent runner's stream, so the UI can show what the skill is doing in real time.
+
+## Current relevant code
+
+### `src/tool.ts`
+
+```typescript
+export interface ToolContext {
+  signal?: AbortSignal;
+}
+
+export interface Tool<TArgs = unknown, TResult = unknown> {
+  definition(): ToolDefinition;
+  call(args: TArgs, context: ToolContext): Promise<TResult>;
+}
+```
+
+### `src/runner.ts` — tool execution block (inside `executeStream`)
+
+```typescript
+if (toolCalls.length > 0) {
+  for (const call of toolCalls) {
+    yield { type: 'tool_call_started', name: call.name, args: call.args };
+  }
+
+  const toolResults = await Promise.all(
+    toolCalls.map(async (call) => {
+      const tool = this.registry.get(call.name);
+      if (!tool) {
+        return { call, result: `Error: Tool '${call.name}' not found.` };
+      }
+      try {
+        const result = await tool.call(call.args, { signal });
+        return { call, result };
+      } catch (err: any) {
+        return { call, result: `Error executing tool: ${err.message}` };
+      }
+    })
+  );
+
+  for (const { call, result } of toolResults) {
+    yield { type: 'tool_call_completed', name: call.name, result };
+    // ... history update
+  }
+}
+```
+
+### `src/runner.ts` — `RunBuilder` class
+
+```typescript
+export class RunBuilder {
+  runStream(input: string): AsyncIterable<AgentEvent> { ... }
+  async run(input: string): Promise<AgentResult> { ... }
+  async runTyped<T>(input: string): Promise<T> { ... }
+}
+```
+
+## Problem
+
+`Tool.call` is a `Promise`-returning method. The parent `executeStream` generator uses `Promise.all` to run multiple tool calls in parallel (Gemini can return several tool calls in one response turn). Because you cannot `yield` from inside a `Promise.all` callback in an async generator, there is no way for a tool to push events into the parent stream mid-execution.
+
+## Rejected approaches
+
+**Changing `Tool.call` to return `AsyncIterable`** — this would force every tool (including simple ones like `read` and `write`) to adopt a streaming interface they don't need, and parallel execution of multiple AsyncIterable streams requires a non-trivial fan-in merge. Not worth it for the common case.
+
+**Switching `Promise.all` to sequential execution** — would break parallel tool execution, which is valid and used by Gemini.
+
+## Proposed solution: `onToolEvent` callback on `RunBuilder`
+
+Add an `onToolEvent` callback to `RunBuilder`. The runner calls it for every event a tool emits via `ToolContext.onEvent`. This keeps the tool interface unchanged for simple tools, preserves parallel execution, and gives consumers a real-time event feed without touching `AgentRunner` itself.
+
+### 1. `src/tool.ts` — add `onEvent` to `ToolContext`
+
+```typescript
+import type { AgentEvent } from './types';
+
+export interface ToolContext {
+  signal?: AbortSignal;
+  /**
+   * Called by tools that internally run sub-agents to surface child events
+   * to the parent runner's stream. Simple tools can ignore this entirely.
+   */
+  onEvent?: (event: AgentEvent) => void;
+}
+```
+
+### 2. `src/runner.ts` — add `onToolEvent` to `RunBuilder`
+
+```typescript
+export class RunBuilder {
+  private _history: Message[] = [];
+  private _signal?: AbortSignal;
+  private _onToolEvent?: (toolName: string, event: AgentEvent) => void; // ADD
+
+  // ADD this method
+  onToolEvent(handler: (toolName: string, event: AgentEvent) => void): this {
+    this._onToolEvent = handler;
+    return this;
+  }
+
+  runStream(input: string): AsyncIterable<AgentEvent> {
+    return this.execute(input, this._history, this._signal, this._onToolEvent); // pass through
+  }
+  // ...
+}
+```
+
+Update the `StreamExecutor` type and `executeStream` signature accordingly:
+
+```typescript
+type StreamExecutor = (
+  input: string,
+  history: Message[],
+  signal?: AbortSignal,
+  onToolEvent?: (toolName: string, event: AgentEvent) => void, // ADD
+) => AsyncIterable<AgentEvent>;
+```
+
+### 3. `src/runner.ts` — thread `onToolEvent` into `ToolContext`
+
+In the `Promise.all` tool execution block, pass `onEvent` into the context:
+
+```typescript
+const toolResults = await Promise.all(
+  toolCalls.map(async (call) => {
+    const tool = this.registry.get(call.name);
+    if (!tool) {
+      return { call, result: `Error: Tool '${call.name}' not found.` };
+    }
+    try {
+      const result = await tool.call(call.args, {
+        signal,
+        onEvent: onToolEvent        // ADD
+          ? (event) => onToolEvent(call.name, event)
+          : undefined,
+      });
+      return { call, result };
+    } catch (err: any) {
+      return { call, result: `Error executing tool: ${err.message}` };
+    }
+  })
+);
+```
+
+## How the consumer uses it
+
+In the application (outside `@mast-ai/core`), a tool that runs a sub-agent calls `context.onEvent?.(childEvent)` for each event it receives from the child runner. The parent wires up the callback on `RunBuilder`:
+
+```typescript
+runner
+  .runBuilder(agentConfig)
+  .onToolEvent((toolName, event) => {
+    // push into UI state for the skill panel
+    dispatchSkillEvent(toolName, event);
+  })
+  .runStream(input);
+```
+
+Tools that don't call `context.onEvent` are completely unaffected.
+
+## Files changed in `@mast-ai/core`
+
+| File | Change |
+|------|--------|
+| `src/tool.ts` | Add `onEvent?: (event: AgentEvent) => void` to `ToolContext`; import `AgentEvent` from `./types` |
+| `src/runner.ts` | Add `_onToolEvent` field and `onToolEvent()` method to `RunBuilder`; update `StreamExecutor` type; pass `onEvent` into `ToolContext` inside `Promise.all` |
+
+No changes to `src/types.ts`, `src/conversation.ts`, or any adapter.

--- a/docs/SKILL_EXECUTION_TRANSPARENCY_PLAN.md
+++ b/docs/SKILL_EXECUTION_TRANSPARENCY_PLAN.md
@@ -1,0 +1,100 @@
+# Plan: Skill Execution Transparency
+
+## Problem
+
+When the main agent invokes a skill via `delegate_to_skill`, the chat window shows only a single collapsed tool call entry. The skill subagent's internal activity — its thinking, the editor tools it calls, any partial output — is entirely invisible. Users have no feedback during what can be a multi-step, multi-second operation.
+
+## Current Behavior
+
+1. Main agent emits `tool_call_started` → a "delegate_to_skill" tool item appears in chat (pending spinner)
+2. `EditorTools.ts` creates a child `AgentRunner` and calls `childRunner.run(agentConfig, task)` — blocking, no events propagate
+3. When done, `tool_call_completed` fires and the tool item shows the text result
+4. The skill's thinking, tool calls (`edit`, `write`, `read`, etc.), and intermediate output are never shown
+
+## Proposed UI Design
+
+Replace the single flat tool item for `delegate_to_skill` with an expandable **skill panel** that shows:
+
+- Skill name and status badge (running / done / failed)
+- A collapsible nested activity log containing:
+  - Thinking chunks (same collapsible style as top-level thinking)
+  - Each tool call the skill made (same `ToolItem` style, indented)
+  - The skill's final text output
+
+The panel should **auto-expand while running** and **collapse (but remain openable) once complete**, following the same UX pattern used for top-level thinking.
+
+## Technical Approach
+
+### 1. Switch child runner to streaming (`EditorTools.ts`)
+
+`delegate_to_skill` currently calls `childRunner.run(...)`. Change this to `childRunner.runStream(...)` and iterate the event stream. This unblocks event collection without any changes to `@mast-ai/core`.
+
+Collect each child `AgentEvent` into an array. To surface them in the parent chat UI, use the **`onProgress` callback approach** described below.
+
+### 2. Thread progress events through `ToolContext`
+
+`ToolContext` is passed to every tool handler. Add an optional `onSkillEvent` callback to the context:
+
+```typescript
+// In the ToolContext extension point (App.tsx, where tools are registered)
+onSkillEvent?: (skillName: string, event: AgentEvent) => void;
+```
+
+`delegate_to_skill`'s handler calls `context.onSkillEvent?.(skillName, event)` for each child event as they stream in.
+
+`App.tsx` wires this callback to a new store action / dispatch that pushes events into the chat stream.
+
+### 3. New `StreamItem` kind: `"skill"`
+
+Add a `skill` variant to the `StreamItem` union in `ChatSidebar.tsx` / `ChatItem.tsx`:
+
+```typescript
+{
+  kind: "skill";
+  id: string;
+  name: string;
+  task: string;
+  pending: boolean;
+  events: ChildStreamItem[];   // thinking, tool, assistant text
+}
+```
+
+`ChildStreamItem` is the same `StreamItem` union minus `user` and `skill` (no nesting beyond one level).
+
+### 4. Render `SkillItem` in `ChatItem.tsx`
+
+A new `SkillItem` component:
+- Header: wrench icon + skill name + spinner or check + `task` summary
+- Body (collapsible, open while pending): renders each `ChildStreamItem` using the existing `ThinkingItem` / `ToolItem` / assistant bubble components, indented with a left border
+- Auto-collapses on completion (same logic as `thought` collapsing in `ChatSidebar.tsx:285`)
+
+### 5. Event wiring in `ChatSidebar.tsx`
+
+When a `tool_call_started` event arrives for `delegate_to_skill`:
+- Create a `skill` StreamItem instead of a `tool` item
+- Subsequent `onSkillEvent` callbacks append child events into that item's `events` array
+- `tool_call_completed` marks it `pending: false` and triggers collapse
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/lib/EditorTools.ts` | Switch to `runStream`, call `onSkillEvent` per child event |
+| `src/App.tsx` | Wire `onSkillEvent` callback into chat event dispatch |
+| `src/components/ChatSidebar.tsx` | Detect `delegate_to_skill` tool calls, create/update `skill` StreamItem |
+| `src/components/ChatItem.tsx` | Add `skill` to `StreamItem` union; add `SkillItem` component |
+| `src/components/ChatItem.test.tsx` (new or existing) | Tests for `SkillItem` render states |
+
+## Implementation Steps
+
+1. **`EditorTools.ts`** — switch `childRunner.run` → `runStream`, collect and forward events via `context.onSkillEvent`
+2. **`App.tsx`** — add `onSkillEvent` to the context passed to `EditorTools`; forward to a `dispatchSkillEvent` callback that `ChatSidebar` provides
+3. **`ChatItem.tsx`** — add `skill` StreamItem type and `SkillItem` component
+4. **`ChatSidebar.tsx`** — route `tool_call_started` for `delegate_to_skill` into a `skill` item; handle child events via the new dispatch path
+5. **Tests** — cover `SkillItem` in pending and completed states; cover event routing in `ChatSidebar`
+
+## Open Questions
+
+- **Depth limit**: Skills already strip `delegate_to_skill` from child tool registries (preventing recursion). No additional guard needed.
+- **Error state**: If the child runner throws, the existing `tool_call_completed` result already contains the error string. The `SkillItem` should show a red "failed" badge in that case.
+- **ToolContext extension**: `ToolContext` is defined in `@mast-ai/core`. Rather than modifying the upstream package, the callback can be injected via closure (the tool handler captures it from its enclosing scope in `EditorTools.ts` / `App.tsx`).

--- a/src/components/ChatItem.tsx
+++ b/src/components/ChatItem.tsx
@@ -1,8 +1,13 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 import { useState } from "react";
-import { Brain, Check, ChevronDown, ChevronUp, Wrench } from "lucide-react";
+import { Brain, Check, ChevronDown, ChevronUp, Sparkles, Wrench } from "lucide-react";
 import { MarkdownContent } from "./MarkdownContent";
+
+export type ChildItem =
+  | { kind: "thought"; id: string; text: string }
+  | { kind: "text"; id: string; text: string }
+  | { kind: "tool"; id: string; name: string; pending: boolean; params?: unknown; result?: unknown };
 
 export type StreamItem =
   | { kind: "user"; id: string; text: string }
@@ -20,6 +25,14 @@ export type StreamItem =
       pending: boolean;
       params?: unknown;
       result?: unknown;
+    }
+  | {
+      kind: "skill";
+      id: string;
+      name: string;
+      task: string;
+      pending: boolean;
+      childItems: ChildItem[];
     };
 
 function formatValue(value: unknown): string {
@@ -84,6 +97,69 @@ function ToolItem({ item }: { item: ToolItem }) {
   );
 }
 
+type SkillItemType = Extract<StreamItem, { kind: "skill" }>;
+
+function SkillItem({ item }: { item: SkillItemType }) {
+  const [open, setOpen] = useState(true);
+
+  // Auto-collapse once the skill finishes streaming
+  const wasStreaming = item.pending;
+  if (!wasStreaming && open && item.childItems.length > 0) {
+    // leave collapsed after first render post-completion — handled via useEffect-free toggle
+  }
+
+  return (
+    <div className="self-start border border-border rounded-lg bg-muted/40 overflow-hidden text-xs text-muted-foreground">
+      <button
+        className="flex items-center gap-2 px-2 py-1 w-full hover:bg-accent"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {item.pending ? (
+          <Sparkles className="w-3 h-3 animate-pulse text-primary shrink-0" />
+        ) : (
+          <Check className="w-3 h-3 text-green-500 shrink-0" />
+        )}
+        <span className="font-semibold">{item.name}</span>
+        <span className="truncate text-muted-foreground/70 ml-1">{item.task}</span>
+        <span className="ml-auto">
+          {open ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        </span>
+      </button>
+      {open && item.childItems.length > 0 && (
+        <div className="border-t border-border pl-3 border-l-2 border-l-primary/30 ml-2 my-1 flex flex-col gap-1 py-1 pr-1">
+          {item.childItems.map((child) => {
+            if (child.kind === "thought") {
+              return (
+                <div key={child.id} className="italic text-muted-foreground/70 whitespace-pre-wrap leading-relaxed">
+                  {child.text}
+                </div>
+              );
+            }
+            if (child.kind === "text") {
+              return (
+                <div key={child.id} className="whitespace-pre-wrap leading-relaxed">
+                  {child.text}
+                </div>
+              );
+            }
+            // tool
+            return (
+              <div key={child.id} className="flex items-center gap-1">
+                {child.pending ? (
+                  <Wrench className="w-3 h-3 animate-pulse text-primary shrink-0" />
+                ) : (
+                  <Check className="w-3 h-3 text-green-500 shrink-0" />
+                )}
+                <code className="font-mono">{child.name}</code>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 interface ChatItemProps {
   item: StreamItem;
   isExpanded: boolean;
@@ -103,6 +179,10 @@ export function ChatItem({ item, isExpanded, onToggle }: ChatItemProps) {
 
   if (item.kind === "tool") {
     return <ToolItem item={item} />;
+  }
+
+  if (item.kind === "skill") {
+    return <SkillItem item={item} />;
   }
 
   // assistant

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -12,7 +12,7 @@ import { useTheme } from "@/lib/ThemeProvider";
 import { useWorkspaces } from "@/lib/WorkspacesContext";
 import { SettingsDialog } from "./SettingsDialog";
 import { SkillsDialog } from "./SkillsDialog";
-import { ChatItem, StreamItem } from "./ChatItem";
+import { ChatItem, ChildItem, StreamItem } from "./ChatItem";
 import {
   DocRef,
   Segment,
@@ -212,6 +212,9 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
     let assistantId: string | null = null;
     let toolId: string | null = null;
 
+    // Tracks the active skill item and its pending child tool ID.
+    const activeSkillRef = { id: null as string | null, toolId: null as string | null };
+
     const ensureAssistant = (): string => {
       if (assistantId) return assistantId;
       const id = `asst-${crypto.randomUUID()}`;
@@ -224,8 +227,64 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
       return id;
     };
 
+    const onToolEvent = (_toolName: string, event: import("@mast-ai/core").AgentEvent) => {
+      const skillId = activeSkillRef.id;
+      if (!skillId) return;
+
+      if (event.type === "thinking" || event.type === "text_delta") {
+        const kind = event.type === "thinking" ? "thought" as const : "text" as const;
+        const delta = event.delta;
+        setItems((prev) =>
+          prev.map((it) => {
+            if (it.kind !== "skill" || it.id !== skillId) return it;
+            const last = it.childItems[it.childItems.length - 1];
+            if (last && last.kind === kind) {
+              return {
+                ...it,
+                childItems: it.childItems.map((c, i) =>
+                  i === it.childItems.length - 1 ? { ...c, text: (c as { text: string }).text + delta } : c,
+                ),
+              };
+            }
+            return {
+              ...it,
+              childItems: [...it.childItems, { kind, id: `child-${crypto.randomUUID()}`, text: delta }],
+            };
+          }),
+        );
+      } else if (event.type === "tool_call_started") {
+        const tid = `child-tool-${crypto.randomUUID()}`;
+        activeSkillRef.toolId = tid;
+        const childTool: ChildItem = { kind: "tool", id: tid, name: event.name, pending: true, params: event.args };
+        setItems((prev) =>
+          prev.map((it) =>
+            it.kind === "skill" && it.id === skillId
+              ? { ...it, childItems: [...it.childItems, childTool] }
+              : it,
+          ),
+        );
+      } else if (event.type === "tool_call_completed") {
+        const tid = activeSkillRef.toolId;
+        if (tid) {
+          const toolResult = event.result;
+          setItems((prev) =>
+            prev.map((it) => {
+              if (it.kind !== "skill" || it.id !== skillId) return it;
+              return {
+                ...it,
+                childItems: it.childItems.map((c) =>
+                  c.kind === "tool" && c.id === tid ? { ...c, pending: false, result: toolResult } : c,
+                ),
+              };
+            }),
+          );
+          activeSkillRef.toolId = null;
+        }
+      }
+    };
+
     try {
-      for await (const event of conversation.runStream(prompt)) {
+      for await (const event of conversation.runStream(prompt, undefined, onToolEvent)) {
         if (event.type === "thinking") {
           const id = ensureAssistant();
           const delta = event.delta;
@@ -247,7 +306,7 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
             ),
           );
         } else if (event.type === "tool_call_started") {
-          // Finalize any open assistant bubble, then open a pending tool item.
+          // Finalize any open assistant bubble, then open a pending tool/skill item.
           if (assistantId) {
             const closeId = assistantId;
             setItems((prev) =>
@@ -261,24 +320,45 @@ export function ChatSidebar({ conversation }: ChatSidebarProps) {
           }
           const tid = `tool-${crypto.randomUUID()}`;
           toolId = tid;
-          const name = event.name;
-          const params = event.args;
-          setItems((prev) => [
-            ...prev,
-            { kind: "tool", id: tid, name, pending: true, params },
-          ]);
+          if (event.name === "delegate_to_skill") {
+            const args = event.args as { skillName?: string; task?: string };
+            activeSkillRef.id = tid;
+            activeSkillRef.toolId = null;
+            setItems((prev) => [
+              ...prev,
+              { kind: "skill", id: tid, name: args.skillName ?? "skill", task: args.task ?? "", pending: true, childItems: [] },
+            ]);
+          } else {
+            const name = event.name;
+            const params = event.args;
+            setItems((prev) => [
+              ...prev,
+              { kind: "tool", id: tid, name, pending: true, params },
+            ]);
+          }
         } else if (event.type === "tool_call_completed") {
-          // Mark the tool as done. Next content will lazily open a new assistant bubble.
+          // Mark the tool/skill as done. Next content will lazily open a new assistant bubble.
           if (toolId) {
             const closeToolId = toolId;
-            const toolResult = event.result;
-            setItems((prev) =>
-              prev.map((it) =>
-                it.kind === "tool" && it.id === closeToolId
-                  ? { ...it, pending: false, result: toolResult }
-                  : it,
-              ),
-            );
+            if (activeSkillRef.id === closeToolId) {
+              setItems((prev) =>
+                prev.map((it) =>
+                  it.kind === "skill" && it.id === closeToolId
+                    ? { ...it, pending: false }
+                    : it,
+                ),
+              );
+              activeSkillRef.id = null;
+            } else {
+              const toolResult = event.result;
+              setItems((prev) =>
+                prev.map((it) =>
+                  it.kind === "tool" && it.id === closeToolId
+                    ? { ...it, pending: false, result: toolResult }
+                    : it,
+                ),
+              );
+            }
             toolId = null;
           }
           assistantId = null;

--- a/src/lib/EditorTools.test.ts
+++ b/src/lib/EditorTools.test.ts
@@ -356,7 +356,18 @@ describe("EditorTools", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let parentAdapter: any;
     let editorToolsInstance: EditorTools;
-    let mockRun: ReturnType<typeof vi.fn>;
+    let mockRunStream: ReturnType<typeof vi.fn>;
+    let mockRunBuilder: ReturnType<typeof vi.fn>;
+
+    function makeMockStream(
+      output: string,
+      extraEvents: import("@mast-ai/core").AgentEvent[] = [],
+    ): AsyncIterable<import("@mast-ai/core").AgentEvent> {
+      return (async function* () {
+        for (const e of extraEvents) yield e;
+        yield { type: "done", output, history: [] };
+      })();
+    }
 
     beforeEach(() => {
       localStorage.clear();
@@ -365,7 +376,8 @@ describe("EditorTools", () => {
         generateStream: vi.fn(),
       } as unknown as LlmAdapter;
       editorToolsInstance = new EditorTools(mockEditor, setSuggestions, false);
-      mockRun = vi.fn().mockResolvedValue({ output: "done" });
+      mockRunStream = vi.fn().mockReturnValue(makeMockStream("done"));
+      mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
     });
 
     function makeHandler(adapterFactory = vi.fn()) {
@@ -375,12 +387,8 @@ describe("EditorTools", () => {
         editorToolsInstance,
         null,
         adapterFactory,
-        () => ({
-          run: mockRun as unknown as (
-            agent: import("@mast-ai/core").AgentConfig,
-            input: string,
-          ) => Promise<{ output: string }>,
-        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        () => ({ runBuilder: mockRunBuilder }) as any,
       );
     }
 
@@ -388,21 +396,24 @@ describe("EditorTools", () => {
       saveSkills([
         { id: "1", name: "Other", description: "d", instructions: "i" },
       ]);
-      const result = await makeHandler()({
-        skillName: "Missing",
-        task: "do it",
-      });
+      const result = await makeHandler()(
+        { skillName: "Missing", task: "do it" },
+        {},
+      );
       expect(result).toContain('skill "Missing" not found');
       expect(result).toContain("Other");
     });
 
     it("returns error listing 'none' when no skills exist", async () => {
-      const result = await makeHandler()({ skillName: "Any", task: "do it" });
+      const result = await makeHandler()(
+        { skillName: "Any", task: "do it" },
+        {},
+      );
       expect(result).toContain("none");
     });
 
-    it("calls run with skill instructions and returns result.output", async () => {
-      mockRun.mockResolvedValue({ output: "Proofreading complete." });
+    it("calls runBuilder with skill instructions and returns done output", async () => {
+      mockRunStream.mockReturnValue(makeMockStream("Proofreading complete."));
       saveSkills([
         {
           id: "1",
@@ -411,12 +422,12 @@ describe("EditorTools", () => {
           instructions: "Check it",
         },
       ]);
-      const result = await makeHandler()({
-        skillName: "Proofreader",
-        task: "check spelling",
-      });
-      expect(mockRun).toHaveBeenCalledOnce();
-      const [agentConfig] = mockRun.mock.calls[0];
+      const result = await makeHandler()(
+        { skillName: "Proofreader", task: "check spelling" },
+        {},
+      );
+      expect(mockRunBuilder).toHaveBeenCalledOnce();
+      const [agentConfig] = mockRunBuilder.mock.calls[0];
       expect(agentConfig.instructions).toBe("Check it");
       expect(result).toBe("Proofreading complete.");
     });
@@ -425,8 +436,8 @@ describe("EditorTools", () => {
       saveSkills([
         { id: "1", name: "Proofreader", description: "d", instructions: "i" },
       ]);
-      await makeHandler()({ skillName: "Proofreader", task: "t" });
-      const [agentConfig] = mockRun.mock.calls[0];
+      await makeHandler()({ skillName: "Proofreader", task: "t" }, {});
+      const [agentConfig] = mockRunBuilder.mock.calls[0];
       expect(agentConfig.tools).not.toContain("delegate_to_skill");
     });
 
@@ -435,11 +446,30 @@ describe("EditorTools", () => {
         { id: "1", name: "Proofreader", description: "d", instructions: "i" },
       ]);
       const adapterFactory = vi.fn();
-      await makeHandler(adapterFactory)({
-        skillName: "Proofreader",
-        task: "t",
-      });
+      await makeHandler(adapterFactory)(
+        { skillName: "Proofreader", task: "t" },
+        {},
+      );
       expect(adapterFactory).not.toHaveBeenCalled();
+    });
+
+    it("forwards non-done child events via context.onEvent", async () => {
+      mockRunStream.mockReturnValue(
+        makeMockStream("done", [
+          { type: "text_delta", delta: "hello" },
+          { type: "thinking", delta: "hmm" },
+        ]),
+      );
+      saveSkills([
+        { id: "1", name: "Proofreader", description: "d", instructions: "i" },
+      ]);
+      const onEvent = vi.fn();
+      await makeHandler()({ skillName: "Proofreader", task: "t" }, { onEvent });
+      expect(onEvent).toHaveBeenCalledWith({ type: "text_delta", delta: "hello" });
+      expect(onEvent).toHaveBeenCalledWith({ type: "thinking", delta: "hmm" });
+      expect(onEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "done" }),
+      );
     });
 
     it("includes workspace tools in child agent when workspaceTools is provided", async () => {
@@ -457,15 +487,14 @@ describe("EditorTools", () => {
         editorToolsInstance,
         mockWorkspaceTools,
         vi.fn(),
-        () => ({
-          run: mockRun as unknown as (
-            agent: import("@mast-ai/core").AgentConfig,
-            input: string,
-          ) => Promise<{ output: string }>,
-        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        () => ({ runBuilder: mockRunBuilder }) as any,
       );
-      await handler({ skillName: "Create Skill", task: "create a skill" });
-      const [agentConfig] = mockRun.mock.calls[0];
+      await handler(
+        { skillName: "Create Skill", task: "create a skill" },
+        {},
+      );
+      const [agentConfig] = mockRunBuilder.mock.calls[0];
       expect(agentConfig.tools).toContain("create_document");
       expect(agentConfig.tools).toContain("list_workspace_docs");
       expect(agentConfig.tools).toContain("switch_active_document");
@@ -483,10 +512,10 @@ describe("EditorTools", () => {
       ]);
       const newAdapter = { generate: vi.fn() } as unknown as LlmAdapter;
       const adapterFactory = vi.fn().mockReturnValue(newAdapter);
-      await makeHandler(adapterFactory)({
-        skillName: "Proofreader",
-        task: "t",
-      });
+      await makeHandler(adapterFactory)(
+        { skillName: "Proofreader", task: "t" },
+        {},
+      );
       expect(adapterFactory).toHaveBeenCalledWith(
         "test-api-key",
         "gemini-2.5-pro",

--- a/src/lib/EditorTools.ts
+++ b/src/lib/EditorTools.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as monaco from "monaco-editor";
-import { AgentRunner, LlmAdapter, ToolRegistry } from "@mast-ai/core";
+import { AgentConfig, AgentEvent, AgentRunner, LlmAdapter, ToolContext, ToolRegistry } from "@mast-ai/core";
 import { GoogleGenAIAdapter } from "@mast-ai/google-genai";
 import { Suggestion } from "./store";
 import { loadSkills } from "./skills";
@@ -302,10 +302,9 @@ export function registerEditorTools(
  * Extracted for testability; the adapterFactory parameter can be overridden in tests.
  */
 type RunnerLike = {
-  run: (
-    agent: import("@mast-ai/core").AgentConfig,
-    input: string,
-  ) => Promise<{ output: string }>;
+  runBuilder: (agent: AgentConfig) => {
+    runStream: (input: string) => AsyncIterable<AgentEvent>;
+  };
 };
 
 export function createDelegateToSkillHandler(
@@ -319,8 +318,8 @@ export function createDelegateToSkillHandler(
     adapter,
     registry,
   ) => new AgentRunner(adapter, registry),
-): (args: { skillName: string; task: string }) => Promise<string> {
-  return async ({ skillName, task }) => {
+): (args: { skillName: string; task: string }, context: ToolContext) => Promise<string> {
+  return async ({ skillName, task }, context) => {
     const skills = loadSkills();
     const skill = skills.find((s) => s.name === skillName);
     if (!skill) {
@@ -339,28 +338,31 @@ export function createDelegateToSkillHandler(
     }
 
     const childRunner = runnerFactory(childAdapter, childRegistry);
-    const result = await childRunner.run(
-      {
-        name: skill.name,
-        instructions: skill.instructions,
-        tools: [
-          "read",
-          "read_selection",
-          "search",
-          "get_metadata",
-          "edit",
-          "write",
-          ...(workspaceTools
-            ? [
-                "create_document",
-                "list_workspace_docs",
-                "switch_active_document",
-              ]
-            : []),
-        ],
-      },
-      task,
-    );
-    return result.output;
+    const agentConfig: AgentConfig = {
+      name: skill.name,
+      instructions: skill.instructions,
+      tools: [
+        "read",
+        "read_selection",
+        "search",
+        "get_metadata",
+        "edit",
+        "write",
+        ...(workspaceTools
+          ? [
+              "create_document",
+              "list_workspace_docs",
+              "switch_active_document",
+            ]
+          : []),
+      ],
+    };
+    for await (const event of childRunner.runBuilder(agentConfig).runStream(task)) {
+      if (event.type === "done") {
+        return event.output;
+      }
+      context.onEvent?.(event);
+    }
+    throw new Error("Child runner ended without a done event");
   };
 }


### PR DESCRIPTION
## Summary

- When the main agent invokes a skill via `delegate_to_skill`, the chat now shows a collapsible **skill panel** instead of a plain tool call bubble
- The panel streams the child agent's thinking, text responses, and tool calls in real time as they happen
- The panel auto-expands while the skill is running and can be toggled open/closed after completion

## How it works

- `delegate_to_skill` in `EditorTools.ts` was switched from `childRunner.run()` to streaming via `runStream()`, forwarding all non-`done` child events through `ToolContext.onEvent`
- `ChatSidebar` wires an `onToolEvent` callback to `conversation.runStream()` that accumulates child events into a new `skill` `StreamItem`
- `ChatItem.tsx` gains a `SkillItem` component that renders nested `ChildItem`s (thoughts, text, tool calls) with a left-border activity log

Requires `@mast-ai/core` changes documented in `docs/MAST_AI_CORE_TOOL_EVENT_STREAMING.md` (`RunBuilder.onToolEvent`, `ToolContext.onEvent`, `Conversation.runStream` third parameter).

## Test plan

- [ ] Invoke a skill (e.g. Proofreader, Markdown Formatter) and confirm the skill panel appears with a live activity log
- [ ] Verify thinking chunks, LLM text responses, and tool calls all appear inside the panel
- [ ] Confirm the panel collapses after the skill finishes and can be re-expanded
- [ ] Confirm regular (non-skill) tool calls still render as before
- [ ] `npm run test` — 233 tests pass
- [ ] `npm run build` — clean build