### PR TITLE
feat: create_document with optional content + fix stale debounce corruption

### DIFF
--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -63,13 +63,19 @@ export function EditorPanel() {
   const prevDocIdRef = useRef<string | null>(activeDocument?.id ?? null);
   const updateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const decorationsRef = useRef<monaco.editor.IEditorDecorationsCollection | null>(null);
+  const decorationsRef =
+    useRef<monaco.editor.IEditorDecorationsCollection | null>(null);
   const [toolbarTop, setToolbarTop] = useState<number>(8);
-  const pendingSuggestion = suggestions.find((s) => s.status === "pending") ?? null;
+  const pendingSuggestion =
+    suggestions.find((s) => s.status === "pending") ?? null;
 
   useEffect(() => {
     if (activeDocument?.id !== prevDocIdRef.current) {
       prevDocIdRef.current = activeDocument?.id ?? null;
+      if (updateTimerRef.current) {
+        clearTimeout(updateTimerRef.current);
+        updateTimerRef.current = null;
+      }
       setLocalContent(activeDocument?.content || DEFAULT_CONTENT);
     }
   }, [activeDocument]);
@@ -110,7 +116,8 @@ export function EditorPanel() {
     const decorations = computeDiffDecorations(pendingSuggestion);
 
     if (!decorationsRef.current) {
-      decorationsRef.current = editorInstance.createDecorationsCollection(decorations);
+      decorationsRef.current =
+        editorInstance.createDecorationsCollection(decorations);
     } else {
       decorationsRef.current.set(decorations);
     }
@@ -128,8 +135,9 @@ export function EditorPanel() {
 
     const computeTop = () => {
       const lineTop =
-        editorInstance.getTopForLineNumber(pendingSuggestion.range.startLineNumber) -
-        editorInstance.getScrollTop();
+        editorInstance.getTopForLineNumber(
+          pendingSuggestion.range.startLineNumber,
+        ) - editorInstance.getScrollTop();
       setToolbarTop(Math.max(GAP, lineTop - TOOLBAR_HEIGHT - GAP));
     };
 
@@ -154,7 +162,9 @@ export function EditorPanel() {
       setSuggestions((prev) =>
         prev.map((s) => (s.id === id ? { ...s, status: "accepted" } : s)),
       );
-      suggestion.resolve("User accepted the edit. The document has been updated.");
+      suggestion.resolve(
+        "User accepted the edit. The document has been updated.",
+      );
     }
   };
 
@@ -247,7 +257,9 @@ export function EditorPanel() {
                 style={{ top: toolbarTop }}
               >
                 <div className="flex items-center gap-2 pointer-events-auto bg-background border rounded-lg px-3 py-1.5 shadow-md text-sm">
-                  <span className="text-muted-foreground text-xs mr-1">Proposed edit</span>
+                  <span className="text-muted-foreground text-xs mr-1">
+                    Proposed edit
+                  </span>
                   <button
                     onClick={() => handleAccept(pendingSuggestion.id)}
                     className="flex items-center gap-1 text-green-600 hover:text-green-700 font-medium"

--- a/src/lib/WorkspaceTools.test.ts
+++ b/src/lib/WorkspaceTools.test.ts
@@ -197,9 +197,12 @@ describe("WorkspaceTools", () => {
       SetPendingWorkspaceActionFn;
 
     beforeEach(() => {
-      createDocumentFn = vi.fn().mockReturnValue("new-doc-id") as unknown as typeof createDocumentFn;
+      createDocumentFn = vi
+        .fn()
+        .mockReturnValue("new-doc-id") as unknown as typeof createDocumentFn;
       setEditorValueFn = vi.fn() as unknown as typeof setEditorValueFn;
-      setPendingWorkspaceAction = vi.fn() as unknown as typeof setPendingWorkspaceAction;
+      setPendingWorkspaceAction =
+        vi.fn() as unknown as typeof setPendingWorkspaceAction;
     });
 
     function makeTools(approveAll = false) {
@@ -261,6 +264,85 @@ describe("WorkspaceTools", () => {
       expect(await promise).toBe("Action rejected by user.");
       expect(createDocumentFn).not.toHaveBeenCalled();
     });
+
+    it("sets editor to provided content and saves it when approveAll is true", async () => {
+      const saveDocContentFn = vi.fn();
+      const tools = new WorkspaceTools(
+        makeRef([]),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+        createDocumentFn,
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        saveDocContentFn,
+        vi.fn().mockReturnValue(""),
+        setEditorValueFn,
+        setPendingWorkspaceAction,
+        true,
+      );
+      await tools.create_document({ title: "My Doc", content: "Hello world" });
+      expect(setEditorValueFn).toHaveBeenCalledWith("Hello world");
+      expect(saveDocContentFn).toHaveBeenCalledWith(
+        "new-doc-id",
+        "Hello world",
+      );
+    });
+
+    it("uses empty string for editor when no content provided", async () => {
+      const saveDocContentFn = vi.fn();
+      const tools = new WorkspaceTools(
+        makeRef([]),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+        createDocumentFn,
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        saveDocContentFn,
+        vi.fn().mockReturnValue(""),
+        setEditorValueFn,
+        setPendingWorkspaceAction,
+        true,
+      );
+      await tools.create_document({ title: "My Doc" });
+      expect(setEditorValueFn).toHaveBeenCalledWith("");
+      expect(saveDocContentFn).not.toHaveBeenCalledWith(
+        "new-doc-id",
+        expect.anything(),
+      );
+    });
+
+    it("applies content via pending action when approveAll is false", async () => {
+      const saveDocContentFn = vi.fn();
+      const tools = new WorkspaceTools(
+        makeRef([]),
+        noActiveDoc,
+        adapterFactory,
+        runnerFactory,
+        createDocumentFn,
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        saveDocContentFn,
+        vi.fn().mockReturnValue(""),
+        setEditorValueFn,
+        setPendingWorkspaceAction,
+        false,
+      );
+      const promise = tools.create_document({
+        title: "Draft",
+        content: "Body text",
+      });
+      const request = setPendingWorkspaceAction.mock.calls[0][0];
+      request.apply();
+      expect(setEditorValueFn).toHaveBeenCalledWith("Body text");
+      expect(saveDocContentFn).toHaveBeenCalledWith("new-doc-id", "Body text");
+      request.resolve("Action applied successfully.");
+      expect(await promise).toBe("Action applied successfully.");
+    });
   });
 
   describe("rename_document", () => {
@@ -270,7 +352,8 @@ describe("WorkspaceTools", () => {
 
     beforeEach(() => {
       renameDocumentFn = vi.fn() as unknown as typeof renameDocumentFn;
-      setPendingWorkspaceAction = vi.fn() as unknown as typeof setPendingWorkspaceAction;
+      setPendingWorkspaceAction =
+        vi.fn() as unknown as typeof setPendingWorkspaceAction;
     });
 
     function makeTools(docs: WorkspaceDocument[], approveAll = false) {
@@ -344,7 +427,8 @@ describe("WorkspaceTools", () => {
 
     beforeEach(() => {
       deleteDocumentFn = vi.fn() as unknown as typeof deleteDocumentFn;
-      setPendingWorkspaceAction = vi.fn() as unknown as typeof setPendingWorkspaceAction;
+      setPendingWorkspaceAction =
+        vi.fn() as unknown as typeof setPendingWorkspaceAction;
     });
 
     function makeTools(docs: WorkspaceDocument[], approveAll = false) {
@@ -407,9 +491,14 @@ describe("WorkspaceTools", () => {
     let setEditorValueFn: ReturnType<typeof vi.fn> & SetEditorValueFn;
 
     beforeEach(() => {
-      setActiveDocumentIdFn = vi.fn() as unknown as typeof setActiveDocumentIdFn;
+      setActiveDocumentIdFn =
+        vi.fn() as unknown as typeof setActiveDocumentIdFn;
       saveDocContentFn = vi.fn() as unknown as typeof saveDocContentFn;
-      getEditorContent = vi.fn().mockReturnValue("editor content") as unknown as typeof getEditorContent;
+      getEditorContent = vi
+        .fn()
+        .mockReturnValue(
+          "editor content",
+        ) as unknown as typeof getEditorContent;
       setEditorValueFn = vi.fn() as unknown as typeof setEditorValueFn;
     });
 
@@ -468,7 +557,9 @@ describe("WorkspaceTools", () => {
     });
 
     it("syncs editor value to new document content immediately", async () => {
-      const docs = [makeDoc({ id: "d1", title: "Doc 1", content: "new content" })];
+      const docs = [
+        makeDoc({ id: "d1", title: "Doc 1", content: "new content" }),
+      ];
       const tools = makeTools(docs);
       await tools.switch_active_document({ id: "d1" });
       expect(setEditorValueFn).toHaveBeenCalledWith("new content");

--- a/src/lib/WorkspaceTools.ts
+++ b/src/lib/WorkspaceTools.ts
@@ -93,7 +93,13 @@ export class WorkspaceTools {
     return JSON.stringify({ summary: result.output });
   }
 
-  create_document({ title }: { title: string }): Promise<string> {
+  create_document({
+    title,
+    content,
+  }: {
+    title: string;
+    content?: string;
+  }): Promise<string> {
     if (!title?.trim()) {
       return Promise.resolve(JSON.stringify({ error: "title is required" }));
     }
@@ -104,10 +110,14 @@ export class WorkspaceTools {
         if (currentDoc) {
           this.saveDocContentFn(currentDoc.id, this.getEditorContent());
         }
-        this.createDocumentFn(title);
-        // Immediately clear Monaco so subsequent reads see the new empty doc
+        const newId = this.createDocumentFn(title);
+        const initialContent = content ?? "";
+        // Immediately sync Monaco so subsequent reads see the correct content
         // before React's async re-render cycle completes.
-        this.setEditorValueFn("");
+        this.setEditorValueFn(initialContent);
+        if (content && newId) {
+          this.saveDocContentFn(newId, content);
+        }
       },
       `Document "${title}" created automatically (Approve All is ON).`,
     );
@@ -276,7 +286,7 @@ export function registerWorkspaceTools(
     definition: () => ({
       name: "create_document",
       description:
-        "Creates a new blank document in the workspace with the given title. Pauses for user authorization before creating.",
+        "Creates a new document in the workspace with the given title and optional initial content. Providing content avoids a separate write step. Pauses for user authorization before creating.",
       parameters: {
         type: "object",
         properties: {
@@ -284,11 +294,17 @@ export function registerWorkspaceTools(
             type: "string",
             description: "The title for the new document.",
           },
+          content: {
+            type: "string",
+            description:
+              "Optional initial content for the new document. If omitted the document is created blank.",
+          },
         },
         required: ["title"],
       },
     }),
-    call: async (args: { title: string }) => tools.create_document(args),
+    call: async (args: { title: string; content?: string }) =>
+      tools.create_document(args),
   });
 
   registry.register({


### PR DESCRIPTION
## Summary

- `create_document` now accepts an optional `content` parameter, letting the agent populate a new document in a single approved action instead of requiring a separate `write` step
- Fixed a race condition where calling `editorInstance.setValue()` inside the workspace action closure (before React re-renders) caused Monaco's `onChange` to fire with the old `activeDocument` still in scope — the debounce timer would then persist the new content to the **original** document's id. The fix cancels any pending debounce timer in `EditorPanel` whenever the active document changes.

## Test plan

- [ ] Ask the agent to translate a document and save it to a new document — confirm original document is unchanged and new document contains the translation
- [ ] Ask the agent to create a new blank document — confirm original is unchanged and new document is empty
- [ ] Verify all 237 existing tests pass (`npm run test`)