### PR TITLE
fix: prevent new document from being deleted after tool creation

### DIFF
--- a/src/lib/WorkspacesContext.tsx
+++ b/src/lib/WorkspacesContext.tsx
@@ -232,17 +232,22 @@ export function WorkspacesProvider({
   };
 
   function mutateActiveWorkspace(fn: (data: WorkspaceData) => WorkspaceData) {
-    if (!activeWorkspaceId || !activeWorkspace) return;
-    const updated = fn(activeWorkspace);
-    setActiveWorkspace(updated);
-    saveWorkspaceData(activeWorkspaceId, updated);
+    if (!activeWorkspaceId) return;
+    setActiveWorkspace((prev) => {
+      if (!prev) return prev;
+      const updated = fn(prev);
+      saveWorkspaceData(activeWorkspaceId, updated);
+      return updated;
+    });
 
     const now = Date.now();
-    const newIndex = index.map((m) =>
-      m.id === activeWorkspaceId ? { ...m, updatedAt: now } : m,
-    );
-    setIndex(newIndex);
-    saveIndex(newIndex);
+    setIndex((prev) => {
+      const newIndex = prev.map((m) =>
+        m.id === activeWorkspaceId ? { ...m, updatedAt: now } : m,
+      );
+      saveIndex(newIndex);
+      return newIndex;
+    });
   }
 
   const addDocument = () => {


### PR DESCRIPTION
## Summary

- `mutateActiveWorkspace` used direct `setActiveWorkspace(value)` calls, so any mutation that ran from a stale closure (e.g. a debounced `onChange`) would overwrite the current React state with an old snapshot
- When `create_document` was approved, `editorInstance.setValue('')` triggered Monaco's `onChange` synchronously, starting a 500 ms debounce that captured the pre-creation workspace state
- 500 ms later the debounce fired `setActiveWorkspace(staleState)`, silently rolling back the workspace to before the new document existed — making it disappear from the list

**Fix:** switch `setActiveWorkspace` and `setIndex` to functional updaters (`prev => fn(prev)`) so every mutation always operates on the latest committed state, regardless of when or from which closure it was called.

## Test plan

- [x] Create a workspace, ask the agent to translate content into a new document (approveAll OFF)
- [x] Accept the "create document" action — verify the new document persists in the sidebar
- [x] Accept the subsequent `write` suggestion — verify the translated content is saved
- [x] Verify existing document CRUD (rename, delete, switch) still works correctly