### PR TITLE
fix: textarea always occupies full row below mention chips

### DIFF
--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -558,7 +558,7 @@ export function ChatSidebar({ conversation, onBeforeSend }: ChatSidebarProps) {
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
               disabled={isLoading}
-              className="flex-1 min-w-0 bg-transparent outline-none text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 resize-none overflow-hidden"
+              className="w-full min-w-0 bg-transparent outline-none text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 resize-none overflow-hidden"
               aria-label="Chat input"
             />
           </div>


### PR DESCRIPTION
## Summary

- Fixes #52
- Changed `flex-1` to `w-full` on the `<textarea>` in the compound chat input so it always breaks onto its own row in the `flex flex-wrap` container, regardless of how many mention chips are present.

## Test plan

- [ ] Type `@` in the chat sidebar, select a document, then continue typing — textarea should span full width below the chips
- [ ] Verify chips still render correctly and the remove button works
- [ ] Verify the input works normally when no chips are present