### PR TITLE
fix: prevent conversation reset on every message

### DIFF
--- a/docs/CONVERSATION_RESET_AND_STORE_REFACTOR.md
+++ b/docs/CONVERSATION_RESET_AND_STORE_REFACTOR.md
@@ -1,0 +1,146 @@
+# Conversation Reset Bug & Store Decoupling Plan
+
+## Problem
+
+The main agent conversation resets to a blank slate on every message (and even on every
+keystroke). The agent has no memory of what was said earlier in the session.
+
+### Root Cause — Cascade Recreation
+
+The bug is a chain of `useMemo` dependencies in `App.tsx`:
+
+```
+editorContent (changes on every keystroke)
+  → editorTools (useMemo dep: editorContent)
+      → runner   (useMemo dep: editorTools)
+          → conversation (useMemo dep: runner)
+```
+
+1. **`editorTools`** lists `editorContent` and `activeTab` as `useMemo` dependencies.
+   Those values are only read inside tool call callbacks, not at memo creation time, so
+   they don't need to be deps — but as reactive state they trigger a full recreation on
+   every keystroke.
+
+2. **`runner`** lists `editorTools` as a dep. When `editorTools` is replaced, `runner`
+   is replaced.
+
+3. **`conversation`** lists `runner` and `activeWorkspaceId` as deps. When `runner` is
+   replaced the `Conversation` object is discarded and a new one is created, erasing all
+   history. The `activeWorkspaceId` dep means switching workspaces also resets history.
+
+### Secondary Cause — Monolithic Store
+
+`store.tsx` puts all application state into a single React context:
+
+| State slice                                                                         | Change frequency       |
+| ----------------------------------------------------------------------------------- | ---------------------- |
+| `editorInstance`                                                                    | Once (editor mounts)   |
+| `apiKey`, `modelName`, `skills`                                                     | Rarely (user settings) |
+| `editorContent`                                                                     | Every keystroke        |
+| `activeTab`                                                                         | On tab switch          |
+| `suggestions`, `pendingTabSwitchRequest`, `pendingWorkspaceAction`, `workflowState` | Per agent turn         |
+| `approveAll`, `totalTokens`                                                         | Occasionally           |
+
+Every keystroke triggers a re-render of every consumer of `useApp()`. More critically,
+anything in this single context can accidentally land in a `useMemo` dependency array and
+cause expensive object recreation.
+
+---
+
+## Fixes
+
+### Fix 1 — Pass Ref Objects to Tools Instead of Getter Closures
+
+`editorContent`, `activeTab`, `editorInstance`, and `approveAll` are only read inside
+`EditorTools` and `WorkspaceTools` callbacks — they are never needed at memo creation
+time. The naive fix is to create getter closures `() => ref.current` inside `useMemo`,
+but the `react-hooks/refs` ESLint rule flags any `.current` access in render-phase code
+(including inside arrow functions defined in `useMemo`), because the linter can't tell
+the difference between reading a ref _during_ render vs. creating a closure that _will_
+read it later.
+
+**The correct approach**: change `EditorTools` and `WorkspaceTools` constructors to
+accept ref-like objects (`{ current: X }`) directly. Class methods read `.current` when
+they execute — in tool call handlers, well outside the React render phase — which the
+linter permits.
+
+```typescript
+// EditorTools constructor (before → after)
+// Before: getEditor: () => editor | null
+// After:  editorRef: { current: editor | null }
+
+// In App.tsx — no .current access during render:
+const editorTools = useMemo(
+  () =>
+    new EditorTools(
+      editorInstanceRef, // the ref object itself
+      setSuggestions,
+      approveAllRef,
+      editorContentRef,
+      activeTabRef,
+      requestTabSwitchFn,
+    ),
+  [setSuggestions, requestTabSwitchFn],
+);
+```
+
+The same pattern applies to `WorkspaceTools`. Because `getEditorContent` and
+`setEditorValueFn` were getter/setter pairs that both needed the editor instance, they
+are replaced by a single `editorRef` (plus a `editorContentRef` fallback):
+
+```typescript
+// WorkspaceTools constructor (before → after)
+// Before: getEditorContent: () => string, setEditorValueFn: (v: string) => void
+// After:  editorRef: { current: { getValue(): string; setValue(v: string): void } | null }
+//         editorContentRef: { current: string }
+```
+
+**Files changed:** `EditorTools.ts`, `WorkspaceTools.ts`, `App.tsx`, all related test
+files.
+
+### Fix 2 — Stabilize the `conversation` Object
+
+Remove `activeWorkspaceId` from the `conversation` `useMemo` dependencies. The
+conversation should survive workspace switches — workspace context reaches the agent
+through tool results and system-prompt text, not through conversation identity.
+
+If a workspace switch must reset the conversation, do it explicitly (e.g., call a
+`reset()` method or recreate on a button press) rather than implicitly via a dep.
+
+### Fix 3 — Split the Store
+
+Divide `AppContext` into two separate contexts by change frequency:
+
+**`AgentConfigContext`** — changes infrequently; triggers `runner`/`conversation`
+recreation only when truly necessary:
+
+- `apiKey`, `setApiKey`
+- `modelName`, `setModelName`
+- `skills`, `setSkills`
+- `totalTokens`, `setTotalTokens`
+
+**`EditorUIContext`** — high-frequency UI state that should never appear in agent
+construction deps:
+
+- `editorInstance`, `setEditorInstance`
+- `editorContent`, `setEditorContent`
+- `activeTab`, `setActiveTab`
+- `suggestions`, `setSuggestions`
+- `pendingTabSwitchRequest`, `setPendingTabSwitchRequest`
+- `pendingWorkspaceAction`, `setPendingWorkspaceAction`
+- `approveAll`, `setApproveAll`
+- `workflowState`, `setWorkflowState`
+
+A combined `useApp()` hook (merging both contexts) is retained for backward
+compatibility. Components that only need one slice should use `useAgentConfig()` or
+`useEditorUI()` directly to avoid unnecessary re-renders.
+
+---
+
+## Implementation Order
+
+1. **Fix 2** — remove `activeWorkspaceId` from `conversation` deps. One-liner.
+2. **Fix 1** — change `EditorTools`/`WorkspaceTools` constructors to accept ref objects;
+   update `App.tsx` to pass refs directly. Breaks the cascade and fixes the reset bug.
+3. **Fix 3** — split the store. More invasive but structurally enforces the invariant
+   that agent construction deps never include high-frequency UI state.

--- a/docs/multi-agent/PHASE-B.md
+++ b/docs/multi-agent/PHASE-B.md
@@ -1,0 +1,213 @@
+# Phase B: Tool Registry Refactor
+
+## Goal
+
+Enforce the write access policy in code. All sub-agent creation sites use named registry builders; `delegate_to_skill` returns `ProposedEdit[]` instead of calling `edit`/`write` directly. No user-visible features — purely infrastructure.
+
+---
+
+## Context
+
+Phase A delivered:
+
+- `AgentRunnerFactory` + `DefaultAgentRunnerFactory`
+- `DelegationTools.ts` with `invoke_agent` — sub-agents receive `"workspace_readonly"` tool group
+- `delegate_to_skill` in `EditorTools.ts` — currently gives skills a **full read+write** registry (includes `edit`, `write`, `create_document`, `switch_active_document`)
+
+The problem: skills can call `edit`/`write` directly, bypassing the Orchestrator's approval workflow context, and concurrent sub-agents could race on document state. Phase B fixes this structurally.
+
+---
+
+## What changes
+
+### 1. `src/lib/tools/EditorTools.ts` — add `registerReadonlyEditorTools`
+
+`registerEditorTools` registers all tools including `edit`, `write`, `request_switch_to_editor`. There is no read-only variant yet. Add one, following the same pattern as `registerReadonlyWorkspaceTools` in `WorkspaceTools.ts`:
+
+```ts
+export function registerReadonlyEditorTools(
+  registry: ToolRegistry,
+  tools: EditorTools,
+): void;
+```
+
+Registers only: `read`, `read_selection`, `search`, `get_metadata`, `get_current_mode`. Does **not** register `edit`, `write`, or `request_switch_to_editor`.
+
+---
+
+### 2. `src/lib/tools/registries.ts` (new file)
+
+Export the `ProposedEdit` interface, two named registry builder functions, and nothing else:
+
+```ts
+// Apache-2.0 license header required (all source files in this project carry it)
+
+export interface ProposedEdit {
+  originalText: string;
+  replacementText: string;
+  reason?: string;
+}
+
+export function buildReadonlyRegistry(
+  editorTools: EditorTools,
+  workspaceTools: WorkspaceTools,
+): ToolRegistry;
+
+export function buildReadWriteRegistry(
+  editorTools: EditorTools,
+  workspaceTools: WorkspaceTools,
+): ToolRegistry;
+```
+
+**`buildReadonlyRegistry`** calls `registerReadonlyEditorTools` (new, see above) and `registerReadonlyWorkspaceTools`. Read-only tool names: `read`, `read_selection`, `search`, `get_metadata`, `get_current_mode`, `get_active_doc_info`, `list_workspace_docs`, `read_workspace_doc`, `query_workspace_doc`, `query_workspace`.
+
+**`buildReadWriteRegistry`** calls `registerEditorTools` (all tools including `edit`, `write`, `request_switch_to_editor`) and `registerWorkspaceTools` (all tools including `create_document`, `rename_document`, `delete_document`, `switch_active_document`).
+
+Note on `switch_active_document`: it mutates editor state (changes active doc, calls `setEditorValueFn`) without user approval. It belongs in the write registry despite not going through `applyWorkspaceAction`.
+
+---
+
+### 3. `src/lib/tools/EditorTools.ts` — update `createDelegateToSkillHandler`
+
+- Replace the inline `childRegistry` construction (currently calls `registerEditorTools` giving skills full write access) with `buildReadonlyRegistry(editorTools, workspaceTools)`. The `workspaceTools` parameter becomes non-nullable (drop the `= null` default).
+- Inject the output format instruction into `agentConfig.instructions`. Currently the code sets `instructions: skill.instructions`; change it to:
+
+  ```ts
+  const outputFormat =
+    "\n\nOUTPUT FORMAT: Respond only with a JSON array of ProposedEdit objects:\n" +
+    '[{ "originalText": "...", "replacementText": "...", "reason": "..." }]\n' +
+    "If no changes are needed, return an empty array: []";
+
+  const agentConfig: AgentConfig = {
+    name: skill.name,
+    instructions: skill.instructions + outputFormat,
+    tools: [...readonlyToolNames],
+  };
+  ```
+
+- The handler parses the skill's `done` event output as `ProposedEdit[]` and returns it as a JSON string. On parse failure, return an error string (e.g. `"Error: skill returned non-JSON response: ..."`).
+
+- `ProposedEdit` is imported from `./registries` (not redeclared here).
+
+---
+
+### 4. `src/lib/tools/DelegationTools.ts`
+
+**`buildRegistryForGroups`** is replaced by a call to `buildReadonlyRegistry`. The `"workspace_readonly"` string group remains supported for the `invoke_agent` API, but internally it now always routes through `buildReadonlyRegistry`.
+
+`workspaceTools` is non-nullable here too — `registerDelegationTools` is always called with a real `WorkspaceTools` instance (see App.tsx). Drop the `| null` from its signature. Since `_editorTools` is currently unused (prefixed with `_`), pass it through to `buildReadonlyRegistry` so editor read tools are also available to `invoke_agent` sub-agents when needed in future phases. For now, only include them if an `"editor_readonly"` group is requested — keep the current behaviour for the existing test suite.
+
+---
+
+### 5. `src/App.tsx` — wire `buildReadWriteRegistry` and update `delegate_to_skill` description
+
+Two changes in the `useMemo` that builds the runner (around line 390–428):
+
+1. **Replace inline registry construction** with `buildReadWriteRegistry`:
+
+   ```ts
+   // Before:
+   const registry = new ToolRegistry();
+   registerEditorTools(registry, editorTools);
+   registerWorkspaceTools(registry, workspaceTools);
+
+   // After:
+   const registry = buildReadWriteRegistry(editorTools, workspaceTools);
+   ```
+
+   `workspaceTools` is always a `WorkspaceTools` instance at this call site (constructed unconditionally in its own `useMemo`). `addAllBuiltInAITools`, `registerDelegationTools`, and the `delegate_to_skill` registration are appended to this registry after construction, unchanged.
+
+2. **Update `delegate_to_skill` tool description** — currently says "The skill runs with its own instructions and can read and edit the document." Change to: "The skill runs with read-only access and returns a JSON array of ProposedEdit objects for the Orchestrator to apply."
+
+---
+
+### 6. `src/lib/agents/orchestrator.ts`
+
+Extend `BASE_INSTRUCTIONS` to describe how `delegate_to_skill` results should be applied:
+
+```
+delegate_to_skill returns a JSON array of ProposedEdit objects. Apply each edit via your own edit() call so the user sees and approves each change.
+```
+
+---
+
+## Files modified
+
+| File                               | Change                                                                                                                                                                                              |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/tools/EditorTools.ts`     | Add `registerReadonlyEditorTools`; update `createDelegateToSkillHandler` to use `buildReadonlyRegistry`, inject output format into `agentConfig.instructions`, parse `ProposedEdit[]` from response |
+| `src/lib/tools/DelegationTools.ts` | Replace `buildRegistryForGroups` body with `buildReadonlyRegistry` call                                                                                                                             |
+| `src/lib/agents/orchestrator.ts`   | Extend `BASE_INSTRUCTIONS` with `delegate_to_skill` result-application instruction                                                                                                                  |
+| `src/App.tsx`                      | Replace inline registry build with `buildReadWriteRegistry`; update `delegate_to_skill` tool description                                                                                            |
+
+## Files created
+
+| File                          | Purpose                                                                   |
+| ----------------------------- | ------------------------------------------------------------------------- |
+| `src/lib/tools/registries.ts` | Exports `ProposedEdit`, `buildReadonlyRegistry`, `buildReadWriteRegistry` |
+
+---
+
+## Tests
+
+All tests live in `src/lib/tools/registries.test.ts` (new) and updates to `src/lib/tools/EditorTools.test.ts`.
+
+### `registries.test.ts`
+
+```
+buildReadonlyRegistry
+  ✓ includes read, read_selection, search, get_metadata, get_current_mode
+  ✓ excludes edit, write, request_switch_to_editor
+  ✓ includes workspace read tools (get_active_doc_info, list_workspace_docs, read_workspace_doc, query_workspace_doc, query_workspace)
+  ✓ excludes workspace write tools (create_document, rename_document, delete_document, switch_active_document)
+
+buildReadWriteRegistry
+  ✓ includes all read-only tools
+  ✓ includes edit, write, request_switch_to_editor
+  ✓ includes workspace write tools (create_document, rename_document, delete_document, switch_active_document)
+```
+
+### `EditorTools.test.ts` additions
+
+```
+createDelegateToSkillHandler (Phase B)
+  ✓ gives skill a read-only registry (no edit, no write tool registered)
+  ✓ wraps skill instructions with ProposedEdit JSON output format requirement
+  ✓ returns JSON-serialised ProposedEdit[] parsed from skill's final response
+  ✓ returns empty array when skill returns []
+  ✓ returns error string when skill final response is not valid JSON
+```
+
+### `DelegationTools.test.ts` additions
+
+```
+invoke_agent (Phase B)
+  ✓ existing tests still pass unchanged
+  ✓ workspace_readonly group yields only read workspace tools (no create_document etc.)
+```
+
+---
+
+## Step-by-step implementation order
+
+1. Add `registerReadonlyEditorTools` to `src/lib/tools/EditorTools.ts`.
+2. Create `src/lib/tools/registries.ts` — export `ProposedEdit`, `buildReadonlyRegistry`, `buildReadWriteRegistry`.
+3. Write `src/lib/tools/registries.test.ts` — run tests, confirm they pass.
+4. Update `createDelegateToSkillHandler` in `EditorTools.ts` — use `buildReadonlyRegistry`, inject output format into `agentConfig.instructions`, parse `ProposedEdit[]` from response, import `ProposedEdit` from `./registries`.
+5. Update `EditorTools.test.ts` with Phase B cases — run tests.
+6. Update `DelegationTools.ts` — replace `buildRegistryForGroups` body with `buildReadonlyRegistry` call.
+7. Update `DelegationTools.test.ts` — add workspace write-tool exclusion assertion.
+8. Update `orchestrator.ts` — extend `BASE_INSTRUCTIONS`.
+9. Update `App.tsx` — replace inline `new ToolRegistry()` + `registerEditorTools` + `registerWorkspaceTools` with `buildReadWriteRegistry`; update `delegate_to_skill` description.
+10. Run `npm run lint && npm run format && npm run test` — all green.
+
+---
+
+## Working state
+
+After Phase B:
+
+- Skills are structurally read-only. No code path can give a skill `edit` or `write`.
+- `delegate_to_skill` returns `ProposedEdit[]`; the Orchestrator applies each via `edit()`, preserving the approval workflow.
+- `invoke_agent` sub-agents remain read-only via `buildReadonlyRegistry`.
+- The Orchestrator remains the sole writer, making Phase G's parallel fan-out safe by construction.

--- a/docs/multi-agent/PLAN.md
+++ b/docs/multi-agent/PLAN.md
@@ -67,19 +67,27 @@ class AgentRunner {
 
 // Passed to runBuilder / run to configure a single agent invocation
 interface AgentConfig {
-  name: string;           // identifies the agent in events (agentRole)
-  instructions: string;  // system prompt for this invocation
-  tools: string[];        // names of tools from the registry to expose
+  name: string; // identifies the agent in events (agentRole)
+  instructions: string; // system prompt for this invocation
+  tools: string[]; // names of tools from the registry to expose
 }
 
 // Register a tool with an object form (definition factory + async call handler)
 class ToolRegistry {
   register(tool: {
-    definition: () => { name: string; description: string; parameters: JsonSchema };
+    definition: () => {
+      name: string;
+      description: string;
+      parameters: JsonSchema;
+    };
     call: (args: unknown, context: ToolContext) => Promise<string>;
   }): void;
 
-  definitions(): Array<{ name: string; description: string; parameters: JsonSchema }>;
+  definitions(): Array<{
+    name: string;
+    description: string;
+    parameters: JsonSchema;
+  }>;
 }
 
 interface ToolContext {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import {
   PanelRightOpen,
   LayoutGrid,
 } from "lucide-react";
-import { useApp } from "@/lib/store";
+import { useAgentConfig, useEditorUI } from "@/lib/store";
 import { useWorkspaces } from "@/lib/WorkspacesContext";
 import {
   Dialog,
@@ -284,21 +284,18 @@ function App() {
     deleteDocument,
     setActiveDocumentId,
   } = useWorkspaces();
+  const { apiKey, setApiKey, modelName, setTotalTokens, skills } =
+    useAgentConfig();
   const {
-    apiKey,
-    setApiKey,
-    modelName,
-    setTotalTokens,
     editorInstance,
     setSuggestions,
     approveAll,
-    skills,
     activeTab,
     editorContent,
     setPendingTabSwitchRequest,
     pendingWorkspaceAction,
     setPendingWorkspaceAction,
-  } = useApp();
+  } = useEditorUI();
   const [tempKey, setTempKey] = useState("");
   const [showKeyDialog, setShowKeyDialog] = useState(!apiKey);
 
@@ -318,27 +315,45 @@ function App() {
       : null;
   }, [activeDocument]);
 
+  const editorInstanceRef = useRef(editorInstance);
+  useEffect(() => {
+    editorInstanceRef.current = editorInstance;
+  }, [editorInstance]);
+
+  const editorContentRef = useRef(editorContent);
+  useEffect(() => {
+    editorContentRef.current = editorContent;
+  }, [editorContent]);
+
+  const activeTabRef = useRef(activeTab);
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab]);
+
+  const approveAllRef = useRef(approveAll);
+  useEffect(() => {
+    approveAllRef.current = approveAll;
+  }, [approveAll]);
+
+  const requestTabSwitch = useCallback(
+    () =>
+      new Promise<boolean>((resolve) => {
+        setPendingTabSwitchRequest({ resolve });
+      }),
+    [setPendingTabSwitchRequest],
+  );
+
   const editorTools = useMemo(
     () =>
       new EditorTools(
-        editorInstance,
+        editorInstanceRef,
         setSuggestions,
-        approveAll,
-        () => editorContent,
-        () => activeTab,
-        () =>
-          new Promise<boolean>((resolve) => {
-            setPendingTabSwitchRequest({ resolve });
-          }),
+        approveAllRef,
+        editorContentRef,
+        activeTabRef,
+        requestTabSwitch,
       ),
-    [
-      editorInstance,
-      setSuggestions,
-      approveAll,
-      editorContent,
-      activeTab,
-      setPendingTabSwitchRequest,
-    ],
+    [setSuggestions, requestTabSwitch],
   );
 
   const factory = useMemo(
@@ -362,10 +377,10 @@ function App() {
         (id) => deleteDocument(id),
         (id) => setActiveDocumentId(id),
         (id, content) => updateDocument(id, { content }),
-        () => editorInstance?.getValue() ?? editorContent,
-        (content) => editorInstance?.setValue(content),
+        editorInstanceRef,
+        editorContentRef,
         setPendingWorkspaceAction,
-        approveAll,
+        approveAllRef,
       ),
     [
       docsRef,
@@ -375,10 +390,7 @@ function App() {
       updateDocument,
       deleteDocument,
       setActiveDocumentId,
-      editorInstance,
-      editorContent,
       setPendingWorkspaceAction,
-      approveAll,
     ],
   );
 
@@ -434,7 +446,7 @@ function App() {
       instructions: buildOrchestratorPrompt(skills),
     };
     return runner.conversation(agent);
-  }, [runner, skills, activeWorkspaceId]);
+  }, [runner, skills]);
 
   const isMobile = useIsMobile();
 

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -7,7 +7,7 @@ import { Switch } from "./ui/switch";
 import { Label } from "./ui/label";
 import { Conversation } from "@mast-ai/core";
 import { Settings, Wand2, Sun, Moon, X } from "lucide-react";
-import { useApp } from "@/lib/store";
+import { useEditorUI } from "@/lib/store";
 import { useTheme } from "@/lib/ThemeProvider";
 import { useWorkspaces } from "@/lib/WorkspacesContext";
 import { SettingsDialog } from "./SettingsDialog";
@@ -43,7 +43,7 @@ export function ChatSidebar({ conversation, onBeforeSend }: ChatSidebarProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [skillsOpen, setSkillsOpen] = useState(false);
-  const { approveAll, setApproveAll } = useApp();
+  const { approveAll, setApproveAll } = useEditorUI();
   const { theme, toggleTheme } = useTheme();
   const { activeWorkspace } = useWorkspaces();
 

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { MarkdownContent } from "./MarkdownContent";
-import { useApp } from "@/lib/store";
+import { useEditorUI } from "@/lib/store";
 import { useTheme } from "@/lib/ThemeProvider";
 import { useWorkspaces } from "@/lib/WorkspacesContext";
 import { computeDiffDecorations } from "@/lib/diffDecorations";
@@ -33,7 +33,7 @@ export function EditorPanel() {
     setEditorContent,
     pendingTabSwitchRequest,
     setPendingTabSwitchRequest,
-  } = useApp();
+  } = useEditorUI();
   const { activeDocument, updateDocument } = useWorkspaces();
 
   const { theme } = useTheme();

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -13,31 +13,15 @@ const mockSetApiKey = vi.fn();
 const mockSetModelName = vi.fn();
 
 function mockStore(apiKey: string | null, modelName: string) {
-  vi.spyOn(storeModule, "useApp").mockReturnValue({
+  vi.spyOn(storeModule, "useAgentConfig").mockReturnValue({
     apiKey,
     setApiKey: mockSetApiKey,
     modelName,
     setModelName: mockSetModelName,
     totalTokens: 0,
     setTotalTokens: vi.fn(),
-    suggestions: [],
-    setSuggestions: vi.fn(),
-    editorInstance: null,
-    setEditorInstance: vi.fn(),
-    activeTab: "editor",
-    setActiveTab: vi.fn(),
-    editorContent: "",
-    setEditorContent: vi.fn(),
-    pendingTabSwitchRequest: null,
-    setPendingTabSwitchRequest: vi.fn(),
-    pendingWorkspaceAction: null,
-    setPendingWorkspaceAction: vi.fn(),
-    approveAll: false,
-    setApproveAll: vi.fn(),
     skills: [],
     setSkills: vi.fn(),
-    workflowState: null,
-    setWorkflowState: vi.fn(),
   });
 }
 

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useApp } from "@/lib/store";
+import { useAgentConfig } from "@/lib/store";
 
 const MODELS = [
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
@@ -38,7 +38,7 @@ function SettingsForm({
 }: {
   onOpenChange: (open: boolean) => void;
 }) {
-  const { apiKey, setApiKey, modelName, setModelName } = useApp();
+  const { apiKey, setApiKey, modelName, setModelName } = useAgentConfig();
   const { theme: currentTheme, setTheme } = useTheme();
   const [draftKey, setDraftKey] = useState(apiKey ?? "");
   const [draftModel, setDraftModel] = useState(modelName);

--- a/src/components/SkillsDialog.test.tsx
+++ b/src/components/SkillsDialog.test.tsx
@@ -21,31 +21,15 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
 }
 
 function mockStore(skills: Skill[]) {
-  vi.spyOn(storeModule, "useApp").mockReturnValue({
+  vi.spyOn(storeModule, "useAgentConfig").mockReturnValue({
     apiKey: "test-key",
     setApiKey: vi.fn(),
     modelName: "gemini-2.5-flash",
     setModelName: vi.fn(),
     totalTokens: 0,
     setTotalTokens: vi.fn(),
-    suggestions: [],
-    setSuggestions: vi.fn(),
-    editorInstance: null,
-    setEditorInstance: vi.fn(),
-    activeTab: "editor",
-    setActiveTab: vi.fn(),
-    editorContent: "",
-    setEditorContent: vi.fn(),
-    pendingTabSwitchRequest: null,
-    setPendingTabSwitchRequest: vi.fn(),
-    pendingWorkspaceAction: null,
-    setPendingWorkspaceAction: vi.fn(),
-    approveAll: false,
-    setApproveAll: vi.fn(),
     skills,
     setSkills: mockSetSkills,
-    workflowState: null,
-    setWorkflowState: vi.fn(),
   });
 }
 

--- a/src/components/SkillsDialog.tsx
+++ b/src/components/SkillsDialog.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useApp } from "@/lib/store";
+import { useAgentConfig } from "@/lib/store";
 import { Skill } from "@/lib/skills";
 import { Pencil, Trash2 } from "lucide-react";
 
@@ -32,7 +32,7 @@ function SkillsForm({
 }: {
   onOpenChange: (open: boolean) => void;
 }) {
-  const { skills, setSkills, modelName } = useApp();
+  const { skills, setSkills, modelName } = useAgentConfig();
   const [editState, setEditState] = useState<EditState | null>(null);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);

--- a/src/lib/WebMCPTools.test.ts
+++ b/src/lib/WebMCPTools.test.ts
@@ -23,7 +23,7 @@ function makeEditorTools(): EditorTools {
     }),
     getSelection: vi.fn().mockReturnValue(null),
   };
-  return new EditorTools(mockEditor, vi.fn(), false);
+  return new EditorTools({ current: mockEditor }, vi.fn(), { current: false });
 }
 
 function makeWorkspaceTools(): WorkspaceTools {

--- a/src/lib/WorkspacesContext.tsx
+++ b/src/lib/WorkspacesContext.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useState, useCallback } from "react";
 import { WorkspaceDocument, WorkspaceMeta, WorkspaceData } from "./workspace";
 
 const WORKSPACES_INDEX_KEY = "workspaces_index";
@@ -163,94 +163,106 @@ export function WorkspacesProvider({
       (d) => d.id === activeWorkspace.activeDocumentId,
     ) ?? null;
 
-  const createWorkspace = (name: string): WorkspaceMeta => {
-    const now = Date.now();
-    const meta: WorkspaceMeta = {
-      id: crypto.randomUUID(),
-      name,
-      createdAt: now,
-      updatedAt: now,
-    };
-    const untitled: WorkspaceDocument = {
-      id: crypto.randomUUID(),
-      title: "Untitled Document",
-      content: "",
-      updatedAt: now,
-    };
-    const data: WorkspaceData = {
-      documents: [untitled],
-      activeDocumentId: untitled.id,
-    };
+  const createWorkspace = useCallback(
+    (name: string): WorkspaceMeta => {
+      const now = Date.now();
+      const meta: WorkspaceMeta = {
+        id: crypto.randomUUID(),
+        name,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const untitled: WorkspaceDocument = {
+        id: crypto.randomUUID(),
+        title: "Untitled Document",
+        content: "",
+        updatedAt: now,
+      };
+      const data: WorkspaceData = {
+        documents: [untitled],
+        activeDocumentId: untitled.id,
+      };
 
-    const newIndex = [...index, meta];
-    setIndex(newIndex);
-    saveIndex(newIndex);
-    saveWorkspaceData(meta.id, data);
-    setActiveWorkspaceId(meta.id);
-    setActiveWorkspace(data);
-    localStorage.setItem(ACTIVE_WORKSPACE_KEY, meta.id);
-    return meta;
-  };
+      const newIndex = [...index, meta];
+      setIndex(newIndex);
+      saveIndex(newIndex);
+      saveWorkspaceData(meta.id, data);
+      setActiveWorkspaceId(meta.id);
+      setActiveWorkspace(data);
+      localStorage.setItem(ACTIVE_WORKSPACE_KEY, meta.id);
+      return meta;
+    },
+    [index],
+  );
 
-  const openWorkspace = (id: string) => {
+  const openWorkspace = useCallback((id: string) => {
     const data = loadWorkspaceData(id);
     setActiveWorkspaceId(id);
     setActiveWorkspace(data);
     localStorage.setItem(ACTIVE_WORKSPACE_KEY, id);
-  };
+  }, []);
 
-  const closeWorkspace = () => {
+  const closeWorkspace = useCallback(() => {
     setActiveWorkspaceId(null);
     setActiveWorkspace(null);
     localStorage.removeItem(ACTIVE_WORKSPACE_KEY);
-  };
+  }, []);
 
-  const renameWorkspace = (id: string, newName: string) => {
-    const newIndex = index.map((m) =>
-      m.id === id ? { ...m, name: newName, updatedAt: Date.now() } : m,
-    );
-    setIndex(newIndex);
-    saveIndex(newIndex);
-  };
-
-  const deleteWorkspace = (id: string) => {
-    const newIndex = index.filter((m) => m.id !== id);
-    setIndex(newIndex);
-    saveIndex(newIndex);
-    localStorage.removeItem(workspaceKey(id));
-
-    if (activeWorkspaceId === id) {
-      const next = newIndex[0] ?? null;
-      if (next) {
-        openWorkspace(next.id);
-      } else {
-        setActiveWorkspaceId(null);
-        setActiveWorkspace(null);
-        localStorage.removeItem(ACTIVE_WORKSPACE_KEY);
-      }
-    }
-  };
-
-  function mutateActiveWorkspace(fn: (data: WorkspaceData) => WorkspaceData) {
-    if (!activeWorkspaceId) return;
-    setActiveWorkspace((prev) => {
-      if (!prev) return prev;
-      const updated = fn(prev);
-      saveWorkspaceData(activeWorkspaceId, updated);
-      return updated;
-    });
-
-    const now = Date.now();
-    setIndex((prev) => {
-      const newIndex = prev.map((m) =>
-        m.id === activeWorkspaceId ? { ...m, updatedAt: now } : m,
+  const renameWorkspace = useCallback(
+    (id: string, newName: string) => {
+      const newIndex = index.map((m) =>
+        m.id === id ? { ...m, name: newName, updatedAt: Date.now() } : m,
       );
+      setIndex(newIndex);
       saveIndex(newIndex);
-      return newIndex;
-    });
-  }
+    },
+    [index],
+  );
 
-  const addDocument = () => {
+  const deleteWorkspace = useCallback(
+    (id: string) => {
+      const newIndex = index.filter((m) => m.id !== id);
+      setIndex(newIndex);
+      saveIndex(newIndex);
+      localStorage.removeItem(workspaceKey(id));
+
+      if (activeWorkspaceId === id) {
+        const next = newIndex[0] ?? null;
+        if (next) {
+          openWorkspace(next.id);
+        } else {
+          setActiveWorkspaceId(null);
+          setActiveWorkspace(null);
+          localStorage.removeItem(ACTIVE_WORKSPACE_KEY);
+        }
+      }
+    },
+    [index, activeWorkspaceId, openWorkspace],
+  );
+
+  const mutateActiveWorkspace = useCallback(
+    (fn: (data: WorkspaceData) => WorkspaceData) => {
+      if (!activeWorkspaceId) return;
+      setActiveWorkspace((prev) => {
+        if (!prev) return prev;
+        const updated = fn(prev);
+        saveWorkspaceData(activeWorkspaceId, updated);
+        return updated;
+      });
+
+      const now = Date.now();
+      setIndex((prev) => {
+        const newIndex = prev.map((m) =>
+          m.id === activeWorkspaceId ? { ...m, updatedAt: now } : m,
+        );
+        saveIndex(newIndex);
+        return newIndex;
+      });
+    },
+    [activeWorkspaceId],
+  );
+
+  const addDocument = useCallback(() => {
     const doc: WorkspaceDocument = {
       id: crypto.randomUUID(),
       title: "Untitled Document",
@@ -262,49 +274,61 @@ export function WorkspacesProvider({
       documents: [...data.documents, doc],
       activeDocumentId: doc.id,
     }));
-  };
+  }, [mutateActiveWorkspace]);
 
-  const createDocumentWithTitle = (title: string): string => {
-    const doc: WorkspaceDocument = {
-      id: crypto.randomUUID(),
-      title,
-      content: "",
-      updatedAt: Date.now(),
-    };
-    mutateActiveWorkspace((data) => ({
-      ...data,
-      documents: [...data.documents, doc],
-      activeDocumentId: doc.id,
-    }));
-    return doc.id;
-  };
+  const createDocumentWithTitle = useCallback(
+    (title: string): string => {
+      const doc: WorkspaceDocument = {
+        id: crypto.randomUUID(),
+        title,
+        content: "",
+        updatedAt: Date.now(),
+      };
+      mutateActiveWorkspace((data) => ({
+        ...data,
+        documents: [...data.documents, doc],
+        activeDocumentId: doc.id,
+      }));
+      return doc.id;
+    },
+    [mutateActiveWorkspace],
+  );
 
-  const updateDocument = (
-    id: string,
-    patch: Partial<Pick<WorkspaceDocument, "title" | "content">>,
-  ) => {
-    mutateActiveWorkspace((data) => ({
-      ...data,
-      documents: data.documents.map((d) =>
-        d.id === id ? { ...d, ...patch, updatedAt: Date.now() } : d,
-      ),
-    }));
-  };
+  const updateDocument = useCallback(
+    (
+      id: string,
+      patch: Partial<Pick<WorkspaceDocument, "title" | "content">>,
+    ) => {
+      mutateActiveWorkspace((data) => ({
+        ...data,
+        documents: data.documents.map((d) =>
+          d.id === id ? { ...d, ...patch, updatedAt: Date.now() } : d,
+        ),
+      }));
+    },
+    [mutateActiveWorkspace],
+  );
 
-  const deleteDocument = (id: string) => {
-    mutateActiveWorkspace((data) => {
-      const remaining = data.documents.filter((d) => d.id !== id);
-      let newActiveId = data.activeDocumentId;
-      if (newActiveId === id) {
-        newActiveId = remaining[0]?.id ?? null;
-      }
-      return { documents: remaining, activeDocumentId: newActiveId };
-    });
-  };
+  const deleteDocument = useCallback(
+    (id: string) => {
+      mutateActiveWorkspace((data) => {
+        const remaining = data.documents.filter((d) => d.id !== id);
+        let newActiveId = data.activeDocumentId;
+        if (newActiveId === id) {
+          newActiveId = remaining[0]?.id ?? null;
+        }
+        return { documents: remaining, activeDocumentId: newActiveId };
+      });
+    },
+    [mutateActiveWorkspace],
+  );
 
-  const setActiveDocumentId = (id: string) => {
-    mutateActiveWorkspace((data) => ({ ...data, activeDocumentId: id }));
-  };
+  const setActiveDocumentId = useCallback(
+    (id: string) => {
+      mutateActiveWorkspace((data) => ({ ...data, activeDocumentId: id }));
+    },
+    [mutateActiveWorkspace],
+  );
 
   return (
     <WorkspacesContext.Provider

--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -34,17 +34,26 @@ export interface WorkflowState {
   }>;
 }
 
-interface AppState {
+// --- Agent config context (slow-changing: API key, model, skills, token count) ---
+
+interface AgentConfigState {
   apiKey: string | null;
   setApiKey: (key: string | null) => void;
   modelName: string;
   setModelName: (name: string) => void;
   totalTokens: number;
   setTotalTokens: (tokens: number | ((prev: number) => number)) => void;
-  suggestions: Suggestion[];
-  setSuggestions: (
-    suggestions: Suggestion[] | ((prev: Suggestion[]) => Suggestion[]),
-  ) => void;
+  skills: Skill[];
+  setSkills: (skills: Skill[]) => void;
+}
+
+const AgentConfigContext = createContext<AgentConfigState | undefined>(
+  undefined,
+);
+
+// --- Editor UI context (fast-changing: editor state, suggestions, UI toggles) ---
+
+interface EditorUIState {
   editorInstance: monaco.editor.IStandaloneCodeEditor | null;
   setEditorInstance: (
     editor: monaco.editor.IStandaloneCodeEditor | null,
@@ -53,19 +62,27 @@ interface AppState {
   setActiveTab: (tab: "editor" | "preview") => void;
   editorContent: string;
   setEditorContent: (content: string) => void;
+  suggestions: Suggestion[];
+  setSuggestions: (
+    suggestions: Suggestion[] | ((prev: Suggestion[]) => Suggestion[]),
+  ) => void;
   pendingTabSwitchRequest: TabSwitchRequest | null;
   setPendingTabSwitchRequest: (req: TabSwitchRequest | null) => void;
   pendingWorkspaceAction: WorkspaceActionRequest | null;
   setPendingWorkspaceAction: (action: WorkspaceActionRequest | null) => void;
   approveAll: boolean;
   setApproveAll: (approve: boolean) => void;
-  skills: Skill[];
-  setSkills: (skills: Skill[]) => void;
   workflowState: WorkflowState | null;
   setWorkflowState: (state: WorkflowState | null) => void;
 }
 
-const AppContext = createContext<AppState | undefined>(undefined);
+const EditorUIContext = createContext<EditorUIState | undefined>(undefined);
+
+// --- Combined type (for useApp backward compat) ---
+
+interface AppState extends AgentConfigState, EditorUIState {}
+
+// --- Provider ---
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -79,6 +96,8 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
     return saved || "gemini-3.1-flash-lite-preview";
   });
   const [totalTokens, setTotalTokens] = useState<number>(0);
+  const [skills, setSkillsState] = useState<Skill[]>(() => initializeSkills());
+
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [editorInstance, setEditorInstance] =
     useState<monaco.editor.IStandaloneCodeEditor | null>(null);
@@ -89,7 +108,6 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
   const [pendingWorkspaceAction, setPendingWorkspaceAction] =
     useState<WorkspaceActionRequest | null>(null);
   const [approveAll, setApproveAll] = useState(false);
-  const [skills, setSkillsState] = useState<Skill[]>(() => initializeSkills());
   const [workflowState, setWorkflowState] = useState<WorkflowState | null>(
     null,
   );
@@ -111,44 +129,62 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
     localStorage.setItem("gemini_model_name", modelName);
   }, [modelName]);
 
+  const agentConfigValue: AgentConfigState = {
+    apiKey,
+    setApiKey,
+    modelName,
+    setModelName,
+    totalTokens,
+    setTotalTokens,
+    skills,
+    setSkills,
+  };
+
+  const editorUIValue: EditorUIState = {
+    editorInstance,
+    setEditorInstance,
+    activeTab,
+    setActiveTab,
+    editorContent,
+    setEditorContent,
+    suggestions,
+    setSuggestions,
+    pendingTabSwitchRequest,
+    setPendingTabSwitchRequest,
+    pendingWorkspaceAction,
+    setPendingWorkspaceAction,
+    approveAll,
+    setApproveAll,
+    workflowState,
+    setWorkflowState,
+  };
+
   return (
-    <AppContext.Provider
-      value={{
-        apiKey,
-        setApiKey,
-        modelName,
-        setModelName,
-        totalTokens,
-        setTotalTokens,
-        suggestions,
-        setSuggestions,
-        editorInstance,
-        setEditorInstance,
-        activeTab,
-        setActiveTab,
-        editorContent,
-        setEditorContent,
-        pendingTabSwitchRequest,
-        setPendingTabSwitchRequest,
-        pendingWorkspaceAction,
-        setPendingWorkspaceAction,
-        approveAll,
-        setApproveAll,
-        skills,
-        setSkills,
-        workflowState,
-        setWorkflowState,
-      }}
-    >
-      {children}
-    </AppContext.Provider>
+    <AgentConfigContext.Provider value={agentConfigValue}>
+      <EditorUIContext.Provider value={editorUIValue}>
+        {children}
+      </EditorUIContext.Provider>
+    </AgentConfigContext.Provider>
   );
 };
 
-export const useApp = () => {
-  const context = useContext(AppContext);
-  if (context === undefined) {
-    throw new Error("useApp must be used within an AppProvider");
+export const useAgentConfig = (): AgentConfigState => {
+  const ctx = useContext(AgentConfigContext);
+  if (ctx === undefined) {
+    throw new Error("useAgentConfig must be used within an AppProvider");
   }
-  return context;
+  return ctx;
+};
+
+export const useEditorUI = (): EditorUIState => {
+  const ctx = useContext(EditorUIContext);
+  if (ctx === undefined) {
+    throw new Error("useEditorUI must be used within an AppProvider");
+  }
+  return ctx;
+};
+
+/** Combined hook — subscribes to both contexts. Use targeted hooks where possible. */
+export const useApp = (): AppState => {
+  return { ...useAgentConfig(), ...useEditorUI() };
 };

--- a/src/lib/tools/EditorTools.test.ts
+++ b/src/lib/tools/EditorTools.test.ts
@@ -38,21 +38,25 @@ describe("EditorTools", () => {
 
   describe("read", () => {
     it("should return the editor content", () => {
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.read()).toBe("Initial content");
     });
 
     it("should return empty string if editor is not initialized and no fallback", () => {
-      const tools = new EditorTools(null, setSuggestions, false);
+      const tools = new EditorTools({ current: null }, setSuggestions, {
+        current: false,
+      });
       expect(tools.read()).toBe("");
     });
 
     it("should fall back to getEditorContent when editor is not initialized", () => {
       const tools = new EditorTools(
-        null,
+        { current: null },
         setSuggestions,
-        false,
-        () => "fallback content",
+        { current: false },
+        { current: "fallback content" },
       );
       expect(tools.read()).toBe("fallback content");
     });
@@ -60,20 +64,20 @@ describe("EditorTools", () => {
     it("should fall back to getEditorContent when editor returns empty string", () => {
       mockEditor.getValue.mockReturnValue("");
       const tools = new EditorTools(
-        mockEditor,
+        { current: mockEditor },
         setSuggestions,
-        false,
-        () => "fallback content",
+        { current: false },
+        { current: "fallback content" },
       );
       expect(tools.read()).toBe("fallback content");
     });
 
     it("should prefer editor content over fallback when editor has content", () => {
       const tools = new EditorTools(
-        mockEditor,
+        { current: mockEditor },
         setSuggestions,
-        false,
-        () => "fallback content",
+        { current: false },
+        { current: "fallback content" },
       );
       expect(tools.read()).toBe("Initial content");
     });
@@ -81,17 +85,19 @@ describe("EditorTools", () => {
 
   describe("get_current_mode", () => {
     it("should return editor mode by default", () => {
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.get_current_mode()).toBe("editor");
     });
 
     it("should return the mode from getActiveTab", () => {
       const tools = new EditorTools(
-        mockEditor,
+        { current: mockEditor },
         setSuggestions,
-        false,
-        () => "",
-        () => "preview",
+        { current: false },
+        { current: "" },
+        { current: "preview" },
       );
       expect(tools.get_current_mode()).toBe("preview");
     });
@@ -100,11 +106,11 @@ describe("EditorTools", () => {
   describe("request_switch_to_editor", () => {
     it("should return already-in-editor message when already in editor mode", async () => {
       const tools = new EditorTools(
-        mockEditor,
+        { current: mockEditor },
         setSuggestions,
-        false,
-        () => "",
-        () => "editor",
+        { current: false },
+        { current: "" },
+        { current: "editor" },
       );
       expect(await tools.request_switch_to_editor()).toBe(
         "Already in editor mode.",
@@ -114,11 +120,11 @@ describe("EditorTools", () => {
     it("should return success message when user accepts the switch", async () => {
       const requestTabSwitch = vi.fn().mockResolvedValue(true);
       const tools = new EditorTools(
-        mockEditor,
+        { current: mockEditor },
         setSuggestions,
-        false,
-        () => "",
-        () => "preview",
+        { current: false },
+        { current: "" },
+        { current: "preview" },
         requestTabSwitch,
       );
       expect(await tools.request_switch_to_editor()).toBe(
@@ -130,11 +136,11 @@ describe("EditorTools", () => {
     it("should return declined message when user rejects the switch", async () => {
       const requestTabSwitch = vi.fn().mockResolvedValue(false);
       const tools = new EditorTools(
-        mockEditor,
+        { current: mockEditor },
         setSuggestions,
-        false,
-        () => "",
-        () => "preview",
+        { current: false },
+        { current: "" },
+        { current: "preview" },
         requestTabSwitch,
       );
       expect(await tools.request_switch_to_editor()).toBe(
@@ -145,14 +151,18 @@ describe("EditorTools", () => {
 
   describe("search", () => {
     it("should return error if editor is not initialized", () => {
-      const tools = new EditorTools(null, setSuggestions, false);
+      const tools = new EditorTools({ current: null }, setSuggestions, {
+        current: false,
+      });
       expect(tools.search({ query: "hello" })).toBe(
         "Error: Editor not initialized.",
       );
     });
 
     it("should return error for empty query", () => {
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.search({ query: "" })).toBe(
         "Error: query parameter is required.",
       );
@@ -160,7 +170,9 @@ describe("EditorTools", () => {
 
     it("should return not-found message when there are no matches", () => {
       mockModel.findMatches.mockReturnValue([]);
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.search({ query: "xyz" })).toBe(
         'No occurrences of "xyz" found.',
       );
@@ -177,7 +189,9 @@ describe("EditorTools", () => {
           },
         },
       ]);
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.search({ query: "foo" })).toBe(
         'Found 1 occurrence(s) of "foo": line 3, col 5.',
       );
@@ -202,7 +216,9 @@ describe("EditorTools", () => {
           },
         },
       ]);
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.search({ query: "foo" })).toBe(
         'Found 2 occurrence(s) of "foo": line 1, col 1; line 5, col 10.',
       );
@@ -211,12 +227,16 @@ describe("EditorTools", () => {
 
   describe("read_selection", () => {
     it("should return empty string if editor is not initialized", () => {
-      const tools = new EditorTools(null, setSuggestions, false);
+      const tools = new EditorTools({ current: null }, setSuggestions, {
+        current: false,
+      });
       expect(tools.read_selection()).toBe("");
     });
 
     it("should return empty string when selection is null", () => {
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.read_selection()).toBe("");
     });
 
@@ -229,7 +249,9 @@ describe("EditorTools", () => {
       };
       mockEditor.getSelection.mockReturnValue(selection);
       mockModel.getValueInRange = vi.fn().mockReturnValue("hello");
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.read_selection()).toBe("hello");
       expect(mockModel.getValueInRange).toHaveBeenCalledWith(selection);
     });
@@ -242,38 +264,50 @@ describe("EditorTools", () => {
         endLineNumber: 1,
         endColumn: 6,
       });
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.read_selection()).toBe("");
     });
   });
 
   describe("get_metadata", () => {
     it("should return error if editor is not initialized", () => {
-      const tools = new EditorTools(null, setSuggestions, false);
+      const tools = new EditorTools({ current: null }, setSuggestions, {
+        current: false,
+      });
       expect(tools.get_metadata()).toBe("Error: Editor not initialized.");
     });
 
     it("should return zero counts for an empty document", () => {
       mockEditor.getValue.mockReturnValue("");
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.get_metadata()).toBe("Characters: 0, Words: 0, Lines: 0.");
     });
 
     it("should return correct counts for a single-line document", () => {
       mockEditor.getValue.mockReturnValue("hello world");
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.get_metadata()).toBe("Characters: 11, Words: 2, Lines: 1.");
     });
 
     it("should return correct line count for a multi-line document", () => {
       mockEditor.getValue.mockReturnValue("line one\nline two\nline three");
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.get_metadata()).toBe("Characters: 28, Words: 6, Lines: 3.");
     });
 
     it("should not count leading/trailing whitespace as words", () => {
       mockEditor.getValue.mockReturnValue("  hello world  ");
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
       expect(tools.get_metadata()).toBe("Characters: 15, Words: 2, Lines: 1.");
     });
   });
@@ -281,7 +315,9 @@ describe("EditorTools", () => {
   describe("edit", () => {
     it("should return an error if text is not found", async () => {
       mockModel.findMatches.mockReturnValue([]);
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
 
       const result = await tools.edit({
         originalText: "missing",
@@ -303,7 +339,9 @@ describe("EditorTools", () => {
           },
         },
       ]);
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
 
       const promise = tools.edit({
         originalText: "old",
@@ -339,7 +377,9 @@ describe("EditorTools", () => {
           },
         },
       ]);
-      const tools = new EditorTools(mockEditor, setSuggestions, true);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: true,
+      });
 
       const result = await tools.edit({
         originalText: "old",
@@ -370,7 +410,11 @@ describe("EditorTools", () => {
 
     beforeEach(() => {
       localStorage.clear();
-      editorToolsInstance = new EditorTools(mockEditor, setSuggestions, false);
+      editorToolsInstance = new EditorTools(
+        { current: mockEditor },
+        setSuggestions,
+        { current: false },
+      );
       mockRunStream = vi.fn().mockReturnValue(makeMockStream("done"));
       mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
       mockFactory = {
@@ -520,7 +564,9 @@ describe("EditorTools", () => {
 
   describe("write", () => {
     it("should create a suggestion for the full document if not approveAll", async () => {
-      const tools = new EditorTools(mockEditor, setSuggestions, false);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: false,
+      });
 
       const promise = tools.write({ content: "New document content" });
 
@@ -540,7 +586,9 @@ describe("EditorTools", () => {
     });
 
     it("should apply full replacement immediately if approveAll is true", async () => {
-      const tools = new EditorTools(mockEditor, setSuggestions, true);
+      const tools = new EditorTools({ current: mockEditor }, setSuggestions, {
+        current: true,
+      });
 
       const result = await tools.write({ content: "New document content" });
 

--- a/src/lib/tools/EditorTools.ts
+++ b/src/lib/tools/EditorTools.ts
@@ -16,27 +16,30 @@ import { v4 as uuidv4 } from "uuid";
 
 export class EditorTools {
   constructor(
-    private editor: monaco.editor.IStandaloneCodeEditor | null,
+    private editorRef: { current: monaco.editor.IStandaloneCodeEditor | null },
     private setSuggestions: (fn: (prev: Suggestion[]) => Suggestion[]) => void,
-    private approveAll: boolean,
-    private getEditorContent: () => string = () => "",
-    private getActiveTab: () => "editor" | "preview" = () => "editor",
+    private approveAllRef: { current: boolean },
+    private editorContentRef: { current: string } = { current: "" },
+    private activeTabRef: { current: "editor" | "preview" } = {
+      current: "editor",
+    },
     private requestTabSwitch: () => Promise<boolean> = () =>
       Promise.resolve(false),
   ) {}
 
   read(): string {
-    if (!this.editor) return this.getEditorContent();
-    const value = this.editor.getValue();
-    return value || this.getEditorContent();
+    const editor = this.editorRef.current;
+    if (!editor) return this.editorContentRef.current;
+    const value = editor.getValue();
+    return value || this.editorContentRef.current;
   }
 
   get_current_mode(): string {
-    return this.getActiveTab();
+    return this.activeTabRef.current;
   }
 
   async request_switch_to_editor(): Promise<string> {
-    if (this.getActiveTab() === "editor") {
+    if (this.activeTabRef.current === "editor") {
       return "Already in editor mode.";
     }
     const accepted = await this.requestTabSwitch();
@@ -47,16 +50,18 @@ export class EditorTools {
   }
 
   read_selection(): string {
-    if (!this.editor) return "";
-    const selection = this.editor.getSelection();
+    const editor = this.editorRef.current;
+    if (!editor) return "";
+    const selection = editor.getSelection();
     if (!selection) return "";
-    return this.editor.getModel()?.getValueInRange(selection) || "";
+    return editor.getModel()?.getValueInRange(selection) || "";
   }
 
   search({ query }: { query: string }): string {
-    if (!this.editor) return "Error: Editor not initialized.";
+    const editor = this.editorRef.current;
+    if (!editor) return "Error: Editor not initialized.";
     if (!query) return "Error: query parameter is required.";
-    const model = this.editor.getModel();
+    const model = editor.getModel();
     if (!model) return "Error: Model not found.";
 
     const matches = model.findMatches(query, true, false, false, null, false);
@@ -69,8 +74,9 @@ export class EditorTools {
   }
 
   get_metadata(): string {
-    if (!this.editor) return "Error: Editor not initialized.";
-    const text = this.editor.getValue();
+    const editor = this.editorRef.current;
+    if (!editor) return "Error: Editor not initialized.";
+    const text = editor.getValue();
     const charCount = text.length;
     const lineCount = text === "" ? 0 : text.split("\n").length;
     const wordCount = text.trim() === "" ? 0 : text.trim().split(/\s+/).length;
@@ -84,7 +90,7 @@ export class EditorTools {
     originalText: string;
     replacementText: string;
   }): Promise<string> {
-    const editor = this.editor;
+    const editor = this.editorRef.current;
     if (!editor) return Promise.resolve("Error: Editor not initialized.");
 
     const model = editor.getModel();
@@ -143,7 +149,7 @@ export class EditorTools {
   }
 
   write({ content }: { content: string }): Promise<string> {
-    const editor = this.editor;
+    const editor = this.editorRef.current;
     if (!editor) return Promise.resolve("Error: Editor not initialized.");
 
     const model = editor.getModel();
@@ -172,7 +178,7 @@ export class EditorTools {
     autoApply: () => void,
     autoMessage: string,
   ): Promise<string> {
-    if (this.approveAll) {
+    if (this.approveAllRef.current) {
       autoApply();
       return Promise.resolve(autoMessage);
     }
@@ -190,6 +196,68 @@ export class EditorTools {
 
 /** Registers the standard editor tools on a ToolRegistry. */
 export function registerEditorTools(
+  registry: ToolRegistry,
+  tools: EditorTools,
+): void {
+  registerReadonlyEditorTools(registry, tools);
+
+  registry.register({
+    definition: () => ({
+      name: "edit",
+      description:
+        "Proposes a targeted edit. This tool pauses and waits for user approval. ONLY use this for small, localized changes (e.g., 1-2 sentences). Never pass the entire document.",
+      parameters: {
+        type: "object",
+        properties: {
+          originalText: {
+            type: "string",
+            description:
+              "The exact, minimal string of text to replace. Must be short. Do NOT pass the whole document.",
+          },
+          replacementText: {
+            type: "string",
+            description: "The new text to replace the originalText with.",
+          },
+        },
+        required: ["originalText", "replacementText"],
+      },
+    }),
+    call: async (args: { originalText: string; replacementText: string }) =>
+      tools.edit(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "write",
+      description:
+        "Proposes a complete rewrite. This tool pauses and waits for user approval. ONLY use this when the user explicitly requests a total rewrite of the entire document.",
+      parameters: {
+        type: "object",
+        properties: {
+          content: {
+            type: "string",
+            description: "The full new document content.",
+          },
+        },
+        required: ["content"],
+      },
+    }),
+    call: async (args: { content: string }) => tools.write(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "request_switch_to_editor",
+      description:
+        "Requests the user to switch from Preview mode to Editor mode. This will display a prompt to the user and pause until they accept or decline. Call this before attempting edits when in preview mode.",
+      parameters: { type: "object", properties: {} },
+    }),
+    call: async () => tools.request_switch_to_editor(),
+  });
+}
+
+/** Registers read-only editor tools (no edit, write, or request_switch_to_editor). */
+export function registerReadonlyEditorTools(
   registry: ToolRegistry,
   tools: EditorTools,
 ): void {
@@ -239,66 +307,12 @@ export function registerEditorTools(
 
   registry.register({
     definition: () => ({
-      name: "edit",
-      description:
-        "Proposes a targeted edit. This tool pauses and waits for user approval. ONLY use this for small, localized changes (e.g., 1-2 sentences). Never pass the entire document.",
-      parameters: {
-        type: "object",
-        properties: {
-          originalText: {
-            type: "string",
-            description:
-              "The exact, minimal string of text to replace. Must be short. Do NOT pass the whole document.",
-          },
-          replacementText: {
-            type: "string",
-            description: "The new text to replace the originalText with.",
-          },
-        },
-        required: ["originalText", "replacementText"],
-      },
-    }),
-    call: async (args: { originalText: string; replacementText: string }) =>
-      tools.edit(args),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "write",
-      description:
-        "Proposes a complete rewrite. This tool pauses and waits for user approval. ONLY use this when the user explicitly requests a total rewrite of the entire document.",
-      parameters: {
-        type: "object",
-        properties: {
-          content: {
-            type: "string",
-            description: "The full new document content.",
-          },
-        },
-        required: ["content"],
-      },
-    }),
-    call: async (args: { content: string }) => tools.write(args),
-  });
-
-  registry.register({
-    definition: () => ({
       name: "get_current_mode",
       description:
         "Returns the current UI mode: 'editor' (Monaco editor is visible) or 'preview' (Markdown preview is visible). Check this before making edits to ensure the editor is accessible.",
       parameters: { type: "object", properties: {} },
     }),
     call: async () => tools.get_current_mode(),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "request_switch_to_editor",
-      description:
-        "Requests the user to switch from Preview mode to Editor mode. This will display a prompt to the user and pause until they accept or decline. Call this before attempting edits when in preview mode.",
-      parameters: { type: "object", properties: {} },
-    }),
-    call: async () => tools.request_switch_to_editor(),
   });
 }
 

--- a/src/lib/tools/WorkspaceTools.test.ts
+++ b/src/lib/tools/WorkspaceTools.test.ts
@@ -9,9 +9,8 @@ import type {
   DeleteDocumentFn,
   SetActiveDocumentIdFn,
   SaveDocContentFn,
-  GetEditorContentFn,
-  SetEditorValueFn,
   SetPendingWorkspaceActionFn,
+  EditorLike,
 } from "./WorkspaceTools";
 import type { WorkspaceDocument } from "../workspace";
 import type { AgentRunnerFactory } from "../agents/factory";
@@ -167,7 +166,8 @@ describe("WorkspaceTools", () => {
 
   describe("create_document", () => {
     let createDocumentFn: ReturnType<typeof vi.fn> & CreateDocumentFn;
-    let setEditorValueFn: ReturnType<typeof vi.fn> & SetEditorValueFn;
+    let setEditorValueFn: ReturnType<typeof vi.fn>;
+    let mockEditorRef: { current: EditorLike };
     let setPendingWorkspaceAction: ReturnType<typeof vi.fn> &
       SetPendingWorkspaceActionFn;
 
@@ -175,7 +175,13 @@ describe("WorkspaceTools", () => {
       createDocumentFn = vi
         .fn()
         .mockReturnValue("new-doc-id") as unknown as typeof createDocumentFn;
-      setEditorValueFn = vi.fn() as unknown as typeof setEditorValueFn;
+      setEditorValueFn = vi.fn();
+      mockEditorRef = {
+        current: {
+          getValue: vi.fn().mockReturnValue(""),
+          setValue: setEditorValueFn,
+        },
+      };
       setPendingWorkspaceAction =
         vi.fn() as unknown as typeof setPendingWorkspaceAction;
     });
@@ -190,10 +196,10 @@ describe("WorkspaceTools", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
-        vi.fn().mockReturnValue(""),
-        setEditorValueFn,
+        mockEditorRef,
+        { current: "" },
         setPendingWorkspaceAction,
-        approveAll,
+        { current: approveAll },
       );
     }
 
@@ -250,10 +256,10 @@ describe("WorkspaceTools", () => {
         vi.fn(),
         vi.fn(),
         saveDocContentFn,
-        vi.fn().mockReturnValue(""),
-        setEditorValueFn,
+        mockEditorRef,
+        { current: "" },
         setPendingWorkspaceAction,
-        true,
+        { current: true },
       );
       await tools.create_document({ title: "My Doc", content: "Hello world" });
       expect(setEditorValueFn).toHaveBeenCalledWith("Hello world");
@@ -274,10 +280,10 @@ describe("WorkspaceTools", () => {
         vi.fn(),
         vi.fn(),
         saveDocContentFn,
-        vi.fn().mockReturnValue(""),
-        setEditorValueFn,
+        mockEditorRef,
+        { current: "" },
         setPendingWorkspaceAction,
-        true,
+        { current: true },
       );
       await tools.create_document({ title: "My Doc" });
       expect(setEditorValueFn).toHaveBeenCalledWith("");
@@ -298,10 +304,10 @@ describe("WorkspaceTools", () => {
         vi.fn(),
         vi.fn(),
         saveDocContentFn,
-        vi.fn().mockReturnValue(""),
-        setEditorValueFn,
+        mockEditorRef,
+        { current: "" },
         setPendingWorkspaceAction,
-        false,
+        { current: false },
       );
       const promise = tools.create_document({
         title: "Draft",
@@ -337,10 +343,10 @@ describe("WorkspaceTools", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
-        vi.fn().mockReturnValue(""),
-        vi.fn(),
+        { current: null },
+        { current: "" },
         setPendingWorkspaceAction,
-        approveAll,
+        { current: approveAll },
       );
     }
 
@@ -411,10 +417,10 @@ describe("WorkspaceTools", () => {
         deleteDocumentFn,
         vi.fn(),
         vi.fn(),
-        vi.fn().mockReturnValue(""),
-        vi.fn(),
+        { current: null },
+        { current: "" },
         setPendingWorkspaceAction,
-        approveAll,
+        { current: approveAll },
       );
     }
 
@@ -456,19 +462,20 @@ describe("WorkspaceTools", () => {
   describe("switch_active_document", () => {
     let setActiveDocumentIdFn: ReturnType<typeof vi.fn> & SetActiveDocumentIdFn;
     let saveDocContentFn: ReturnType<typeof vi.fn> & SaveDocContentFn;
-    let getEditorContent: ReturnType<typeof vi.fn> & GetEditorContentFn;
-    let setEditorValueFn: ReturnType<typeof vi.fn> & SetEditorValueFn;
+    let setEditorValueFn: ReturnType<typeof vi.fn>;
+    let mockEditorRef: { current: EditorLike };
 
     beforeEach(() => {
       setActiveDocumentIdFn =
         vi.fn() as unknown as typeof setActiveDocumentIdFn;
       saveDocContentFn = vi.fn() as unknown as typeof saveDocContentFn;
-      getEditorContent = vi
-        .fn()
-        .mockReturnValue(
-          "editor content",
-        ) as unknown as typeof getEditorContent;
-      setEditorValueFn = vi.fn() as unknown as typeof setEditorValueFn;
+      setEditorValueFn = vi.fn();
+      mockEditorRef = {
+        current: {
+          getValue: vi.fn().mockReturnValue("editor content"),
+          setValue: setEditorValueFn,
+        },
+      };
     });
 
     function makeTools(
@@ -484,10 +491,10 @@ describe("WorkspaceTools", () => {
         vi.fn(),
         setActiveDocumentIdFn,
         saveDocContentFn,
-        getEditorContent,
-        setEditorValueFn,
+        mockEditorRef,
+        { current: "" },
         vi.fn(),
-        false,
+        { current: false },
       );
     }
 

--- a/src/lib/tools/WorkspaceTools.ts
+++ b/src/lib/tools/WorkspaceTools.ts
@@ -12,8 +12,6 @@ export type RenameDocumentFn = (id: string, title: string) => void;
 export type DeleteDocumentFn = (id: string) => void;
 export type SetActiveDocumentIdFn = (id: string) => void;
 export type SaveDocContentFn = (id: string, content: string) => void;
-export type GetEditorContentFn = () => string;
-export type SetEditorValueFn = (content: string) => void;
 export type SetPendingWorkspaceActionFn = (
   action: WorkspaceActionRequest | null,
 ) => void;
@@ -27,6 +25,12 @@ export interface ActiveDocRef {
   current: { id: string; title: string } | null;
 }
 
+/** Minimal editor interface needed by WorkspaceTools. */
+export interface EditorLike {
+  getValue(): string;
+  setValue(content: string): void;
+}
+
 export class WorkspaceTools {
   constructor(
     private docsRef: DocsRef,
@@ -37,11 +41,19 @@ export class WorkspaceTools {
     private deleteDocumentFn: DeleteDocumentFn = () => {},
     private setActiveDocumentIdFn: SetActiveDocumentIdFn = () => {},
     private saveDocContentFn: SaveDocContentFn = () => {},
-    private getEditorContent: GetEditorContentFn = () => "",
-    private setEditorValueFn: SetEditorValueFn = () => {},
+    private editorRef: { current: EditorLike | null } = { current: null },
+    private editorContentRef: { current: string } = { current: "" },
     private setPendingWorkspaceAction: SetPendingWorkspaceActionFn = () => {},
-    private approveAll: boolean = false,
+    private approveAllRef: { current: boolean } = { current: false },
   ) {}
+
+  private getEditorContent(): string {
+    return this.editorRef.current?.getValue() ?? this.editorContentRef.current;
+  }
+
+  private setEditorValue(content: string): void {
+    this.editorRef.current?.setValue(content);
+  }
 
   get_active_doc_info(): string {
     const doc = this.activeDocRef.current;
@@ -103,7 +115,7 @@ export class WorkspaceTools {
         const initialContent = content ?? "";
         // Immediately sync Monaco so subsequent reads see the correct content
         // before React's async re-render cycle completes.
-        this.setEditorValueFn(initialContent);
+        this.setEditorValue(initialContent);
         if (content && newId) {
           this.saveDocContentFn(newId, content);
         }
@@ -153,7 +165,7 @@ export class WorkspaceTools {
     this.setActiveDocumentIdFn(id);
     // Immediately sync Monaco so subsequent read/edit calls see the new content
     // before React's async re-render cycle completes.
-    this.setEditorValueFn(doc.content);
+    this.setEditorValue(doc.content);
     return JSON.stringify({ switched: true, id, title: doc.title });
   }
 
@@ -162,7 +174,7 @@ export class WorkspaceTools {
     apply: () => void,
     autoMessage: string,
   ): Promise<string> {
-    if (this.approveAll) {
+    if (this.approveAllRef.current) {
       apply();
       return Promise.resolve(autoMessage);
     }

--- a/src/lib/tools/registries.test.ts
+++ b/src/lib/tools/registries.test.ts
@@ -1,0 +1,110 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from "vitest";
+import { buildReadonlyRegistry, buildReadWriteRegistry } from "./registries";
+import { EditorTools } from "./EditorTools";
+import { WorkspaceTools } from "./WorkspaceTools";
+import type { AgentRunnerFactory } from "../agents/factory";
+
+function makeTools() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockEditor: any = {
+    getValue: vi.fn().mockReturnValue(""),
+    setValue: vi.fn(),
+    getModel: vi.fn().mockReturnValue(null),
+    getSelection: vi.fn().mockReturnValue(null),
+  };
+  const setSuggestions = vi.fn();
+  const mockFactory: AgentRunnerFactory = { create: vi.fn() };
+
+  const editorTools = new EditorTools({ current: mockEditor }, setSuggestions, {
+    current: false,
+  });
+  const workspaceTools = new WorkspaceTools(
+    { current: [] },
+    { current: null },
+    mockFactory,
+  );
+  return { editorTools, workspaceTools };
+}
+
+describe("buildReadonlyRegistry", () => {
+  it("includes read, read_selection, search, get_metadata, get_current_mode", () => {
+    const { editorTools, workspaceTools } = makeTools();
+    const registry = buildReadonlyRegistry(editorTools, workspaceTools);
+    const names = registry.definitions().map((d) => d.name);
+    expect(names).toContain("read");
+    expect(names).toContain("read_selection");
+    expect(names).toContain("search");
+    expect(names).toContain("get_metadata");
+    expect(names).toContain("get_current_mode");
+  });
+
+  it("excludes edit, write, request_switch_to_editor", () => {
+    const { editorTools, workspaceTools } = makeTools();
+    const registry = buildReadonlyRegistry(editorTools, workspaceTools);
+    const names = registry.definitions().map((d) => d.name);
+    expect(names).not.toContain("edit");
+    expect(names).not.toContain("write");
+    expect(names).not.toContain("request_switch_to_editor");
+  });
+
+  it("includes workspace read tools", () => {
+    const { editorTools, workspaceTools } = makeTools();
+    const registry = buildReadonlyRegistry(editorTools, workspaceTools);
+    const names = registry.definitions().map((d) => d.name);
+    expect(names).toContain("get_active_doc_info");
+    expect(names).toContain("list_workspace_docs");
+    expect(names).toContain("read_workspace_doc");
+    expect(names).toContain("query_workspace_doc");
+    expect(names).toContain("query_workspace");
+  });
+
+  it("excludes workspace write tools", () => {
+    const { editorTools, workspaceTools } = makeTools();
+    const registry = buildReadonlyRegistry(editorTools, workspaceTools);
+    const names = registry.definitions().map((d) => d.name);
+    expect(names).not.toContain("create_document");
+    expect(names).not.toContain("rename_document");
+    expect(names).not.toContain("delete_document");
+    expect(names).not.toContain("switch_active_document");
+  });
+});
+
+describe("buildReadWriteRegistry", () => {
+  it("includes all read-only tools", () => {
+    const { editorTools, workspaceTools } = makeTools();
+    const registry = buildReadWriteRegistry(editorTools, workspaceTools);
+    const names = registry.definitions().map((d) => d.name);
+    expect(names).toContain("read");
+    expect(names).toContain("read_selection");
+    expect(names).toContain("search");
+    expect(names).toContain("get_metadata");
+    expect(names).toContain("get_current_mode");
+    expect(names).toContain("get_active_doc_info");
+    expect(names).toContain("list_workspace_docs");
+    expect(names).toContain("read_workspace_doc");
+    expect(names).toContain("query_workspace_doc");
+    expect(names).toContain("query_workspace");
+  });
+
+  it("includes edit, write, request_switch_to_editor", () => {
+    const { editorTools, workspaceTools } = makeTools();
+    const registry = buildReadWriteRegistry(editorTools, workspaceTools);
+    const names = registry.definitions().map((d) => d.name);
+    expect(names).toContain("edit");
+    expect(names).toContain("write");
+    expect(names).toContain("request_switch_to_editor");
+  });
+
+  it("includes workspace write tools", () => {
+    const { editorTools, workspaceTools } = makeTools();
+    const registry = buildReadWriteRegistry(editorTools, workspaceTools);
+    const names = registry.definitions().map((d) => d.name);
+    expect(names).toContain("create_document");
+    expect(names).toContain("rename_document");
+    expect(names).toContain("delete_document");
+    expect(names).toContain("switch_active_document");
+  });
+});

--- a/src/lib/tools/registries.ts
+++ b/src/lib/tools/registries.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { ToolRegistry } from "@mast-ai/core";
+import {
+  EditorTools,
+  registerEditorTools,
+  registerReadonlyEditorTools,
+} from "./EditorTools";
+import {
+  WorkspaceTools,
+  registerWorkspaceTools,
+  registerReadonlyWorkspaceTools,
+} from "./WorkspaceTools";
+
+export interface ProposedEdit {
+  originalText: string;
+  replacementText: string;
+  reason?: string;
+}
+
+export function buildReadonlyRegistry(
+  editorTools: EditorTools,
+  workspaceTools: WorkspaceTools,
+): ToolRegistry {
+  const registry = new ToolRegistry();
+  registerReadonlyEditorTools(registry, editorTools);
+  registerReadonlyWorkspaceTools(registry, workspaceTools);
+  return registry;
+}
+
+export function buildReadWriteRegistry(
+  editorTools: EditorTools,
+  workspaceTools: WorkspaceTools,
+): ToolRegistry {
+  const registry = new ToolRegistry();
+  registerEditorTools(registry, editorTools);
+  registerWorkspaceTools(registry, workspaceTools);
+  return registry;
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `WorkspacesContext` functions (`updateDocument`, `createDocumentWithTitle`, etc.) were defined without `useCallback`, so they were new references on every `WorkspacesProvider` render. Calling `updateDocument` in `flushEditorContent` (before each send) triggered a re-render cascade: `workspaceTools` → `runner` → `conversation` reset, erasing history on every message.
- **Fix 1**: Wrap all `WorkspacesContext` mutation functions in `useCallback` so they are stable between workspace state changes.
- **Fix 2**: Split the monolithic `AppStore` into `AgentConfigContext` (slow: API key, model, skills) and `EditorUIContext` (fast: editor state, suggestions), so high-frequency keystrokes don't cause the agent construction chain to re-evaluate.
- **Fix 3**: Refactor `EditorTools` and `WorkspaceTools` constructors to accept `{ current: T }` ref objects instead of getter closures, eliminating `react-hooks/refs` lint violations while keeping `.current` access outside the render phase.
- **Addition**: `buildReadonlyRegistry` / `buildReadWriteRegistry` helpers and Phase B multi-agent orchestration foundation (`DelegationTools`, agent runner factory).

## Test plan

- [ ] All 264 tests pass (`npm run test`)
- [ ] No lint errors (`npm run lint`)
- [ ] Send two messages in sequence; agent remembers the first on the second reply