### PR TITLE
feat: Phase C — Planner Agent

### DIFF
--- a/docs/multi-agent/PHASE-C.md
+++ b/docs/multi-agent/PHASE-C.md
@@ -1,0 +1,129 @@
+# Phase C: Planner Agent
+
+## Goal
+
+Implement the LLM agent that decomposes a task into a structured `Plan` and wire it as an invokable `invoke_planner` tool. `invoke_planner` returns the plan as a JSON string and the Orchestrator proceeds immediately. Sub-agent progress is already rendered by the existing `invoke_agent` event infrastructure — no new UI or store state needed here.
+
+---
+
+## Context
+
+Phase B delivered:
+
+- Named registry builders (`buildReadonlyRegistry`, `buildReadWriteRegistry`)
+- `delegate_to_skill` returns the skill's raw string response; Orchestrator interprets and acts
+- `invoke_agent` creates generic sub-agents with a read-only registry; their streaming output is already attributed and rendered in `ChatSidebar` via the `"agent"` `StreamItem` kind
+- Write access policy enforced structurally — Orchestrator is the sole writer
+
+What's missing: the Orchestrator has no way to decompose a complex task into discrete steps before dispatching sub-agents. Without a plan, the Orchestrator either guesses the right sequence or collapses everything into a single `invoke_agent` call. Phase C fixes this with a dedicated Planner that reasons over text and produces a machine-readable work plan.
+
+---
+
+## What changes
+
+### 1. `src/lib/agents/planner.ts` (new)
+
+Exports the `Plan` type hierarchy, the system prompt constant, and the factory function.
+
+**Types:**
+
+```ts
+export interface PlanStep {
+  id: string; // e.g. "step_1"
+  instruction: string; // what needs to happen in this step
+  dependsOn: string[]; // IDs of steps whose output is needed as input
+}
+
+export interface Plan {
+  goal: string;
+  steps: PlanStep[];
+}
+```
+
+**System prompt** (`PLANNER_SYSTEM_PROMPT`):
+
+> You are a planning agent. Given a writing task and optional context, produce a structured JSON plan.
+>
+> - Output ONLY valid JSON matching the Plan schema below. No prose, no markdown fences, no explanation.
+> - Steps that can run independently must declare `dependsOn: []`. Steps that need prior output must list the prerequisite step IDs.
+> - Keep steps focused — one outcome per step. Simple tasks warrant 1–2 steps.
+>
+> Schema: `{ "goal": "string", "steps": [{ "id": "step_1", "instruction": "...", "dependsOn": [] }] }`
+
+**`createPlannerAgent(factory: AgentRunnerFactory): AgentRunner`** — constructs a runner with an empty `ToolRegistry` (no tools registered). The Planner reasons over text only.
+
+---
+
+### 2. `src/lib/tools/DelegationTools.ts` — `invoke_planner`
+
+New tool registration alongside `invoke_agent`. No new parameters on `registerDelegationTools`.
+
+**Parameters:**
+
+| Name      | Type     | Required | Description                                                                      |
+| --------- | -------- | -------- | -------------------------------------------------------------------------------- |
+| `task`    | `string` | yes      | The high-level task to decompose into a plan.                                    |
+| `context` | `string` | no       | Optional additional context (e.g. current document summary, workspace doc list). |
+
+**Execution sequence:**
+
+1. Call `createPlannerAgent(factory)` — runner with empty registry, planner system prompt.
+2. Build the prompt: the `task` string, with `context` appended on a new line if provided.
+3. Run the agent and collect the `done` event's output string.
+4. Parse the output as `Plan` JSON. Throw a descriptive error if parsing fails or the shape is invalid (missing `goal`, missing `steps` array).
+5. Return `JSON.stringify(plan)` — the Orchestrator reads step IDs, agent roles, and instructions to orchestrate subsequent execution.
+
+---
+
+### 3. `src/lib/agents/index.ts`
+
+Add re-exports from the new `planner.ts` module:
+
+```ts
+export type { Plan, PlanStep } from "./planner";
+export { createPlannerAgent, PLANNER_SYSTEM_PROMPT } from "./planner";
+```
+
+---
+
+## Files modified
+
+| File                               | Change                                                                      |
+| ---------------------------------- | --------------------------------------------------------------------------- |
+| `src/lib/tools/DelegationTools.ts` | Register `invoke_planner` tool                                              |
+| `src/lib/agents/index.ts`          | Re-export `Plan`, `PlanStep`, `createPlannerAgent`, `PLANNER_SYSTEM_PROMPT` |
+
+## Files created
+
+| File                        | Purpose                                                     |
+| --------------------------- | ----------------------------------------------------------- |
+| `src/lib/agents/planner.ts` | `Plan` types, `PLANNER_SYSTEM_PROMPT`, `createPlannerAgent` |
+
+---
+
+## Tests
+
+### `planner.test.ts` (new)
+
+```
+createPlannerAgent
+  ✓ creates runner using the provided factory
+  ✓ passes PLANNER_SYSTEM_PROMPT as the agent's system prompt
+  ✓ registers no tools (tool list is empty)
+```
+
+### `DelegationTools.test.ts` additions
+
+```
+invoke_planner
+  ✓ returns a JSON string that parses to a Plan with a goal and steps array
+  ✓ appends context to the task prompt when context is provided
+  ✓ throws when agent output is not valid JSON
+  ✓ throws when parsed JSON is missing required Plan fields
+```
+
+---
+
+## Working state
+
+Orchestrator can call `invoke_planner(task, context?)` and receive a structured `Plan` as a JSON string. It then dispatches steps via existing tools (`invoke_agent`, `delegate_to_skill`, etc.), whose streaming output is already rendered in the chat. No store or UI changes needed.

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -5,3 +5,5 @@ export type { AgentRunnerFactory } from "./factory";
 export { DefaultAgentRunnerFactory } from "./factory";
 export { buildOrchestratorPrompt } from "./orchestrator";
 export { createGenericAgent } from "./generic";
+export type { Plan, PlanStep } from "./planner";
+export { createPlannerAgent, PLANNER_SYSTEM_PROMPT } from "./planner";

--- a/src/lib/agents/orchestrator.ts
+++ b/src/lib/agents/orchestrator.ts
@@ -10,6 +10,7 @@ const BASE_INSTRUCTIONS =
   "When editing, keep the original text span as short as possible (just the words changing). " +
   "When an edit or write is submitted, execution pauses until the user accepts or rejects it; " +
   "you will receive their decision (and any feedback) as the tool result. " +
+  "For complex tasks with multiple interdependent steps, call invoke_planner first to decompose the task into a structured plan, then execute each step in order using invoke_agent or delegate_to_skill. For simple or single-step tasks, skip planning and act directly. " +
   "You can delegate any ad-hoc research or generation task to a generic sub-agent using the invoke_agent tool. " +
   'Workspace tools are available to list, read, query, create, rename, and delete documents in the workspace. Use invoke_agent with tools=["workspace_readonly"] to let a sub-agent query workspace documents. ' +
   "delegate_to_skill returns the skill's response as a string — interpret it and decide what to do: apply edits via edit(), present a summary, ask follow-up questions, etc.";

--- a/src/lib/agents/planner.test.ts
+++ b/src/lib/agents/planner.test.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from "vitest";
+import { createPlannerAgent, PLANNER_SYSTEM_PROMPT } from "./planner";
+import { ToolRegistry } from "@mast-ai/core";
+import type { AgentRunnerFactory } from "./factory";
+
+function makeFactory(): {
+  factory: AgentRunnerFactory;
+  mockCreate: ReturnType<typeof vi.fn>;
+} {
+  const mockCreate = vi.fn().mockReturnValue({
+    runBuilder: vi.fn().mockReturnValue({ runStream: vi.fn() }),
+  });
+  return { factory: { create: mockCreate }, mockCreate };
+}
+
+describe("createPlannerAgent", () => {
+  it("creates a runner using the provided factory", () => {
+    const { factory, mockCreate } = makeFactory();
+    createPlannerAgent(factory);
+    expect(mockCreate).toHaveBeenCalledOnce();
+  });
+
+  it("passes PLANNER_SYSTEM_PROMPT as the system prompt", () => {
+    const { factory, mockCreate } = makeFactory();
+    createPlannerAgent(factory);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ systemPrompt: PLANNER_SYSTEM_PROMPT }),
+    );
+  });
+
+  it("registers no tools (empty tool registry)", () => {
+    const { factory, mockCreate } = makeFactory();
+    createPlannerAgent(factory);
+    const { tools } = mockCreate.mock.calls[0][0] as { tools: ToolRegistry };
+    expect(tools.definitions()).toEqual([]);
+  });
+});

--- a/src/lib/agents/planner.ts
+++ b/src/lib/agents/planner.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { AgentRunner, ToolRegistry } from "@mast-ai/core";
+import type { AgentRunnerFactory } from "./factory";
+
+export interface PlanStep {
+  id: string;
+  instruction: string;
+  dependsOn: string[];
+}
+
+export interface Plan {
+  goal: string;
+  steps: PlanStep[];
+}
+
+export const PLANNER_SYSTEM_PROMPT =
+  "You are a planning agent. Given a writing task and optional context, produce a structured JSON plan.\n\n" +
+  "- Output ONLY valid JSON matching the Plan schema below. No prose, no markdown fences, no explanation.\n" +
+  "- Steps that can run independently must declare dependsOn: []. Steps that need prior output must list the prerequisite step IDs.\n" +
+  "- Keep steps focused — one outcome per step. Simple tasks warrant 1–2 steps.\n\n" +
+  'Schema: { "goal": "string", "steps": [{ "id": "step_1", "instruction": "...", "dependsOn": [] }] }';
+
+export function createPlannerAgent(factory: AgentRunnerFactory): AgentRunner {
+  return factory.create({
+    systemPrompt: PLANNER_SYSTEM_PROMPT,
+    tools: new ToolRegistry(),
+  });
+}

--- a/src/lib/tools/DelegationTools.test.ts
+++ b/src/lib/tools/DelegationTools.test.ts
@@ -174,3 +174,87 @@ describe("registerDelegationTools / invoke_agent", () => {
     expect(agentConfig.tools).not.toContain("switch_active_document");
   });
 });
+
+describe("registerDelegationTools / invoke_planner", () => {
+  it("invoke_planner tool is registered on the registry", () => {
+    const mockRunStream = vi.fn();
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeTools(factory);
+    registerDelegationTools(registry, factory, et, wt);
+
+    const tool = registry.get("invoke_planner");
+    expect(tool).toBeDefined();
+    expect(tool?.definition().name).toBe("invoke_planner");
+  });
+
+  const validPlan = {
+    goal: "Write a blog post",
+    steps: [{ id: "step_1", instruction: "Research the topic", dependsOn: [] }],
+  };
+
+  it("returns a JSON string that parses to a Plan with goal and steps", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeTools(factory);
+    registerDelegationTools(registry, factory, et, wt);
+
+    const raw = await callTool(registry, "invoke_planner", {
+      task: "Write a blog post about AI",
+    });
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.goal).toBe("Write a blog post");
+    expect(Array.isArray(parsed.steps)).toBe(true);
+    expect(parsed.steps).toHaveLength(1);
+  });
+
+  it("appends context to the task prompt when context is provided", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeTools(factory);
+    registerDelegationTools(registry, factory, et, wt);
+
+    await callTool(registry, "invoke_planner", {
+      task: "Write a blog post",
+      context: "Style: formal",
+    });
+
+    expect(mockRunStream).toHaveBeenCalledWith(
+      "Write a blog post\n\nStyle: formal",
+    );
+  });
+
+  it("throws when agent output is not valid JSON", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream("not json at all"));
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeTools(factory);
+    registerDelegationTools(registry, factory, et, wt);
+
+    await expect(
+      callTool(registry, "invoke_planner", { task: "t" }),
+    ).rejects.toThrow("invalid JSON");
+  });
+
+  it("throws when parsed JSON is missing required Plan fields", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify({ steps: [] })));
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeTools(factory);
+    registerDelegationTools(registry, factory, et, wt);
+
+    await expect(
+      callTool(registry, "invoke_planner", { task: "t" }),
+    ).rejects.toThrow("missing required fields");
+  });
+});

--- a/src/lib/tools/DelegationTools.ts
+++ b/src/lib/tools/DelegationTools.ts
@@ -4,6 +4,11 @@
 import { AgentConfig, ToolContext, ToolRegistry } from "@mast-ai/core";
 import type { AgentRunnerFactory } from "../agents/factory";
 import { createGenericAgent } from "../agents/generic";
+import {
+  createPlannerAgent,
+  Plan,
+  PLANNER_SYSTEM_PROMPT,
+} from "../agents/planner";
 import { EditorTools } from "./EditorTools";
 import { WorkspaceTools } from "./WorkspaceTools";
 import { buildReadonlyRegistry } from "./registries";
@@ -70,6 +75,65 @@ export function registerDelegationTools(
       }
 
       throw new Error("invoke_agent: sub-agent ended without a done event");
+    },
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "invoke_planner",
+      description:
+        "Decomposes a high-level task into a structured step-by-step Plan. Returns a JSON string: { goal, steps: [{ id, instruction, dependsOn }] }. The Orchestrator reads the plan and dispatches each step using the appropriate tools.",
+      parameters: {
+        type: "object",
+        properties: {
+          task: {
+            type: "string",
+            description: "The high-level task to decompose into a plan.",
+          },
+          context: {
+            type: "string",
+            description:
+              "Optional additional context (e.g. current document summary, workspace doc list).",
+          },
+        },
+        required: ["task"],
+      },
+    }),
+    call: async (args: { task: string; context?: string }) => {
+      const runner = createPlannerAgent(factory);
+      const prompt = args.context
+        ? `${args.task}\n\n${args.context}`
+        : args.task;
+      const agentConfig: AgentConfig = {
+        name: "Planner",
+        instructions: PLANNER_SYSTEM_PROMPT,
+        tools: [],
+      };
+
+      for await (const event of runner
+        .runBuilder(agentConfig)
+        .runStream(prompt)) {
+        if (event.type === "done") {
+          let plan: Plan;
+          try {
+            plan = JSON.parse(event.output) as Plan;
+          } catch {
+            throw new Error(
+              `invoke_planner: agent returned invalid JSON: ${event.output}`,
+            );
+          }
+          if (typeof plan.goal !== "string" || !Array.isArray(plan.steps)) {
+            throw new Error(
+              "invoke_planner: plan is missing required fields (goal, steps)",
+            );
+          }
+          return JSON.stringify(plan);
+        }
+      }
+
+      throw new Error(
+        "invoke_planner: planner agent ended without a done event",
+      );
     },
   });
 }


### PR DESCRIPTION
## Summary

- Adds `invoke_planner` tool so the Orchestrator can decompose complex tasks into a structured `Plan` before dispatching sub-agents
- New `src/lib/agents/planner.ts` exports `Plan`/`PlanStep` types, `PLANNER_SYSTEM_PROMPT`, and `createPlannerAgent` (no tool access — text reasoning only)
- Orchestrator system prompt updated with guidance on when to plan vs act directly

## Changes

| File | Change |
| --- | --- |
| `src/lib/agents/planner.ts` | New — Plan types, system prompt, factory function |
| `src/lib/tools/DelegationTools.ts` | Register `invoke_planner` alongside `invoke_agent` |
| `src/lib/agents/orchestrator.ts` | Add `invoke_planner` usage guidance |
| `src/lib/agents/index.ts` | Re-export planner types and helpers |
| `docs/multi-agent/PHASE-C.md` | Phase plan document |

## Tests

- `src/lib/agents/planner.test.ts` (new): 3 tests for `createPlannerAgent`
- `src/lib/tools/DelegationTools.test.ts`: 5 new `invoke_planner` tests covering happy path, context appending, and error cases