### PR TITLE
docs: Phase F plan — Research Agent

### DIFF
--- a/docs/multi-agent/PHASE-F.md
+++ b/docs/multi-agent/PHASE-F.md
@@ -1,0 +1,252 @@
+# Phase F: Research Agent
+
+## Goal
+
+Implement the Research Agent as a structured pipeline that replaces the ad-hoc `query_workspace` / `query_workspace_doc` calls. Phase F introduces `researcher.ts`, the `invoke_researcher` delegation tool, and wires it into the existing `AgentItem` chat block — no new UI components.
+
+---
+
+## Context
+
+Phase E delivered:
+
+- `vitest.evals.config.ts` and the `npm run evals` script.
+- The shared `judge(text, rubric, criteria, adapter)` helper in `src/lib/agents/evals/judge.ts`.
+- The first eval suite: `planning.eval.ts` + `fixtures/planning.json`.
+
+The existing `query_workspace` and `query_workspace_doc` methods on `WorkspaceTools` already implement a map-reduce pattern: per-doc sub-agents produce summaries, a synthesizer sub-agent merges them. Phase F lifts this logic into a proper agent with a typed output (`ResearchResult`) and exposes it through a first-class delegation tool. The per-doc sub-agents are updated to also extract an `excerpt` field so the Orchestrator and Writer can attribute claims in their responses.
+
+---
+
+## What changes
+
+### 1. `ResearchResult` type (in `src/lib/agents/researcher.ts`)
+
+```ts
+export interface ResearchSource {
+  id: string;
+  title: string;
+  excerpt: string; // most relevant verbatim passage, ≤ 200 chars
+}
+
+export interface ResearchResult {
+  summary: string;
+  sources: ResearchSource[];
+}
+```
+
+These types are exported from `researcher.ts` and re-exported through `src/lib/agents/index.ts`.
+
+---
+
+### 2. `src/lib/agents/researcher.ts` (new)
+
+Contains the system prompts, factory functions, and the shared `runResearch` helper.
+
+**Per-document querier system prompt:**
+
+```
+You are a document research assistant. You will be given a document's content and a query.
+Return ONLY valid JSON: { "summary": "...", "excerpt": "..." }
+- summary: a concise answer to the query from this document's perspective (1–3 sentences).
+- excerpt: the single most relevant verbatim passage from the document (≤ 200 characters).
+If the document contains nothing relevant, return { "summary": "No relevant content.", "excerpt": "" }.
+```
+
+**Synthesizer system prompt:**
+
+```
+You are a research synthesizer. You will be given a query and a list of per-document summaries with their source titles.
+Produce ONLY valid JSON: { "summary": "..." }
+- summary: a single coherent answer that combines the per-document summaries. Cite document titles for any claim (e.g. "According to 'Style Guide', ...").
+- If all summaries say "No relevant content.", return { "summary": "No relevant content found in workspace." }.
+```
+
+**Factory functions** (same pattern as `createPlannerAgent`):
+
+```ts
+export function createDocQuerierAgent(factory: AgentRunnerFactory): AgentRunner
+export function createSynthesizerAgent(factory: AgentRunnerFactory): AgentRunner
+```
+
+**Core research logic:**
+
+```ts
+export async function runResearch(
+  query: string,
+  docs: WorkspaceDocument[],
+  factory: AgentRunnerFactory,
+  docIds?: string[],
+): Promise<ResearchResult>
+```
+
+- Filters `docs` to only those in `docIds` if provided; otherwise uses all docs.
+- Runs each filtered doc through `createDocQuerierAgent` in series (parallel is Phase I). Collects `{ summary, excerpt }` per doc.
+- Filters out docs where `summary === "No relevant content."` — these are excluded from `sources`.
+- Passes the remaining summaries to `createSynthesizerAgent` to produce the final `summary`.
+- Returns `ResearchResult` with the synthesized `summary` and a `sources` array of `{ id, title, excerpt }` for each contributing doc.
+
+---
+
+### 3. `WorkspaceTools.ts` — update `query_workspace_doc` and `query_workspace`
+
+`query_workspace_doc` is updated to use the new per-doc querier system prompt and return `{ summary, excerpt }` instead of `{ summary }`. The tool registration description is updated to reflect the new `excerpt` field.
+
+`query_workspace` is refactored to call `runResearch` internally so the two share the same prompt logic. Its return shape changes from `{ answer }` to `{ summary, sources }` to match `ResearchResult`. The tool registration description is updated accordingly.
+
+`docsRef` is exposed as a public readonly property so `registerDelegationTools` can access it without widening the function signature.
+
+---
+
+### 4. `DelegationTools.ts` — add `invoke_researcher` tool
+
+```ts
+registry.register({
+  definition: () => ({
+    name: "invoke_researcher",
+    description:
+      "Queries workspace documents and synthesizes a structured answer. Returns JSON: { summary, sources: [{ id, title, excerpt }] }. Use this when the task requires finding information across workspace documents before writing or reviewing.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The question or information need to research.",
+        },
+        docIds: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional list of document IDs to restrict the search to. If omitted, all workspace documents are queried.",
+        },
+      },
+      required: ["query"],
+    },
+  }),
+  call: async (args: { query: string; docIds?: string[] }) => {
+    const docs = workspaceTools.docsRef.current;
+    const result = await runResearch(args.query, docs, factory, args.docIds);
+    return JSON.stringify(result);
+  },
+});
+```
+
+---
+
+### 5. Orchestrator system prompt update (`src/lib/agents/orchestrator.ts`)
+
+Add guidance for when to use `invoke_researcher` vs direct workspace tools:
+
+> Use `invoke_researcher` when a plan step calls for synthesized research across workspace documents — it returns a structured answer with source attributions the Writer can cite. Use `query_workspace_doc` for a quick targeted lookup of a single known document. Prefer `invoke_researcher` for any multi-document or open-ended information need.
+
+---
+
+### 7. `src/lib/agents/evals/fixtures/routing.json` (new)
+
+Ten routing fixtures. Each entry has:
+
+```json
+{
+  "prompt": "string — what the user typed",
+  "expectedTool": "invoke_planner" | "invoke_researcher" | "none",
+  "rationale": "string — why this tool is correct"
+}
+```
+
+Coverage (5 researcher, 3 planner, 2 none/direct):
+
+| # | Prompt type | Expected tool |
+|---|-------------|--------------|
+| 1 | "Find all mentions of the deadline in my notes" | `invoke_researcher` |
+| 2 | "Summarise the key points from my research documents" | `invoke_researcher` |
+| 3 | "What does the style guide say about headings?" | `invoke_researcher` |
+| 4 | "Look up the background section in my outline" | `invoke_researcher` |
+| 5 | "What do my docs say about the target audience?" | `invoke_researcher` |
+| 6 | "Write a blog post about async collaboration" | `invoke_planner` |
+| 7 | "Research my notes and draft a conclusion" | `invoke_planner` |
+| 8 | "Edit this paragraph to be more concise" | `none` |
+| 9 | "Fix the typos in the selection" | `none` |
+| 10 | "Write a one-line summary of the active document" | `none` |
+
+---
+
+### 8. `src/lib/agents/evals/routing.eval.ts` (new)
+
+Asserts that the Orchestrator routes each fixture to the expected tool (or makes no delegation call for `"none"` fixtures).
+
+**Setup:**
+
+- Reads `GEMINI_API_KEY` and `GEMINI_MODEL` from `process.env`.
+- Uses `describe.skipIf(!apiKey)` so the suite is skipped cleanly when no key is present.
+- Creates a `GoogleGenAIAdapter` and `DefaultAgentRunnerFactory`.
+
+**Stub tools:**
+
+Register lightweight stubs for `invoke_planner`, `invoke_researcher`, and `invoke_agent` that push their tool name to a `calledTools: string[]` array and return a minimal valid response (`"{}"` for planner, `'{"summary":"","sources":[]}'` for researcher) so the Orchestrator can continue without errors.
+
+**Per-fixture test (`it.each`):**
+
+1. Reset `calledTools = []`.
+2. Build the orchestrator `AgentConfig` with the full tool set (including stubs).
+3. Stream `runner.runBuilder(agentConfig).runStream(fixture.prompt)` until `done`.
+4. Assert `calledTools` contains `fixture.expectedTool` (or is empty for `"none"` fixtures).
+
+**Aggregate test:**
+
+One final `it("routing accuracy ≥ 80%")` counts passing fixtures and asserts the pass rate is at least 80%, tolerating a few model misjudgements without hard-failing.
+
+---
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `src/lib/tools/WorkspaceTools.ts` | Update `query_workspace_doc` to return `{ summary, excerpt }`. Refactor `query_workspace` to delegate to `runResearch`. Expose `docsRef` as public. |
+| `src/lib/tools/DelegationTools.ts` | Add `invoke_researcher` tool registration. |
+| `src/lib/agents/index.ts` | Re-export `ResearchResult`, `ResearchSource` from `researcher.ts`. |
+| `src/lib/agents/orchestrator.ts` | Add guidance for `invoke_researcher` vs `query_workspace_doc`. |
+
+## Files created
+
+| File | Purpose |
+|------|---------|
+| `src/lib/agents/researcher.ts` | `ResearchResult` types, agent factory functions, `runResearch` helper. |
+| `src/lib/agents/evals/routing.eval.ts` | Routing accuracy eval suite. |
+| `src/lib/agents/evals/fixtures/routing.json` | Ten routing fixtures. |
+
+---
+
+## Tests
+
+New unit tests in `src/lib/tools/DelegationTools.test.ts` (or a new `researcher.test.ts`):
+
+- `invoke_researcher` with two docs returns a `ResearchResult` with `summary` string and `sources` array.
+- Each source in `sources` has `id`, `title`, and `excerpt` fields.
+- `invoke_researcher` with `docIds` filters to only the specified docs.
+- When no docs contain relevant content, `sources` is empty and `summary` indicates no content was found.
+- `query_workspace_doc` result now includes an `excerpt` field alongside `summary`.
+
+Existing `WorkspaceTools.test.ts` tests must remain green; update assertions for `query_workspace_doc` to accept the new `{ summary, excerpt }` shape.
+
+---
+
+## Evals
+
+`npm run evals` runs both `planning.eval.ts` (Phase E) and `routing.eval.ts` (Phase F). No infrastructure changes needed.
+
+---
+
+## Branch & PR
+
+```
+git checkout multi-agent && git pull origin multi-agent
+git checkout -b multi-agent-phase-f
+# ... implement ...
+gh pr create --base multi-agent --head multi-agent-phase-f
+```
+
+---
+
+## Working state
+
+`invoke_researcher` is available to the Orchestrator as a first-class delegation tool. Calling it runs the map-reduce pipeline across workspace documents and returns a structured `ResearchResult`. The chat sidebar shows it as a collapsible `Researcher` agent block (reusing the existing `AgentItem`). The orchestrator system prompt guides the agent to prefer `invoke_researcher` for multi-document research needs. Routing evals confirm the Orchestrator calls the right agent for the right class of prompt.

--- a/docs/multi-agent/PLAN.md
+++ b/docs/multi-agent/PLAN.md
@@ -259,6 +259,7 @@ interface ResearchResult {
 - Returns structured output so the Orchestrator and Writer can consume it reliably.
 - Source excerpts allow the Writer to attribute claims without re-querying.
 - Can run in parallel with other agents when the plan has no dependency.
+- **No specialized chat UI.** `invoke_researcher` doesn't stream child events, so it renders as a plain ToolItem showing params + result. The Orchestrator's text response conveys attribution naturally.
 
 ---
 
@@ -285,6 +286,7 @@ interface ResearchResult {
 - The Orchestrator then calls `edit()` / `write()` with the draft, triggering the normal approval workflow.
 - Separating generation from application keeps the approval model clean.
 - Uses the user's globally selected model.
+- **No specialized chat UI.** `invoke_writer` renders as a plain ToolItem. The user sees the result when the Orchestrator surfaces it through the edit/write approval flow.
 
 ---
 
@@ -348,6 +350,7 @@ interface ReviewResult {
 - The Orchestrator decides whether to apply fixes automatically or present them to the user.
 - If `passed: false` with `errors`, the Orchestrator can re-invoke the Writer with the feedback before presenting to the user.
 - The existing user-defined Skills can map cleanly onto this interface.
+- **No specialized chat UI.** `invoke_reviewer` renders as a plain ToolItem showing the `ReviewResult` JSON.
 
 ---
 
@@ -433,40 +436,21 @@ Orchestrator
 
 ### Agent Attribution in Chat
 
-Each message in `ChatSidebar` gains an optional `agentRole` label:
+Only delegation tools that stream child events get attributed `AgentItem` blocks in `ChatSidebar`:
 
-```
-┌─────────────────────────────────────────┐
-│ 🤖 Orchestrator                         │
-│  I'll plan this task first...           │
-├─────────────────────────────────────────┤
-│ 📋 Planner                  [collapsed] │
-│  ▶ Step 1: Research key points          │
-│  ▶ Step 2: Draft conclusion             │
-│  ▶ Step 3: Proofread                    │
-├─────────────────────────────────────────┤
-│ 🔍 Research Agent           [collapsed] │
-│  Queried 3 documents...                 │
-├─────────────────────────────────────────┤
-│ ✏️  Writer Agent             [collapsed] │
-│  Drafted 2 paragraphs...               │
-└─────────────────────────────────────────┘
-```
+- `invoke_agent` → `AgentItem` with `agentRole: "Agent"` (already implemented)
+- `invoke_planner` → rendered as a plain ToolItem (the plan is surfaced via `PlanConfirmationWidget`, not a streaming block)
 
-Sub-agent activity blocks are collapsible, similar to the existing thinking chunk panels.
+All other delegation tools (`invoke_researcher`, `invoke_writer`, `invoke_reviewer`) render as plain ToolItems showing their params and result. Attributed chat blocks add complexity only worth paying when there are streaming child events to display.
 
 ### Plan Confirmation Widget
 
 When the Orchestrator invokes the Planner, the resulting plan is displayed as an interactive checklist in the chat. The user can:
 
 - **Confirm** — proceed with all steps.
-- **Edit** — modify a step's instruction before confirming.
-- **Remove step** — exclude a step from execution.
 - **Cancel** — abort the workflow.
 
-### Parallel Progress Indicator
-
-When the plan has parallel branches, the chat shows them as concurrent progress bars until all complete.
+Step editing and removal are deferred — confirm/cancel is sufficient for now.
 
 ---
 
@@ -539,6 +523,8 @@ This is held in React state (not localStorage) and drives the Plan Confirmation 
 
 ## Implementation Phases
 
+> **PR workflow reminder:** each phase uses `multi-agent-phase-<x>` branched off `multi-agent`, with a PR back to `multi-agent` — never to `main`. See the Branching Strategy section above for the exact commands.
+
 ### Phase A: Foundation ✅
 
 **Goal:** Establish the shared infrastructure all agents depend on — factory, delegation tools, generic agent, streaming attribution, and `WorkflowState`.
@@ -581,7 +567,7 @@ This is held in React state (not localStorage) and drives the Plan Confirmation 
 
 ---
 
-### Phase C: Planner Agent
+### Phase C: Planner Agent ✅
 
 **Goal:** Implement the LLM agent that decomposes a task into a structured `Plan` and wire it as an invokable tool. No UI gate yet — `invoke_planner` returns the plan as a string and the Orchestrator proceeds immediately.
 
@@ -599,7 +585,7 @@ This is held in React state (not localStorage) and drives the Plan Confirmation 
 
 ---
 
-### Phase D: Plan Confirmation
+### Phase D: Plan Confirmation ✅
 
 **Goal:** Gate plan execution behind explicit user approval. `invoke_planner` pauses after producing a plan, populates `WorkflowState`, and waits for the user to confirm or cancel — the same pattern as `pendingTabSwitchRequest`.
 
@@ -619,7 +605,7 @@ This is held in React state (not localStorage) and drives the Plan Confirmation 
 
 ---
 
-### Phase E: Eval Infrastructure
+### Phase E: Eval Infrastructure ✅
 
 **Goal:** Add the two-tier eval harness and the first eval suite (planning quality). All subsequent phases drop their eval files straight into this structure.
 
@@ -663,15 +649,15 @@ This is held in React state (not localStorage) and drives the Plan Confirmation 
 
 - Implement `src/lib/agents/writer.ts` + `invoke_writer` tool in `DelegationTools.ts` (no tool access, text generation only).
 - Orchestrator receives draft text and applies it via `edit()` / `write()` through the normal approval workflow.
-- Writer Agent block in chat, streaming.
+- `invoke_writer` renders as a plain ToolItem — no specialized chat UI.
 
-**Files modified:** `src/lib/tools/DelegationTools.ts`, `src/lib/agents/index.ts`, `src/components/ChatItem.tsx`, `src/components/ChatSidebar.tsx` (detect `invoke_writer` calls → create attributed writer block).
+**Files modified:** `src/lib/tools/DelegationTools.ts`, `src/lib/agents/index.ts`.
 
 **Files created:** `src/lib/agents/writer.ts`, `src/lib/agents/evals/writing.eval.ts`, `src/lib/agents/evals/fixtures/writing.json`.
 
 **Tests:** Writer factory has no tools; `invoke_writer` returns raw text; Orchestrator correctly passes research context through to the prompt.
 
-**Evals:** `fixtures/writing.json` + `writing.eval.ts` — score draft on relevance, coherence, and style match using the `judge` helper from Phase D.
+**Evals:** `fixtures/writing.json` + `writing.eval.ts` — score draft on relevance, coherence, and style match using the `judge` helper.
 
 **Working state:** Orchestrator can delegate drafting to a specialist and apply the result through the approval workflow.
 
@@ -679,43 +665,40 @@ This is held in React state (not localStorage) and drives the Plan Confirmation 
 
 ### Phase H: Review Agent + Iterative Refinement
 
-**Goal:** Structured feedback loop before content is applied; Writer → Reviewer cycles with hard iteration cap and error recovery.
+**Goal:** Structured feedback loop before content is applied; Writer → Reviewer cycles guided by the Orchestrator's system prompt.
 
 - Implement `src/lib/agents/reviewer.ts` + `invoke_reviewer` tool in `DelegationTools.ts`.
-- Orchestrator loops Writer → Reviewer up to 3 times before forcing user approval.
-- Error recovery: retry a failed step once; skip and report to user on second failure.
-- Map existing user-defined Skills onto `criteria` so they act as reviewer configurations.
-- Review Agent block in chat with expandable issue list.
+- Orchestrator loops Writer → Reviewer; the iteration cap and retry behaviour are expressed in the Orchestrator's system prompt ("loop at most 3 times; if a step fails twice, report to the user and stop"), not in application state.
+- `invoke_reviewer` renders as a plain ToolItem — no specialized chat UI.
 
-**Files modified:** `src/lib/tools/DelegationTools.ts`, `src/lib/agents/index.ts`, `src/lib/store.tsx` (iteration counter in `WorkflowState`/`EditorUIState`), `src/components/ChatItem.tsx`, `src/components/ChatSidebar.tsx` (detect `invoke_reviewer` calls → create attributed review block), `src/lib/agents/orchestrator.ts` (add Orchestrator guidance for Writer → Reviewer loop and iteration cap).
+**Files modified:** `src/lib/tools/DelegationTools.ts`, `src/lib/agents/index.ts`, `src/lib/agents/orchestrator.ts` (add Writer → Reviewer loop guidance and iteration cap instruction).
 
 **Files created:** `src/lib/agents/reviewer.ts`, `src/lib/agents/evals/reviewing.eval.ts`, `src/lib/agents/evals/fixtures/reviewing.json`.
 
-**Tests:** Reviewer returns valid `ReviewResult`; iteration counter enforces 3-cycle limit; retry logic retries once then marks step skipped; skipped step surfaced in chat.
+**Tests:** Reviewer returns valid `ReviewResult`; `invoke_reviewer` passes criteria through to the agent prompt.
 
 **Evals:** `fixtures/reviewing.json` + `reviewing.eval.ts` — score recall (missed errors) and precision (false positives) against known-error fixtures.
 
-**Working state:** Orchestrator can proofread or fact-check a draft, iterate to fix issues, and fall back to user approval when the limit is reached.
+**Working state:** Orchestrator can proofread or fact-check a draft, iterate to fix issues, and present the final result for user approval.
 
 ---
 
 ### Phase I: Parallel Execution + Full Pipelines
 
-**Goal:** Enable the Planner to express parallel branches; complete the Plan Confirmation Widget; validate end-to-end pipelines against the single-agent baseline.
+**Goal:** Enable the Planner to express parallel branches and validate end-to-end pipelines against the single-agent baseline.
 
 - Update `Plan.steps[].dependsOn` to support parallel fan-out; execute independent steps concurrently via `Promise.all`.
-- Parallel progress UI in `ChatSidebar`.
-- Step editing and removal in Plan Confirmation Widget.
+- No dedicated parallel progress UI — parallel tool calls appear as sequential ToolItems as they complete, which is sufficient.
 
-**Files modified:** `src/lib/tools/DelegationTools.ts` (parallel step execution via `Promise.all`), `src/lib/store.tsx` (`WorkflowState` parallel branch tracking), `src/components/PlanConfirmationWidget.tsx` (add step edit/remove), `src/components/ChatSidebar.tsx` (parallel progress UI).
+**Files modified:** `src/lib/tools/DelegationTools.ts` (parallel step execution via `Promise.all`), `src/lib/store.tsx` (`WorkflowState` parallel branch tracking).
 
 **Files created:** `src/lib/agents/evals/pipeline.eval.ts`, `src/lib/agents/evals/fixtures/pipeline.json`.
 
-**Tests:** Parallel steps fire concurrently; `WorkflowState` tracks each branch independently; dependent steps wait for their inputs.
+**Tests:** Parallel steps fire concurrently; dependent steps wait for their inputs.
 
 **Evals:** `fixtures/pipeline.json` + `pipeline.eval.ts` — run representative end-to-end tasks through the full Orchestrator loop and compare output quality against the current single-agent baseline using LLM-as-judge.
 
-**Working state:** Full orchestration pipelines with parallel branches, iterative refinement, error recovery, and user-controlled plan editing.
+**Working state:** Full orchestration pipelines with parallel branches and iterative refinement.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `PHASE-F.md` with the full Research Agent implementation plan
- Updates `PLAN.md`: marks Phases C/D/E as complete, trims overengineering from G/H/I, adds UI design decision notes, adds PR workflow reminder

## Key decisions recorded

- `invoke_researcher`, `invoke_writer`, and `invoke_reviewer` render as plain ToolItems — no specialized chat UI needed since they don't stream child events
- Writer → Reviewer iteration cap expressed in the Orchestrator system prompt, not application state
- Plan Confirmation Widget is confirm/cancel only; step editing deferred
- Parallel progress UI dropped from Phase I; plain ToolItems are sufficient