### PR TITLE
fix: eagerly sync Monaco model after document-switching tool calls

### DIFF
--- a/docs/BLOG_ASYNC_TOOL_SYNC.md
+++ b/docs/BLOG_ASYNC_TOOL_SYNC.md
@@ -1,0 +1,172 @@
+# Blog Notes: The Tool Contract Problem in Agentic Loops
+
+## The Bug
+
+Our AI agent editor lets an LLM switch between documents, create new ones, and then immediately read or edit the content that should now be open. In practice, after the agent called `switch_active_document`, any subsequent `read()` or `edit()` call would silently operate on the *previous* document. The agent was editing text it thought it had just switched away from.
+
+The fix was a single extra line per tool. Understanding *why* it was needed reveals something fundamental about how agent tools must behave.
+
+---
+
+## The Contract a Tool Makes
+
+When an LLM calls a tool, the agent framework awaits the tool's Promise and feeds the result back into the conversation. That result is the LLM's only evidence that the action happened. So the tool's return value carries an implicit promise:
+
+> **"The world now reflects what I just did. Your next action can build on it."**
+
+This contract is what makes sequential tool use coherent. If `switch_active_document` returns `{ switched: true, title: "Draft v2" }`, the LLM reasonably concludes it can now call `read()` and get "Draft v2"'s content. If that assumption fails, the LLM acts on a lie.
+
+This is not a subtle edge case. It is the foundational requirement for any tool in a multi-step agent loop: **resolve only when the effect is observable by the next tool call.**
+
+---
+
+## "Done" vs "Observable": A General Problem
+
+This contract can be broken any time there is a gap between *initiating* an effect and that effect becoming *visible* to subsequent operations. The agent framework doesn't know about that gap — it sees a resolved Promise and moves on.
+
+Some familiar examples of the same class of problem:
+
+**Databases:** A write that is acknowledged before the replica has caught up. A subsequent read on a replica returns stale data. Read-your-writes consistency exists precisely to prevent this.
+
+**Message queues:** A message is "sent" (accepted by the broker) before consumers have processed it. If the next operation depends on the side-effect of that message, it will race.
+
+**File systems:** A write syscall returns before the OS has flushed to disk. A subsequent reader on a different file descriptor may see the old bytes.
+
+**UI frameworks:** A state mutation is acknowledged before the rendering pipeline has made the new state visible to the parts of the application that subsequent operations read from.
+
+Our bug is the last one. The agent's tools write state through React, but read state through Monaco's editor API — and those two paths are coupled through an asynchronous rendering pipeline.
+
+---
+
+## How It Manifests Here
+
+The application has two separate pathways to the same content:
+
+- **Write path:** Agent tools call React state setters → React schedules a re-render → `EditorPanel`'s `useEffect` fires → `localContent` state updates → the `value` prop of Monaco changes → Monaco updates its internal model.
+- **Read path:** Agent tools call `editor.getValue()` on the Monaco instance directly.
+
+When the write path is asynchronous and the read path is synchronous, a tool that returns after triggering the write path but before it completes leaves the read path stale.
+
+Here is the concrete sequence for `switch_active_document`:
+
+```
+Tool called:
+  setActiveDocumentId(newId)    → React state update: *scheduled*, not applied
+  return { switched: true }     → Promise resolves: agent proceeds immediately
+
+Agent calls read() next:
+  editor.getValue()             → Monaco still holds OLD document content 💥
+```
+
+React 18 batches state updates and flushes them asynchronously. Even if that flush were instant, `useEffect` — which triggers `setLocalContent` in `EditorPanel` — runs *after the browser paints*. There are two full deferred render cycles before Monaco reflects the new document:
+
+```
+Cycle 1: setActiveDocumentId() flushes → React renders
+         → activeDocument is new doc
+         Browser paints
+         useEffect([activeDocument]) fires → setLocalContent(newDoc.content)
+
+Cycle 2: setLocalContent() flushes → React renders
+         → Monaco's value prop changes
+         → Monaco calls editor.setValue(newContent) internally
+```
+
+The agent's next tool call runs between the return and cycle 1. The UI is nowhere near ready.
+
+The same race exists for `create_document`: the workspace context creates the document and switches to it in one state update, but Monaco doesn't know yet.
+
+---
+
+## The Wrong Fix: Waiting for the UI
+
+The apparent solution is to delay the Promise resolution until the rendering pipeline catches up. The options are all bad:
+
+**`flushSync`** forces a synchronous render, but `useEffect` hooks are explicitly deferred until after paint — by design. The `setLocalContent` call still wouldn't happen, so Monaco still wouldn't update.
+
+**`setTimeout(resolve, 0)`** waits one event-loop tick. React's flush usually completes in a microtask, so the first render might be done — but `useEffect` fires post-paint, which is *after* a `requestAnimationFrame`. Chaining `setTimeout(0)` inside `setTimeout(0)` is guessing at timing, not knowing it.
+
+**`requestAnimationFrame` chains** are closer but still fragile. A slow frame (tab in background, heavy layout work) can push the paint back far enough to race. This adds 16–32 ms of artificial latency per tool call, which accumulates noticeably in a multi-step agent loop. And it's still a timing assumption, not a guarantee.
+
+All of these approaches try to solve the problem at the wrong layer. They're trying to make the write path synchronous, but the write path is asynchronous *by design* — React's async rendering is a feature. The real problem is that the write path and the read path are different, and the agent shouldn't have to wait for a UI rendering pipeline at all.
+
+---
+
+## The Right Fix: Separate the Agent's State from the UI's State
+
+The core insight is that the agent tools and the UI *don't have to share the same state pathway*. The UI can stay async. The agent just needs its reads and writes to be consistent with each other.
+
+In our case, the agent reads from and writes to Monaco's imperative API (`editor.getValue()`, `editor.setValue()`). React's rendering pipeline drives the *display*, but the agent cares about the *model*. When a tool changes the active document, it should update the model directly:
+
+```ts
+async switch_active_document({ id }: { id: string }): Promise<string> {
+  const doc = this.docsRef.current.find((d) => d.id === id);
+  if (!doc) return JSON.stringify({ error: "Document not found" });
+
+  const currentDoc = this.activeDocRef.current;
+  if (currentDoc) {
+    this.saveDocContentFn(currentDoc.id, this.getEditorContent());
+  }
+
+  this.setActiveDocumentIdFn(id);      // React state update (async — for the UI)
+  this.setEditorValueFn(doc.content);  // Monaco sync (immediate — for the agent)
+
+  return JSON.stringify({ switched: true, id, title: doc.title });
+}
+```
+
+`setEditorValueFn` is `(content) => editorInstance?.setValue(content)`, passed in from `App.tsx`. It updates Monaco's model synchronously, so the next `editor.getValue()` immediately returns the new document's content. React's rendering pipeline still runs in the background and the UI updates as usual — we're just not blocking the agent on it.
+
+This resolves the contract: the Promise resolves after the effect is observable to subsequent tool calls.
+
+---
+
+## Why This Is Safe
+
+Two follow-on questions arise.
+
+**Won't React overwrite Monaco with stale content when it finally re-renders?**
+
+No. `@monaco-editor/react` guards its controlled `value` prop: it only calls `editor.setValue(v)` when `v !== editor.getValue()`. Once we've eagerly set the model, the subsequent prop update from React's render cycle sees no difference and skips it.
+
+**Won't the Monaco `onChange` event save content to the wrong document?**
+
+No. When `editor.setValue(newContent)` fires, Monaco's `onChange` triggers `handleChange` in `EditorPanel`, which debounces a `updateDocument` save by 500 ms. By the time that debounce fires, React has re-rendered and `activeDocument` is the new document — so the save correctly targets the new document's ID.
+
+---
+
+## What This Looked Like in Practice
+
+The failure mode was silent. The agent would produce output like:
+
+> Switching to "Draft v2"...
+> Reading document...
+> I see the document currently begins with "Introduction to..."
+
+— and "Introduction to..." was from the *previous* document. The agent would then propose an edit, the user would accept it, and the wrong document would be modified. No error, no warning — just the wrong behaviour.
+
+The bug only appeared when the agent chained multiple tools, which is exactly what a capable agent does. A single-tool interaction (switch, then stop) appeared to work fine because the UI caught up before the user took another action. The more capable you make an agent, the worse this class of bug gets.
+
+---
+
+## The General Rule for Agent Tools
+
+Whenever a tool performs an action whose effect is visible to subsequent tools through a different pathway than the one used to initiate it, the tool is responsible for closing that gap before resolving.
+
+The specific fix depends on the architecture:
+
+- If reads and writes go through the same channel (e.g., both through React context via a ref), the gap may not exist.
+- If the write path is async (React state) and the read path is synchronous (imperative API), update the read path directly.
+- If the write path is a message queue and the read path is a database, wait for the queue to be processed before resolving — or restructure so both paths share a single source of truth.
+
+The React-specific mechanics (two render cycles, `useEffect` deferral, `flushSync` limitations) are a concrete instance of a more general class. What makes it a useful case study is that the React behaviour is well-documented and widely misunderstood as "just async" — when the real issue is the mismatch between the agent's expectations and the actual consistency model of the underlying system.
+
+---
+
+## Summary
+
+| Approach | Works? | Why |
+|---|---|---|
+| Trust React to update before the next tool runs | No | React renders are deferred; the agent runs between state mutations and their effects |
+| Delay Promise with `setTimeout(0)` | Unreliable | `useEffect` runs post-paint, not post-microtask; timing is still a guess |
+| Delay Promise with `flushSync` | Partial | Forces one synchronous render; `useEffect` is still deferred until after paint |
+| Eagerly update Monaco + async React state | ✓ | Closes the gap between write path and read path; React catches up without blocking the agent |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -198,10 +198,14 @@ Registers tools scoped to the active workspace. Receives a ref snapshot of `Work
 - `read_workspace_doc(id)`: Returns `{ title, content }` or `{ error: "Document not found" }`.
 - `query_workspace_doc(id, query)`: Spins up a short-lived `AgentRunner` with the document content and query; returns `{ summary }`. The `AgentRunner` factory is injected as a parameter for testability.
 - `query_workspace(query)`: Calls `list_workspace_docs`, then `query_workspace_doc` for each document sequentially, then passes all summaries to a synthesizer `AgentRunner`; returns `{ answer }`.
-- `create_document(title)`: Creates a new document (requires user approval).
+- `create_document(title)`: Creates a new document (requires user approval). On apply, saves the current document's content and immediately syncs the Monaco model to `""` via `setEditorValueFn` — see "React State Synchronization for Agent Tools" below.
 - `rename_document(id, title)`: Renames an existing document (requires user approval).
 - `delete_document(id)`: Deletes a document (requires user approval).
-- `switch_active_document(id)`: Changes the active document in the editor.
+- `switch_active_document(id)`: Changes the active document in the editor. Saves the current document's content then immediately syncs Monaco to the new document's content via `setEditorValueFn` — see "React State Synchronization for Agent Tools" below.
+
+**Constructor parameters relevant to state sync:**
+
+- `setEditorValueFn: (content: string) => void` — calls `editorInstance.setValue(content)` on the Monaco instance. Used by `switch_active_document` and `create_document` to eagerly load the new document's content into Monaco before React's render cycle catches up. See "React State Synchronization for Agent Tools" below.
 
 ### `diffDecorations.ts`
 
@@ -283,6 +287,27 @@ The primary agent should be configured with a system prompt that explains its ro
 > - All edits MUST be proposed via `edit()` or `write()`. Execution will PAUSE until user approval. Do not assume the change was applied until you receive a success confirmation.
 > - Use `list_workspace_docs`, `read_workspace_doc`, or `query_workspace_doc` / `query_workspace` to access other documents in the workspace.
 > - You have access to specialized sub-agents. Use them for focused tasks like proofreading.
+
+## React State Synchronization for Agent Tools
+
+### The Problem
+
+Agent tools execute as async JavaScript outside React's event loop. When a tool calls a React state setter (e.g., `setActiveDocumentId`), React schedules a re-render — it does **not** update state synchronously. The tool's Promise can resolve before React has committed the new state to the DOM.
+
+For document-switching operations this creates a concrete bug: `switch_active_document` calls `setActiveDocumentId(id)` and returns. The agent immediately calls `read()` or `edit()`. But `EditorPanel` drives Monaco via two chained `useEffect` hooks (the first fires when `activeDocument` changes and calls `setLocalContent`; the second propagates `localContent` to the store as `editorContent`). Both effects are deferred until after the browser paints. Monaco therefore still holds the *previous* document's content when the agent reads or edits it.
+
+The same race applies to `create_document`: the newly created document is switched in by the workspace context, but Monaco doesn't reflect it until the effects run.
+
+### The Fix: Eager Monaco Sync
+
+After calling any state setter that changes the active document, immediately call `editorInstance.setValue(newContent)` on the Monaco instance. This is safe because:
+
+1. `@monaco-editor/react` guards its controlled `value` prop: it calls `editor.setValue` only when the incoming prop differs from the current model value. Once we've set the model directly, the subsequent prop update from React's render cycle is a no-op.
+2. Monaco's `onChange` fires synchronously from `setValue`. In `EditorPanel`, `handleChange` updates `localContent` and starts a debounced `updateDocument` save. By the time that debounce fires (500 ms), React has re-rendered and `activeDocument` refers to the new document — so the save targets the correct document.
+
+### Rule for Future Tools
+
+Any tool that changes the active document — whether by switching, creating, or any other mechanism — **must** call `setEditorValueFn(newContent)` after mutating React state. The canonical content to pass is the new document's `content` field from `docsRef`, or `""` for a newly created empty document. Do **not** rely on a `setTimeout` or `flushSync` to delay the Promise resolution; eagerly syncing Monaco is both more reliable and avoids artificial latency in the agent loop.
 
 ## Security
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -347,6 +347,7 @@ function App() {
         (id) => setActiveDocumentId(id),
         (id, content) => updateDocument(id, { content }),
         () => editorInstance?.getValue() ?? editorContent,
+        (content) => editorInstance?.setValue(content),
         setPendingWorkspaceAction,
         approveAll,
       ),

--- a/src/lib/WorkspaceTools.test.ts
+++ b/src/lib/WorkspaceTools.test.ts
@@ -12,6 +12,7 @@ import type {
   SetActiveDocumentIdFn,
   SaveDocContentFn,
   GetEditorContentFn,
+  SetEditorValueFn,
   SetPendingWorkspaceActionFn,
 } from "./WorkspaceTools";
 import type { WorkspaceDocument } from "./workspace";
@@ -191,11 +192,13 @@ describe("WorkspaceTools", () => {
 
   describe("create_document", () => {
     let createDocumentFn: ReturnType<typeof vi.fn> & CreateDocumentFn;
+    let setEditorValueFn: ReturnType<typeof vi.fn> & SetEditorValueFn;
     let setPendingWorkspaceAction: ReturnType<typeof vi.fn> &
       SetPendingWorkspaceActionFn;
 
     beforeEach(() => {
       createDocumentFn = vi.fn().mockReturnValue("new-doc-id") as unknown as typeof createDocumentFn;
+      setEditorValueFn = vi.fn() as unknown as typeof setEditorValueFn;
       setPendingWorkspaceAction = vi.fn() as unknown as typeof setPendingWorkspaceAction;
     });
 
@@ -211,6 +214,7 @@ describe("WorkspaceTools", () => {
         vi.fn(),
         vi.fn(),
         vi.fn().mockReturnValue(""),
+        setEditorValueFn,
         setPendingWorkspaceAction,
         approveAll,
       );
@@ -227,6 +231,7 @@ describe("WorkspaceTools", () => {
       const tools = makeTools(true);
       const result = await tools.create_document({ title: "My Doc" });
       expect(createDocumentFn).toHaveBeenCalledWith("My Doc");
+      expect(setEditorValueFn).toHaveBeenCalledWith("");
       expect(result).toContain("Approve All");
     });
 
@@ -242,6 +247,7 @@ describe("WorkspaceTools", () => {
 
       request.apply();
       expect(createDocumentFn).toHaveBeenCalledWith("Draft");
+      expect(setEditorValueFn).toHaveBeenCalledWith("");
 
       request.resolve("Action applied successfully.");
       expect(await promise).toBe("Action applied successfully.");
@@ -279,6 +285,7 @@ describe("WorkspaceTools", () => {
         vi.fn(),
         vi.fn(),
         vi.fn().mockReturnValue(""),
+        vi.fn(),
         setPendingWorkspaceAction,
         approveAll,
       );
@@ -352,6 +359,7 @@ describe("WorkspaceTools", () => {
         vi.fn(),
         vi.fn(),
         vi.fn().mockReturnValue(""),
+        vi.fn(),
         setPendingWorkspaceAction,
         approveAll,
       );
@@ -396,11 +404,13 @@ describe("WorkspaceTools", () => {
     let setActiveDocumentIdFn: ReturnType<typeof vi.fn> & SetActiveDocumentIdFn;
     let saveDocContentFn: ReturnType<typeof vi.fn> & SaveDocContentFn;
     let getEditorContent: ReturnType<typeof vi.fn> & GetEditorContentFn;
+    let setEditorValueFn: ReturnType<typeof vi.fn> & SetEditorValueFn;
 
     beforeEach(() => {
       setActiveDocumentIdFn = vi.fn() as unknown as typeof setActiveDocumentIdFn;
       saveDocContentFn = vi.fn() as unknown as typeof saveDocContentFn;
       getEditorContent = vi.fn().mockReturnValue("editor content") as unknown as typeof getEditorContent;
+      setEditorValueFn = vi.fn() as unknown as typeof setEditorValueFn;
     });
 
     function makeTools(
@@ -418,6 +428,7 @@ describe("WorkspaceTools", () => {
         setActiveDocumentIdFn,
         saveDocContentFn,
         getEditorContent,
+        setEditorValueFn,
         vi.fn(),
         false,
       );
@@ -454,6 +465,13 @@ describe("WorkspaceTools", () => {
       const tools = makeTools(docs, null);
       await tools.switch_active_document({ id: "d1" });
       expect(saveDocContentFn).not.toHaveBeenCalled();
+    });
+
+    it("syncs editor value to new document content immediately", async () => {
+      const docs = [makeDoc({ id: "d1", title: "Doc 1", content: "new content" })];
+      const tools = makeTools(docs);
+      await tools.switch_active_document({ id: "d1" });
+      expect(setEditorValueFn).toHaveBeenCalledWith("new content");
     });
   });
 

--- a/src/lib/WorkspaceTools.ts
+++ b/src/lib/WorkspaceTools.ts
@@ -19,6 +19,7 @@ export type DeleteDocumentFn = (id: string) => void;
 export type SetActiveDocumentIdFn = (id: string) => void;
 export type SaveDocContentFn = (id: string, content: string) => void;
 export type GetEditorContentFn = () => string;
+export type SetEditorValueFn = (content: string) => void;
 export type SetPendingWorkspaceActionFn = (
   action: WorkspaceActionRequest | null,
 ) => void;
@@ -47,6 +48,7 @@ export class WorkspaceTools {
     private setActiveDocumentIdFn: SetActiveDocumentIdFn = () => {},
     private saveDocContentFn: SaveDocContentFn = () => {},
     private getEditorContent: GetEditorContentFn = () => "",
+    private setEditorValueFn: SetEditorValueFn = () => {},
     private setPendingWorkspaceAction: SetPendingWorkspaceActionFn = () => {},
     private approveAll: boolean = false,
   ) {}
@@ -97,7 +99,16 @@ export class WorkspaceTools {
     }
     return this.applyWorkspaceAction(
       `Create document "${title}"`,
-      () => this.createDocumentFn(title),
+      () => {
+        const currentDoc = this.activeDocRef.current;
+        if (currentDoc) {
+          this.saveDocContentFn(currentDoc.id, this.getEditorContent());
+        }
+        this.createDocumentFn(title);
+        // Immediately clear Monaco so subsequent reads see the new empty doc
+        // before React's async re-render cycle completes.
+        this.setEditorValueFn("");
+      },
       `Document "${title}" created automatically (Approve All is ON).`,
     );
   }
@@ -141,6 +152,9 @@ export class WorkspaceTools {
       this.saveDocContentFn(currentDoc.id, this.getEditorContent());
     }
     this.setActiveDocumentIdFn(id);
+    // Immediately sync Monaco so subsequent read/edit calls see the new content
+    // before React's async re-render cycle completes.
+    this.setEditorValueFn(doc.content);
     return JSON.stringify({ switched: true, id, title: doc.title });
   }
 


### PR DESCRIPTION
## Summary

- `switch_active_document` and `create_document` resolved their Promises immediately after calling React state setters, before the two-render-cycle pipeline had updated Monaco's model. Any subsequent `read()` or `edit()` call would silently operate on the previous document's content.
- Fix: after mutating React state, call `setEditorValueFn(content)` directly on the Monaco instance so the agent's read/write path is immediately consistent. React's rendering pipeline still runs and updates the UI asynchronously — we just don't block the agent on it.
- Added `SetEditorValueFn` type and constructor parameter to `WorkspaceTools`; updated `App.tsx` to pass `(content) => editorInstance?.setValue(content)`.
- New tests assert `setEditorValueFn` is called with the correct content in both tools.
- Updated `SPEC.md` with a "React State Synchronization for Agent Tools" section documenting the pattern and the rule for future tools.
- Added `docs/BLOG_ASYNC_TOOL_SYNC.md` with a detailed writeup of the problem, the general tool contract principle, and why the fix works.

## Test plan

- [x] Run `npm run test` — all 234 tests pass
- [x] Run `npm run build` — clean build, no type errors
- [x] Manually: ask agent to switch to a second document then immediately read it — content should reflect the new document
- [x] Manually: ask agent to create a new document then write to it — write should apply to the new empty document