### PR TITLE
feat: Phase D — Plan Confirmation

### DIFF
--- a/docs/multi-agent/PHASE-B.md
+++ b/docs/multi-agent/PHASE-B.md
@@ -100,19 +100,19 @@ Default skill instructions updated to be natural — no output format constraint
 
 ## Files modified
 
-| File | Change |
-| --- | --- |
-| `src/lib/tools/EditorTools.ts` | Add `registerReadonlyEditorTools`; update `createDelegateToSkillHandler` to use `buildReadonlyRegistry` and return raw string output |
-| `src/lib/tools/WorkspaceTools.ts` | `registerWorkspaceTools` calls `registerReadonlyWorkspaceTools` to eliminate duplication |
-| `src/lib/tools/DelegationTools.ts` | Replace `buildRegistryForGroups` with `buildReadonlyRegistry`; non-nullable params |
-| `src/lib/agents/orchestrator.ts` | Update `BASE_INSTRUCTIONS` for flexible skill response handling |
-| `src/App.tsx` | Replace inline registry build with `buildReadWriteRegistry`; update `delegate_to_skill` description |
-| `src/lib/skills.ts` | Update default skill instructions to be natural, no output format constraints |
+| File                               | Change                                                                                                                               |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/lib/tools/EditorTools.ts`     | Add `registerReadonlyEditorTools`; update `createDelegateToSkillHandler` to use `buildReadonlyRegistry` and return raw string output |
+| `src/lib/tools/WorkspaceTools.ts`  | `registerWorkspaceTools` calls `registerReadonlyWorkspaceTools` to eliminate duplication                                             |
+| `src/lib/tools/DelegationTools.ts` | Replace `buildRegistryForGroups` with `buildReadonlyRegistry`; non-nullable params                                                   |
+| `src/lib/agents/orchestrator.ts`   | Update `BASE_INSTRUCTIONS` for flexible skill response handling                                                                      |
+| `src/App.tsx`                      | Replace inline registry build with `buildReadWriteRegistry`; update `delegate_to_skill` description                                  |
+| `src/lib/skills.ts`                | Update default skill instructions to be natural, no output format constraints                                                        |
 
 ## Files created
 
-| File | Purpose |
-| --- | --- |
+| File                          | Purpose                                                   |
+| ----------------------------- | --------------------------------------------------------- |
 | `src/lib/tools/registries.ts` | Exports `buildReadonlyRegistry`, `buildReadWriteRegistry` |
 
 ---

--- a/docs/multi-agent/PHASE-D.md
+++ b/docs/multi-agent/PHASE-D.md
@@ -1,0 +1,158 @@
+# Phase D: Plan Confirmation
+
+## Goal
+
+Gate plan execution behind explicit user approval. After `invoke_planner` produces a plan it pauses and waits for the user to confirm or cancel — the same await-and-resolve pattern used by `pendingTabSwitchRequest` and `pendingWorkspaceAction`. A new `PlanConfirmationWidget` rendered inline in `ChatSidebar` shows the plan goal and step list with Confirm/Cancel buttons.
+
+---
+
+## Context
+
+Phase C delivered:
+
+- `createPlannerAgent` and `PLANNER_SYSTEM_PROMPT` in `src/lib/agents/planner.ts`
+- `invoke_planner` in `DelegationTools.ts` — parses the LLM output into a typed `Plan` and returns it immediately as a JSON string
+- `Plan` and `PlanStep` types re-exported from `src/lib/agents/index.ts`
+
+What's missing: the Orchestrator proceeds immediately after receiving the plan, with no opportunity for the user to review or reject it. A multi-step plan that restructures a document can have significant consequences — users need to be able to say "yes, proceed" or "no, stop". Phase D adds that gate.
+
+---
+
+## What changes
+
+### 1. `src/lib/store.tsx` — `PlanConfirmationRequest`
+
+**New type** (add at the top of the file, alongside `TabSwitchRequest`):
+
+```ts
+import type { Plan } from "./agents/planner";
+
+export interface PlanConfirmationRequest {
+  plan: Plan;
+  resolve: (accepted: boolean) => void;
+}
+```
+
+**`EditorUIState` additions:**
+
+```ts
+pendingPlanConfirmation: PlanConfirmationRequest | null;
+setPendingPlanConfirmation: (req: PlanConfirmationRequest | null) => void;
+```
+
+Add a matching `useState<PlanConfirmationRequest | null>(null)` in `AppProvider` and include both in `editorUIValue`.
+
+---
+
+### 2. `src/lib/tools/DelegationTools.ts` — confirmation await in `invoke_planner`
+
+One new parameter on `registerDelegationTools`:
+
+| Parameter                    | Type                                             | Purpose                          |
+| ---------------------------- | ------------------------------------------------ | -------------------------------- |
+| `setPendingPlanConfirmation` | `(req: PlanConfirmationRequest \| null) => void` | Triggers the confirmation widget |
+
+Import `PlanConfirmationRequest` from `../store` as a type-only import.
+
+Updated `invoke_planner` execution sequence (replaces the current "parse and return" step 5):
+
+1. Parse the plan JSON and validate shape — unchanged from Phase C.
+2. Create a `Promise<boolean>` and pass its `resolve` callback into `setPendingPlanConfirmation({ plan, resolve })`.
+3. Await the promise.
+4. Call `setPendingPlanConfirmation(null)` to dismiss the widget.
+5. **If rejected:** throw `new Error("Plan rejected by user.")`.
+6. **If accepted:** return `JSON.stringify(plan)` as before.
+
+---
+
+### 3. `src/App.tsx` — thread new callbacks into `registerDelegationTools`
+
+Destructure `setPendingPlanConfirmation` from `useEditorUI()` and pass it to `registerDelegationTools`:
+
+```ts
+registerDelegationTools(
+  registry,
+  factory,
+  editorTools,
+  workspaceTools,
+  setPendingPlanConfirmation,
+);
+```
+
+---
+
+### 4. `src/components/PlanConfirmationWidget.tsx` (new)
+
+A self-contained widget that reads `pendingPlanConfirmation` from `useEditorUI()` and renders `null` when it is unset.
+
+When set, renders a bordered card containing:
+
+- A heading: **"Confirm Plan"**
+- The plan `goal` as a short descriptive paragraph
+- A numbered list of steps, each showing `step.instruction`
+- Two action buttons: **Confirm** (`resolve(true)`) and **Cancel** (`resolve(false)`)
+
+Both buttons only call `resolve` — `invoke_planner` is responsible for clearing state and handling the workflow transition after the promise settles.
+
+---
+
+### 5. `src/components/ChatSidebar.tsx` — render widget when a plan is pending
+
+Import `PlanConfirmationWidget` and insert it between the virtualised message list and the input area:
+
+```tsx
+{
+  /* Plan confirmation gate — shown inline when invoke_planner is awaiting approval */
+}
+<PlanConfirmationWidget />;
+```
+
+No state changes or additional props are required; the widget reads directly from `useEditorUI()`.
+
+---
+
+## Files modified
+
+| File                               | Change                                                                                                                     |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/store.tsx`                | Add `PlanConfirmationRequest` type; add `pendingPlanConfirmation` + setter to `EditorUIState` and `AppProvider`            |
+| `src/lib/tools/DelegationTools.ts` | Add `setPendingPlanConfirmation` param; update `invoke_planner` to await confirmation, clear state, and throw on rejection |
+| `src/App.tsx`                      | Destructure and pass `setPendingPlanConfirmation` to `registerDelegationTools`                                             |
+| `src/components/ChatSidebar.tsx`   | Import and render `PlanConfirmationWidget` between message list and input area                                             |
+
+## Files created
+
+| File                                        | Purpose                                                                                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `src/components/PlanConfirmationWidget.tsx` | Renders plan goal + step list + Confirm/Cancel buttons; self-contained via `useEditorUI()` |
+
+---
+
+## Tests
+
+### `DelegationTools.test.ts` additions
+
+```
+invoke_planner (Phase D)
+  ✓ calls setPendingPlanConfirmation with the plan before awaiting
+  ✓ returns plan JSON when the confirmation callback resolves with true
+  ✓ clears pendingPlanConfirmation after resolution regardless of outcome
+  ✓ throws "Plan rejected by user." when confirmation resolves with false
+```
+
+### `PlanConfirmationWidget.test.tsx` (new)
+
+```
+PlanConfirmationWidget
+  ✓ renders nothing when pendingPlanConfirmation is null
+  ✓ renders the plan goal when pendingPlanConfirmation is set
+  ✓ renders one list item per step showing the instruction text
+  ✓ calls resolve(true) when the Confirm button is clicked
+  ✓ calls resolve(false) when the Cancel button is clicked
+```
+
+---
+
+## Working state
+
+When the Orchestrator calls `invoke_planner`, the user sees a step-by-step plan card appear inline in the chat sidebar. Clicking **Confirm** lets the Orchestrator proceed; clicking **Cancel** clears the workflow state and lets the Orchestrator handle the rejection gracefully.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,6 +287,7 @@ function App() {
     setPendingTabSwitchRequest,
     pendingWorkspaceAction,
     setPendingWorkspaceAction,
+    setPendingPlanConfirmation,
   } = useEditorUI();
   const [tempKey, setTempKey] = useState("");
   const [showKeyDialog, setShowKeyDialog] = useState(!apiKey);
@@ -423,10 +424,24 @@ function App() {
       call: createDelegateToSkillHandler(factory, editorTools, workspaceTools),
     });
 
-    registerDelegationTools(registry, factory, editorTools, workspaceTools);
+    registerDelegationTools(
+      registry,
+      factory,
+      editorTools,
+      workspaceTools,
+      setPendingPlanConfirmation,
+    );
 
     return new AgentRunner(adapter, registry);
-  }, [apiKey, factory, modelName, setTotalTokens, editorTools, workspaceTools]);
+  }, [
+    apiKey,
+    factory,
+    modelName,
+    setTotalTokens,
+    editorTools,
+    workspaceTools,
+    setPendingPlanConfirmation,
+  ]);
 
   const conversation = useMemo(() => {
     if (!runner) return null;

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -13,6 +13,7 @@ import { useWorkspaces } from "@/lib/WorkspacesContext";
 import { SettingsDialog } from "./SettingsDialog";
 import { SkillsDialog } from "./SkillsDialog";
 import { ChatItem, ChildItem, StreamItem } from "./ChatItem";
+import { PlanConfirmationWidget } from "./PlanConfirmationWidget";
 import {
   DocRef,
   Segment,
@@ -551,6 +552,8 @@ export function ChatSidebar({ conversation, onBeforeSend }: ChatSidebarProps) {
           </div>
         )}
       </div>
+
+      <PlanConfirmationWidget />
 
       <div className="p-4 border-t bg-background/50 backdrop-blur-sm flex items-end gap-2">
         <div className="relative flex-1">

--- a/src/components/PlanConfirmationWidget.test.tsx
+++ b/src/components/PlanConfirmationWidget.test.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { useEffect } from "react";
+import { PlanConfirmationWidget } from "./PlanConfirmationWidget";
+import { AppProvider, useEditorUI } from "@/lib/store";
+import type { Plan } from "@/lib/agents/planner";
+
+const samplePlan: Plan = {
+  goal: "Rewrite the introduction",
+  steps: [
+    { id: "step_1", instruction: "Research audience", dependsOn: [] },
+    { id: "step_2", instruction: "Draft new intro", dependsOn: ["step_1"] },
+  ],
+};
+
+function SetPlanConfirmation({
+  resolve,
+}: {
+  resolve: (accepted: boolean) => void;
+}) {
+  const { setPendingPlanConfirmation } = useEditorUI();
+  useEffect(() => {
+    setPendingPlanConfirmation({ plan: samplePlan, resolve });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
+}
+
+function renderWidget(resolve: (accepted: boolean) => void = vi.fn()) {
+  return render(
+    <AppProvider>
+      <SetPlanConfirmation resolve={resolve} />
+      <PlanConfirmationWidget />
+    </AppProvider>,
+  );
+}
+
+describe("PlanConfirmationWidget", () => {
+  it("renders nothing when pendingPlanConfirmation is null", () => {
+    const { container } = render(
+      <AppProvider>
+        <PlanConfirmationWidget />
+      </AppProvider>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the plan goal when pendingPlanConfirmation is set", async () => {
+    renderWidget();
+    expect(
+      await screen.findByText("Rewrite the introduction"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one list item per step with instruction text", async () => {
+    renderWidget();
+    expect(await screen.findByText("Research audience")).toBeInTheDocument();
+    expect(screen.getByText("Draft new intro")).toBeInTheDocument();
+  });
+
+  it("calls resolve(true) when Confirm is clicked", async () => {
+    const user = userEvent.setup();
+    const resolve = vi.fn();
+    renderWidget(resolve);
+    await screen.findByText("Rewrite the introduction");
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(resolve).toHaveBeenCalledWith(true);
+  });
+
+  it("calls resolve(false) when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const resolve = vi.fn();
+    renderWidget(resolve);
+    await screen.findByText("Rewrite the introduction");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(resolve).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/PlanConfirmationWidget.tsx
+++ b/src/components/PlanConfirmationWidget.tsx
@@ -1,0 +1,37 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEditorUI } from "@/lib/store";
+import { Button } from "./ui/button";
+
+export function PlanConfirmationWidget() {
+  const { pendingPlanConfirmation } = useEditorUI();
+
+  if (!pendingPlanConfirmation) return null;
+
+  const { plan, resolve } = pendingPlanConfirmation;
+
+  return (
+    <div className="mx-4 mb-3 rounded-md border bg-muted/30 p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">
+        Confirm Plan
+      </p>
+      <p className="text-sm mb-3">{plan.goal}</p>
+      <ol className="list-decimal list-inside space-y-1 mb-4">
+        {plan.steps.map((step) => (
+          <li key={step.id} className="text-sm text-muted-foreground">
+            {step.instruction}
+          </li>
+        ))}
+      </ol>
+      <div className="flex gap-2">
+        <Button size="sm" onClick={() => resolve(true)}>
+          Confirm
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => resolve(false)}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -4,6 +4,7 @@
 import React, { createContext, useContext, useState, useEffect } from "react";
 import * as monaco from "monaco-editor";
 import { Skill, initializeSkills, saveSkills } from "./skills";
+import type { Plan } from "./agents/planner";
 
 export interface Suggestion {
   id: string;
@@ -15,6 +16,11 @@ export interface Suggestion {
 }
 
 export interface TabSwitchRequest {
+  resolve: (accepted: boolean) => void;
+}
+
+export interface PlanConfirmationRequest {
+  plan: Plan;
   resolve: (accepted: boolean) => void;
 }
 
@@ -70,6 +76,8 @@ interface EditorUIState {
   setPendingTabSwitchRequest: (req: TabSwitchRequest | null) => void;
   pendingWorkspaceAction: WorkspaceActionRequest | null;
   setPendingWorkspaceAction: (action: WorkspaceActionRequest | null) => void;
+  pendingPlanConfirmation: PlanConfirmationRequest | null;
+  setPendingPlanConfirmation: (req: PlanConfirmationRequest | null) => void;
   approveAll: boolean;
   setApproveAll: (approve: boolean) => void;
   workflowState: WorkflowState | null;
@@ -107,6 +115,8 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
     useState<TabSwitchRequest | null>(null);
   const [pendingWorkspaceAction, setPendingWorkspaceAction] =
     useState<WorkspaceActionRequest | null>(null);
+  const [pendingPlanConfirmation, setPendingPlanConfirmation] =
+    useState<PlanConfirmationRequest | null>(null);
   const [approveAll, setApproveAll] = useState(false);
   const [workflowState, setWorkflowState] = useState<WorkflowState | null>(
     null,
@@ -153,6 +163,8 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
     setPendingTabSwitchRequest,
     pendingWorkspaceAction,
     setPendingWorkspaceAction,
+    pendingPlanConfirmation,
+    setPendingPlanConfirmation,
     approveAll,
     setApproveAll,
     workflowState,

--- a/src/lib/tools/DelegationTools.test.ts
+++ b/src/lib/tools/DelegationTools.test.ts
@@ -70,7 +70,13 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory, mockCreate } = makeFactory(mockRunStream);
     const { editorTools, workspaceTools } = makeTools(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, editorTools, workspaceTools);
+    registerDelegationTools(
+      registry,
+      factory,
+      editorTools,
+      workspaceTools,
+      vi.fn(),
+    );
 
     await callTool(registry, "invoke_agent", {
       systemPrompt: "Be brief.",
@@ -87,7 +93,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
 
     const raw = await callTool(registry, "invoke_agent", {
       systemPrompt: "Help.",
@@ -106,7 +112,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
 
     const onEvent = vi.fn();
     await callTool(
@@ -130,7 +136,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory, mockRunBuilder } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
 
     await callTool(registry, "invoke_agent", {
       systemPrompt: "s",
@@ -146,7 +152,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
 
     const tool = registry.get("invoke_agent");
     expect(tool).toBeDefined();
@@ -157,7 +163,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory, mockRunBuilder } = makeFactory(mockRunStream);
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
 
     await callTool(registry, "invoke_agent", {
       systemPrompt: "s",
@@ -176,12 +182,20 @@ describe("registerDelegationTools / invoke_agent", () => {
 });
 
 describe("registerDelegationTools / invoke_planner", () => {
+  let autoConfirm: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    autoConfirm = vi.fn().mockImplementation((req) => {
+      if (req) req.resolve(true);
+    });
+  });
+
   it("invoke_planner tool is registered on the registry", () => {
     const mockRunStream = vi.fn();
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
 
     const tool = registry.get("invoke_planner");
     expect(tool).toBeDefined();
@@ -200,7 +214,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, autoConfirm);
 
     const raw = await callTool(registry, "invoke_planner", {
       task: "Write a blog post about AI",
@@ -218,7 +232,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, autoConfirm);
 
     await callTool(registry, "invoke_planner", {
       task: "Write a blog post",
@@ -237,7 +251,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
 
     await expect(
       callTool(registry, "invoke_planner", { task: "t" }),
@@ -251,10 +265,76 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
 
     await expect(
       callTool(registry, "invoke_planner", { task: "t" }),
     ).rejects.toThrow("missing required fields");
+  });
+
+  it("calls setPendingPlanConfirmation with the plan before awaiting", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeTools(factory);
+    registerDelegationTools(registry, factory, et, wt, autoConfirm);
+
+    await callTool(registry, "invoke_planner", { task: "Write a blog post" });
+
+    expect(autoConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: validPlan }),
+    );
+  });
+
+  it("clears pendingPlanConfirmation with null after resolution", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeTools(factory);
+    registerDelegationTools(registry, factory, et, wt, autoConfirm);
+
+    await callTool(registry, "invoke_planner", { task: "t" });
+
+    expect(autoConfirm).toHaveBeenCalledWith(null);
+  });
+
+  it("throws 'Plan rejected by user.' when confirmation resolves with false", async () => {
+    const rejectConfirm = vi.fn().mockImplementation((req) => {
+      if (req) req.resolve(false);
+    });
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeTools(factory);
+    registerDelegationTools(registry, factory, et, wt, rejectConfirm);
+
+    await expect(
+      callTool(registry, "invoke_planner", { task: "t" }),
+    ).rejects.toThrow("Plan rejected by user.");
+  });
+
+  it("clears pendingPlanConfirmation with null even when rejected", async () => {
+    const rejectConfirm = vi.fn().mockImplementation((req) => {
+      if (req) req.resolve(false);
+    });
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeTools(factory);
+    registerDelegationTools(registry, factory, et, wt, rejectConfirm);
+
+    await expect(
+      callTool(registry, "invoke_planner", { task: "t" }),
+    ).rejects.toThrow();
+
+    expect(rejectConfirm).toHaveBeenCalledWith(null);
   });
 });

--- a/src/lib/tools/DelegationTools.ts
+++ b/src/lib/tools/DelegationTools.ts
@@ -9,6 +9,7 @@ import {
   Plan,
   PLANNER_SYSTEM_PROMPT,
 } from "../agents/planner";
+import type { PlanConfirmationRequest } from "../store";
 import { EditorTools } from "./EditorTools";
 import { WorkspaceTools } from "./WorkspaceTools";
 import { buildReadonlyRegistry } from "./registries";
@@ -18,6 +19,7 @@ export function registerDelegationTools(
   factory: AgentRunnerFactory,
   editorTools: EditorTools,
   workspaceTools: WorkspaceTools,
+  setPendingPlanConfirmation: (req: PlanConfirmationRequest | null) => void,
 ): void {
   registry.register({
     definition: () => ({
@@ -126,6 +128,15 @@ export function registerDelegationTools(
             throw new Error(
               "invoke_planner: plan is missing required fields (goal, steps)",
             );
+          }
+
+          const accepted = await new Promise<boolean>((resolve) => {
+            setPendingPlanConfirmation({ plan, resolve });
+          });
+          setPendingPlanConfirmation(null);
+
+          if (!accepted) {
+            throw new Error("Plan rejected by user.");
           }
           return JSON.stringify(plan);
         }

--- a/src/lib/tools/EditorTools.test.ts
+++ b/src/lib/tools/EditorTools.test.ts
@@ -574,7 +574,6 @@ describe("EditorTools", () => {
       expect(agentConfig.tools).not.toContain("edit");
       expect(agentConfig.tools).not.toContain("write");
     });
-
   });
 
   describe("write", () => {


### PR DESCRIPTION
## Summary

- `invoke_planner` now pauses after producing a plan and awaits explicit user approval via a new `PlanConfirmationRequest` stored in `EditorUIState`
- New `PlanConfirmationWidget` renders inline in `ChatSidebar` showing the plan goal and numbered steps with **Confirm** / **Cancel** buttons
- Confirming resumes the Orchestrator with the plan JSON; cancelling throws `"Plan rejected by user."` for the Orchestrator to handle

## Test plan

- [ ] All 283 existing tests pass (`npm run test`)
- [ ] New `DelegationTools.test.ts` cases: `setPendingPlanConfirmation` called with plan, cleared with `null` on both outcomes, throws on rejection
- [ ] New `PlanConfirmationWidget.test.tsx`: renders nothing when null, shows goal + steps when set, resolves `true`/`false` on button clicks
- [ ] `npm run lint` — no new errors or warnings