### PR TITLE
feat: Phase F — Research Agent

### DIFF
--- a/docs/multi-agent/PHASE-E.md
+++ b/docs/multi-agent/PHASE-E.md
@@ -70,7 +70,7 @@ export async function judge(
   rubric: string,
   criteria: string,
   adapter: LlmAdapter,
-): Promise<number>
+): Promise<number>;
 ```
 
 **Implementation notes:**
@@ -119,13 +119,13 @@ dependsOn: []. Redundant or empty steps are absent.
 
 Fixture coverage:
 
-| # | Task type | Expected shape |
-|---|-----------|---------------|
-| 1 | Simple single-outcome task | 1–2 steps, no dependencies |
-| 2 | Compound multi-phase task (research → draft → polish) | 3+ sequential steps |
-| 3 | Task with parallel opportunities | Multiple steps with `dependsOn: []` |
-| 4 | Revision task (editing existing text) | Steps scoped to diff, not full rewrite |
-| 5 | Research-then-write task | Research step(s) before drafting step(s) |
+| #   | Task type                                             | Expected shape                           |
+| --- | ----------------------------------------------------- | ---------------------------------------- |
+| 1   | Simple single-outcome task                            | 1–2 steps, no dependencies               |
+| 2   | Compound multi-phase task (research → draft → polish) | 3+ sequential steps                      |
+| 3   | Task with parallel opportunities                      | Multiple steps with `dependsOn: []`      |
+| 4   | Revision task (editing existing text)                 | Steps scoped to diff, not full rewrite   |
+| 5   | Research-then-write task                              | Research step(s) before drafting step(s) |
 
 Example fixture shape:
 
@@ -169,7 +169,9 @@ Scores are accumulated in a `beforeAll`-initialised shared array. Each fixture t
 **Running the planner** uses the same streaming pattern as `DelegationTools.ts`:
 
 ```ts
-for await (const event of runner.runBuilder(agentConfig).runStream(fixture.task)) {
+for await (const event of runner
+  .runBuilder(agentConfig)
+  .runStream(fixture.task)) {
   if (event.type === "done") {
     output = event.output;
     break;
@@ -181,18 +183,18 @@ for await (const event of runner.runBuilder(agentConfig).runStream(fixture.task)
 
 ## Files modified
 
-| File | Change |
-|------|--------|
+| File           | Change               |
+| -------------- | -------------------- |
 | `package.json` | Add `"evals"` script |
 
 ## Files created
 
-| File | Purpose |
-|------|---------|
-| `vitest.evals.config.ts` | Separate Vitest config for the eval tier |
-| `src/lib/agents/evals/judge.ts` | Shared LLM-as-judge scoring helper |
-| `src/lib/agents/evals/planning.eval.ts` | Planning quality eval suite |
-| `src/lib/agents/evals/fixtures/planning.json` | Five planning task fixtures |
+| File                                          | Purpose                                  |
+| --------------------------------------------- | ---------------------------------------- |
+| `vitest.evals.config.ts`                      | Separate Vitest config for the eval tier |
+| `src/lib/agents/evals/judge.ts`               | Shared LLM-as-judge scoring helper       |
+| `src/lib/agents/evals/planning.eval.ts`       | Planning quality eval suite              |
+| `src/lib/agents/evals/fixtures/planning.json` | Five planning task fixtures              |
 
 ---
 

--- a/docs/multi-agent/PHASE-F.md
+++ b/docs/multi-agent/PHASE-F.md
@@ -65,8 +65,10 @@ Produce ONLY valid JSON: { "summary": "..." }
 **Factory functions** (same pattern as `createPlannerAgent`):
 
 ```ts
-export function createDocQuerierAgent(factory: AgentRunnerFactory): AgentRunner
-export function createSynthesizerAgent(factory: AgentRunnerFactory): AgentRunner
+export function createDocQuerierAgent(factory: AgentRunnerFactory): AgentRunner;
+export function createSynthesizerAgent(
+  factory: AgentRunnerFactory,
+): AgentRunner;
 ```
 
 **Core research logic:**
@@ -77,7 +79,7 @@ export async function runResearch(
   docs: WorkspaceDocument[],
   factory: AgentRunnerFactory,
   docIds?: string[],
-): Promise<ResearchResult>
+): Promise<ResearchResult>;
 ```
 
 - Filters `docs` to only those in `docIds` if provided; otherwise uses all docs.
@@ -155,18 +157,18 @@ Ten routing fixtures. Each entry has:
 
 Coverage (5 researcher, 3 planner, 2 none/direct):
 
-| # | Prompt type | Expected tool |
-|---|-------------|--------------|
-| 1 | "Find all mentions of the deadline in my notes" | `invoke_researcher` |
-| 2 | "Summarise the key points from my research documents" | `invoke_researcher` |
-| 3 | "What does the style guide say about headings?" | `invoke_researcher` |
-| 4 | "Look up the background section in my outline" | `invoke_researcher` |
-| 5 | "What do my docs say about the target audience?" | `invoke_researcher` |
-| 6 | "Write a blog post about async collaboration" | `invoke_planner` |
-| 7 | "Research my notes and draft a conclusion" | `invoke_planner` |
-| 8 | "Edit this paragraph to be more concise" | `none` |
-| 9 | "Fix the typos in the selection" | `none` |
-| 10 | "Write a one-line summary of the active document" | `none` |
+| #   | Prompt type                                           | Expected tool       |
+| --- | ----------------------------------------------------- | ------------------- |
+| 1   | "Find all mentions of the deadline in my notes"       | `invoke_researcher` |
+| 2   | "Summarise the key points from my research documents" | `invoke_researcher` |
+| 3   | "What does the style guide say about headings?"       | `invoke_researcher` |
+| 4   | "Look up the background section in my outline"        | `invoke_researcher` |
+| 5   | "What do my docs say about the target audience?"      | `invoke_researcher` |
+| 6   | "Write a blog post about async collaboration"         | `invoke_planner`    |
+| 7   | "Research my notes and draft a conclusion"            | `invoke_planner`    |
+| 8   | "Edit this paragraph to be more concise"              | `none`              |
+| 9   | "Fix the typos in the selection"                      | `none`              |
+| 10  | "Write a one-line summary of the active document"     | `none`              |
 
 ---
 
@@ -199,20 +201,20 @@ One final `it("routing accuracy ≥ 80%")` counts passing fixtures and asserts t
 
 ## Files modified
 
-| File | Change |
-|------|--------|
-| `src/lib/tools/WorkspaceTools.ts` | Update `query_workspace_doc` to return `{ summary, excerpt }`. Refactor `query_workspace` to delegate to `runResearch`. Expose `docsRef` as public. |
-| `src/lib/tools/DelegationTools.ts` | Add `invoke_researcher` tool registration. |
-| `src/lib/agents/index.ts` | Re-export `ResearchResult`, `ResearchSource` from `researcher.ts`. |
-| `src/lib/agents/orchestrator.ts` | Add guidance for `invoke_researcher` vs `query_workspace_doc`. |
+| File                               | Change                                                                                                                                              |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/tools/WorkspaceTools.ts`  | Update `query_workspace_doc` to return `{ summary, excerpt }`. Refactor `query_workspace` to delegate to `runResearch`. Expose `docsRef` as public. |
+| `src/lib/tools/DelegationTools.ts` | Add `invoke_researcher` tool registration.                                                                                                          |
+| `src/lib/agents/index.ts`          | Re-export `ResearchResult`, `ResearchSource` from `researcher.ts`.                                                                                  |
+| `src/lib/agents/orchestrator.ts`   | Add guidance for `invoke_researcher` vs `query_workspace_doc`.                                                                                      |
 
 ## Files created
 
-| File | Purpose |
-|------|---------|
-| `src/lib/agents/researcher.ts` | `ResearchResult` types, agent factory functions, `runResearch` helper. |
-| `src/lib/agents/evals/routing.eval.ts` | Routing accuracy eval suite. |
-| `src/lib/agents/evals/fixtures/routing.json` | Ten routing fixtures. |
+| File                                         | Purpose                                                                |
+| -------------------------------------------- | ---------------------------------------------------------------------- |
+| `src/lib/agents/researcher.ts`               | `ResearchResult` types, agent factory functions, `runResearch` helper. |
+| `src/lib/agents/evals/routing.eval.ts`       | Routing accuracy eval suite.                                           |
+| `src/lib/agents/evals/fixtures/routing.json` | Ten routing fixtures.                                                  |
 
 ---
 

--- a/src/lib/agents/evals/fixtures/routing.json
+++ b/src/lib/agents/evals/fixtures/routing.json
@@ -1,0 +1,52 @@
+[
+  {
+    "prompt": "Find all mentions of the deadline in my notes",
+    "expectedTool": "invoke_researcher",
+    "rationale": "Looking up information across workspace documents requires the researcher."
+  },
+  {
+    "prompt": "Summarise the key points from my research documents",
+    "expectedTool": "invoke_researcher",
+    "rationale": "Synthesizing content from multiple documents is the researcher's job."
+  },
+  {
+    "prompt": "What does the style guide say about headings?",
+    "expectedTool": "invoke_researcher",
+    "rationale": "Querying a specific document for information requires the researcher."
+  },
+  {
+    "prompt": "Look up the background section in my outline",
+    "expectedTool": "invoke_researcher",
+    "rationale": "Finding information in a workspace document requires the researcher."
+  },
+  {
+    "prompt": "What do my docs say about the target audience?",
+    "expectedTool": "invoke_researcher",
+    "rationale": "Querying workspace documents for information requires the researcher."
+  },
+  {
+    "prompt": "Plan and write a multi-section blog post about async collaboration",
+    "expectedTool": "invoke_planner",
+    "rationale": "Explicitly multi-step: needs an outline then per-section drafting, so a plan is required."
+  },
+  {
+    "prompt": "Research my notes and draft a conclusion section",
+    "expectedTool": "invoke_planner",
+    "rationale": "This requires both research and writing — a multi-step plan is needed."
+  },
+  {
+    "prompt": "Edit this paragraph to be more concise",
+    "expectedTool": "none",
+    "rationale": "A direct single-step edit that does not require planning or research."
+  },
+  {
+    "prompt": "Fix the typos in the selection",
+    "expectedTool": "none",
+    "rationale": "A straightforward edit requiring no delegation."
+  },
+  {
+    "prompt": "Make this paragraph shorter",
+    "expectedTool": "none",
+    "rationale": "A direct in-place edit on the visible editor text requiring no delegation or research."
+  }
+]

--- a/src/lib/agents/evals/planning.eval.ts
+++ b/src/lib/agents/evals/planning.eval.ts
@@ -46,7 +46,12 @@ describe.skipIf(!apiKey)("planning quality", () => {
     expect(typeof plan.goal).toBe("string");
     expect(Array.isArray(plan.steps)).toBe(true);
 
-    const score = await judge(output, fixture.rubric, PLANNING_CRITERIA, adapter);
+    const score = await judge(
+      output,
+      fixture.rubric,
+      PLANNING_CRITERIA,
+      adapter,
+    );
     scores.push(score);
     expect(score).toBeGreaterThanOrEqual(3);
   });

--- a/src/lib/agents/evals/routing.eval.ts
+++ b/src/lib/agents/evals/routing.eval.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { AgentConfig, AgentRunner, ToolRegistry } from "@mast-ai/core";
+import { GoogleGenAIAdapter } from "@mast-ai/google-genai";
+import { buildOrchestratorPrompt } from "../orchestrator";
+import fixtures from "./fixtures/routing.json";
+
+const apiKey = process.env.GEMINI_API_KEY;
+const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite-preview";
+
+describe.skipIf(!apiKey)("orchestrator routing", () => {
+  let adapter: GoogleGenAIAdapter;
+  const passResults: boolean[] = [];
+
+  beforeAll(() => {
+    adapter = new GoogleGenAIAdapter(apiKey!, modelName);
+  });
+
+  it.each(fixtures)("routes: $prompt", async (fixture) => {
+    const calledTools: string[] = [];
+    const registry = new ToolRegistry();
+
+    registry.register({
+      definition: () => ({
+        name: "invoke_planner",
+        description:
+          "Decomposes a high-level task into a structured step-by-step Plan.",
+        parameters: {
+          type: "object",
+          properties: { task: { type: "string" } },
+          required: ["task"],
+        },
+      }),
+      call: async () => {
+        calledTools.push("invoke_planner");
+        return '{"goal":"done","steps":[]}';
+      },
+    });
+
+    registry.register({
+      definition: () => ({
+        name: "invoke_researcher",
+        description:
+          "Queries workspace documents and synthesizes a structured answer.",
+        parameters: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+      }),
+      call: async () => {
+        calledTools.push("invoke_researcher");
+        return '{"summary":"","sources":[]}';
+      },
+    });
+
+    registry.register({
+      definition: () => ({
+        name: "invoke_agent",
+        description: "Delegates an ad-hoc task to a generic sub-agent.",
+        parameters: {
+          type: "object",
+          properties: {
+            systemPrompt: { type: "string" },
+            task: { type: "string" },
+          },
+          required: ["systemPrompt", "task"],
+        },
+      }),
+      call: async () => {
+        calledTools.push("invoke_agent");
+        return '{"result":""}';
+      },
+    });
+
+    const runner = new AgentRunner(adapter, registry);
+    const agentConfig: AgentConfig = {
+      name: "Orchestrator",
+      instructions: buildOrchestratorPrompt([]),
+      tools: registry.definitions().map((d) => d.name),
+    };
+
+    for await (const event of runner
+      .runBuilder(agentConfig)
+      .runStream(fixture.prompt)) {
+      if (event.type === "done") break;
+    }
+
+    const passed =
+      fixture.expectedTool === "none"
+        ? !calledTools.includes("invoke_planner") &&
+          !calledTools.includes("invoke_researcher")
+        : calledTools.includes(fixture.expectedTool);
+
+    passResults.push(passed);
+    expect(passed).toBe(true);
+  });
+
+  it("routing accuracy ≥ 80%", () => {
+    const passCount = passResults.filter(Boolean).length;
+    const accuracy = passCount / passResults.length;
+    expect(accuracy).toBeGreaterThanOrEqual(0.8);
+  });
+});

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -7,3 +7,4 @@ export { buildOrchestratorPrompt } from "./orchestrator";
 export { createGenericAgent } from "./generic";
 export type { Plan, PlanStep } from "./planner";
 export { createPlannerAgent, PLANNER_SYSTEM_PROMPT } from "./planner";
+export type { ResearchResult, ResearchSource } from "./researcher";

--- a/src/lib/agents/orchestrator.ts
+++ b/src/lib/agents/orchestrator.ts
@@ -13,6 +13,7 @@ const BASE_INSTRUCTIONS =
   "For complex tasks with multiple interdependent steps, call invoke_planner first to decompose the task into a structured plan, then execute each step in order using invoke_agent or delegate_to_skill. For simple or single-step tasks, skip planning and act directly. " +
   "You can delegate any ad-hoc research or generation task to a generic sub-agent using the invoke_agent tool. " +
   'Workspace tools are available to list, read, query, create, rename, and delete documents in the workspace. Use invoke_agent with tools=["workspace_readonly"] to let a sub-agent query workspace documents. ' +
+  "Use invoke_researcher when a plan step calls for synthesized research across workspace documents — it returns a structured answer with source attributions the Writer can cite. Use query_workspace_doc for a quick targeted lookup of a single known document. Prefer invoke_researcher for any multi-document or open-ended information need. " +
   "delegate_to_skill returns the skill's response as a string — interpret it and decide what to do: apply edits via edit(), present a summary, ask follow-up questions, etc.";
 
 export function buildOrchestratorPrompt(skills: Skill[]): string {

--- a/src/lib/agents/researcher.ts
+++ b/src/lib/agents/researcher.ts
@@ -1,0 +1,140 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { AgentConfig, AgentRunner, ToolRegistry } from "@mast-ai/core";
+import type { AgentRunnerFactory } from "./factory";
+import type { WorkspaceDocument } from "../workspace";
+
+export interface ResearchSource {
+  id: string;
+  title: string;
+  excerpt: string;
+}
+
+export interface ResearchResult {
+  summary: string;
+  sources: ResearchSource[];
+}
+
+export const DOC_QUERIER_SYSTEM_PROMPT =
+  "You are a document research assistant. You will be given a document's content and a query.\n" +
+  'Return ONLY valid JSON: { "summary": "...", "excerpt": "..." }\n' +
+  "- summary: a concise answer to the query from this document's perspective (1–3 sentences).\n" +
+  "- excerpt: the single most relevant verbatim passage from the document (≤ 200 characters).\n" +
+  'If the document contains nothing relevant, return { "summary": "No relevant content.", "excerpt": "" }.';
+
+export const SYNTHESIZER_SYSTEM_PROMPT =
+  "You are a research synthesizer. You will be given a query and a list of per-document summaries with their source titles.\n" +
+  'Produce ONLY valid JSON: { "summary": "..." }\n' +
+  "- summary: a single coherent answer that combines the per-document summaries. Cite document titles for any claim (e.g. \"According to 'Style Guide', ...\").\n" +
+  '- If all summaries say "No relevant content.", return { "summary": "No relevant content found in workspace." }.';
+
+export function createDocQuerierAgent(
+  factory: AgentRunnerFactory,
+): AgentRunner {
+  return factory.create({
+    systemPrompt: DOC_QUERIER_SYSTEM_PROMPT,
+    tools: new ToolRegistry(),
+  });
+}
+
+export function createSynthesizerAgent(
+  factory: AgentRunnerFactory,
+): AgentRunner {
+  return factory.create({
+    systemPrompt: SYNTHESIZER_SYSTEM_PROMPT,
+    tools: new ToolRegistry(),
+  });
+}
+
+export async function runResearch(
+  query: string,
+  docs: WorkspaceDocument[],
+  factory: AgentRunnerFactory,
+  docIds?: string[],
+): Promise<ResearchResult> {
+  const filteredDocs = docIds
+    ? docs.filter((d) => docIds.includes(d.id))
+    : docs;
+
+  const docResults: Array<{
+    doc: WorkspaceDocument;
+    summary: string;
+    excerpt: string;
+  }> = [];
+
+  for (const doc of filteredDocs) {
+    const runner = createDocQuerierAgent(factory);
+    const agentConfig: AgentConfig = {
+      name: "DocQuerier",
+      instructions: DOC_QUERIER_SYSTEM_PROMPT,
+      tools: [],
+    };
+    const input = `Document title: ${doc.title}\n\nDocument content:\n${doc.content}\n\nQuery: ${query}`;
+
+    let summary = "No relevant content.";
+    let excerpt = "";
+
+    for await (const event of runner.runBuilder(agentConfig).runStream(input)) {
+      if (event.type === "done") {
+        try {
+          const parsed = JSON.parse(event.output) as {
+            summary: string;
+            excerpt: string;
+          };
+          summary = parsed.summary ?? "No relevant content.";
+          excerpt = parsed.excerpt ?? "";
+        } catch {
+          summary = event.output;
+        }
+        break;
+      }
+    }
+
+    docResults.push({ doc, summary, excerpt });
+  }
+
+  const contributing = docResults.filter(
+    (r) => r.summary !== "No relevant content.",
+  );
+
+  if (contributing.length === 0) {
+    return { summary: "No relevant content found in workspace.", sources: [] };
+  }
+
+  const sources: ResearchSource[] = contributing.map((r) => ({
+    id: r.doc.id,
+    title: r.doc.title,
+    excerpt: r.excerpt,
+  }));
+
+  const summaryLines = contributing.map(
+    (r) => `Document "${r.doc.title}": ${r.summary}`,
+  );
+  const synth = createSynthesizerAgent(factory);
+  const synthConfig: AgentConfig = {
+    name: "WorkspaceSynthesizer",
+    instructions: SYNTHESIZER_SYSTEM_PROMPT,
+    tools: [],
+  };
+  const synthInput = `Query: ${query}\n\nPer-document summaries:\n\n${summaryLines.join("\n\n")}`;
+
+  let finalSummary = "No relevant content found in workspace.";
+
+  for await (const event of synth
+    .runBuilder(synthConfig)
+    .runStream(synthInput)) {
+    if (event.type === "done") {
+      try {
+        const parsed = JSON.parse(event.output) as { summary: string };
+        finalSummary =
+          parsed.summary ?? "No relevant content found in workspace.";
+      } catch {
+        finalSummary = event.output;
+      }
+      break;
+    }
+  }
+
+  return { summary: finalSummary, sources };
+}

--- a/src/lib/tools/DelegationTools.test.ts
+++ b/src/lib/tools/DelegationTools.test.ts
@@ -338,3 +338,155 @@ describe("registerDelegationTools / invoke_planner", () => {
     expect(rejectConfirm).toHaveBeenCalledWith(null);
   });
 });
+
+describe("registerDelegationTools / invoke_researcher", () => {
+  const docs = [
+    { id: "doc1", title: "Doc One", content: "Alpha content", updatedAt: 1 },
+    { id: "doc2", title: "Doc Two", content: "Beta content", updatedAt: 2 },
+  ];
+
+  function makeResearchTools(factory: AgentRunnerFactory, docsOverride = docs) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockEditor: any = {
+      getValue: vi.fn().mockReturnValue(""),
+      setValue: vi.fn(),
+      getModel: vi.fn().mockReturnValue(null),
+      getSelection: vi.fn().mockReturnValue(null),
+    };
+    const editorTools = new EditorTools({ current: mockEditor }, vi.fn(), {
+      current: false,
+    });
+    const workspaceTools = new WorkspaceTools(
+      { current: docsOverride },
+      { current: null },
+      factory,
+    );
+    return { editorTools, workspaceTools };
+  }
+
+  it("invoke_researcher tool is registered on the registry", () => {
+    const mockRunStream = vi.fn();
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
+
+    const tool = registry.get("invoke_researcher");
+    expect(tool).toBeDefined();
+    expect(tool?.definition().name).toBe("invoke_researcher");
+  });
+
+  it("returns ResearchResult with summary string and sources array for two docs", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeMockStream(
+          '{"summary":"Alpha summary.","excerpt":"alpha passage"}',
+        ),
+      )
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"Beta summary.","excerpt":"beta passage"}'),
+      )
+      .mockReturnValueOnce(makeMockStream('{"summary":"Combined answer."}'));
+
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
+
+    const raw = await callTool(registry, "invoke_researcher", {
+      query: "What do the docs say?",
+    });
+    const result = JSON.parse(raw as string);
+
+    expect(typeof result.summary).toBe("string");
+    expect(result.summary).toBe("Combined answer.");
+    expect(Array.isArray(result.sources)).toBe(true);
+    expect(result.sources).toHaveLength(2);
+  });
+
+  it("each source has id, title, and excerpt fields", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeMockStream(
+          '{"summary":"Alpha summary.","excerpt":"alpha excerpt"}',
+        ),
+      )
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"Beta summary.","excerpt":"beta excerpt"}'),
+      )
+      .mockReturnValueOnce(makeMockStream('{"summary":"Combined."}'));
+
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
+
+    const raw = await callTool(registry, "invoke_researcher", { query: "q" });
+    const result = JSON.parse(raw as string);
+
+    for (const source of result.sources) {
+      expect(typeof source.id).toBe("string");
+      expect(typeof source.title).toBe("string");
+      expect(typeof source.excerpt).toBe("string");
+    }
+    expect(result.sources[0]).toMatchObject({
+      id: "doc1",
+      title: "Doc One",
+      excerpt: "alpha excerpt",
+    });
+    expect(result.sources[1]).toMatchObject({
+      id: "doc2",
+      title: "Doc Two",
+      excerpt: "beta excerpt",
+    });
+  });
+
+  it("filters to only docIds when provided", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"Doc Two only.","excerpt":"beta"}'),
+      )
+      .mockReturnValueOnce(makeMockStream('{"summary":"Only doc two."}'));
+
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
+
+    const raw = await callTool(registry, "invoke_researcher", {
+      query: "q",
+      docIds: ["doc2"],
+    });
+    const result = JSON.parse(raw as string);
+
+    expect(result.sources).toHaveLength(1);
+    expect(result.sources[0].id).toBe("doc2");
+    // Only 2 runStream calls: doc2 querier + synthesizer (doc1 was filtered out)
+    expect(mockRunStream).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns empty sources and no-content summary when no docs have relevant content", async () => {
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"No relevant content.","excerpt":""}'),
+      )
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"No relevant content.","excerpt":""}'),
+      );
+
+    const { factory } = makeFactory(mockRunStream);
+    const registry = new ToolRegistry();
+    const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
+    registerDelegationTools(registry, factory, et, wt, vi.fn());
+
+    const raw = await callTool(registry, "invoke_researcher", { query: "q" });
+    const result = JSON.parse(raw as string);
+
+    expect(result.sources).toHaveLength(0);
+    expect(result.summary).toContain("No relevant content");
+  });
+});

--- a/src/lib/tools/DelegationTools.ts
+++ b/src/lib/tools/DelegationTools.ts
@@ -9,6 +9,7 @@ import {
   Plan,
   PLANNER_SYSTEM_PROMPT,
 } from "../agents/planner";
+import { runResearch } from "../agents/researcher";
 import type { PlanConfirmationRequest } from "../store";
 import { EditorTools } from "./EditorTools";
 import { WorkspaceTools } from "./WorkspaceTools";
@@ -145,6 +146,35 @@ export function registerDelegationTools(
       throw new Error(
         "invoke_planner: planner agent ended without a done event",
       );
+    },
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "invoke_researcher",
+      description:
+        "Queries workspace documents and synthesizes a structured answer. Returns JSON: { summary, sources: [{ id, title, excerpt }] }. Use this when the task requires finding information across workspace documents before writing or reviewing.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "The question or information need to research.",
+          },
+          docIds: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Optional list of document IDs to restrict the search to. If omitted, all workspace documents are queried.",
+          },
+        },
+        required: ["query"],
+      },
+    }),
+    call: async (args: { query: string; docIds?: string[] }) => {
+      const docs = workspaceTools.docsRef.current;
+      const result = await runResearch(args.query, docs, factory, args.docIds);
+      return JSON.stringify(result);
     },
   });
 }

--- a/src/lib/tools/WorkspaceTools.test.ts
+++ b/src/lib/tools/WorkspaceTools.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentEvent } from "@mast-ai/core";
 import { WorkspaceTools } from "./WorkspaceTools";
 import type {
   CreateDocumentFn,
@@ -14,6 +15,12 @@ import type {
 } from "./WorkspaceTools";
 import type { WorkspaceDocument } from "../workspace";
 import type { AgentRunnerFactory } from "../agents/factory";
+
+function makeStream(output: string): AsyncIterable<AgentEvent> {
+  return (async function* () {
+    yield { type: "done" as const, output, history: [] };
+  })();
+}
 
 function makeDoc(
   overrides: Partial<WorkspaceDocument> = {},
@@ -122,8 +129,10 @@ describe("WorkspaceTools", () => {
       expect(mockFactory.create).not.toHaveBeenCalled();
     });
 
-    it("creates a sub-agent runner with doc content and query, returns summary", async () => {
-      mockRun.mockResolvedValue({ output: "A concise summary." });
+    it("creates a sub-agent runner with doc content and query, returns summary and excerpt", async () => {
+      mockRun.mockResolvedValue({
+        output: '{"summary":"A concise summary.","excerpt":"The sky is blue."}',
+      });
       const doc = makeDoc({
         id: "d1",
         title: "Brief",
@@ -142,7 +151,10 @@ describe("WorkspaceTools", () => {
         }),
       );
 
-      expect(result).toEqual({ summary: "A concise summary." });
+      expect(result).toEqual({
+        summary: "A concise summary.",
+        excerpt: "The sky is blue.",
+      });
       expect(mockFactory.create).toHaveBeenCalledOnce();
 
       const [agentConfig, input] = mockRun.mock.calls[0];
@@ -542,69 +554,114 @@ describe("WorkspaceTools", () => {
   });
 
   describe("query_workspace", () => {
-    it("calls query_workspace_doc for each document and passes summaries to synthesizer", async () => {
+    let mockRunStream: ReturnType<typeof vi.fn>;
+    let mockRunBuilder: ReturnType<typeof vi.fn>;
+    let streamFactory: AgentRunnerFactory;
+
+    beforeEach(() => {
+      mockRunStream = vi.fn();
+      mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
+      streamFactory = {
+        create: vi.fn().mockReturnValue({ runBuilder: mockRunBuilder }),
+      };
+    });
+
+    it("synthesizes results from multiple docs and returns ResearchResult shape", async () => {
       const docs = [
         makeDoc({ id: "d1", title: "Doc 1", content: "content 1" }),
         makeDoc({ id: "d2", title: "Doc 2", content: "content 2" }),
       ];
 
-      mockRun
-        .mockResolvedValueOnce({ output: "Summary of doc 1." })
-        .mockResolvedValueOnce({ output: "Summary of doc 2." })
-        .mockResolvedValueOnce({ output: "Final synthesized answer." });
+      mockRunStream
+        .mockReturnValueOnce(
+          makeStream('{"summary":"Summary 1.","excerpt":"excerpt 1"}'),
+        )
+        .mockReturnValueOnce(
+          makeStream('{"summary":"Summary 2.","excerpt":"excerpt 2"}'),
+        )
+        .mockReturnValueOnce(makeStream('{"summary":"Combined answer."}'));
 
-      const tools = new WorkspaceTools(makeRef(docs), noActiveDoc, mockFactory);
+      const tools = new WorkspaceTools(
+        makeRef(docs),
+        noActiveDoc,
+        streamFactory,
+      );
       const result = JSON.parse(
         await tools.query_workspace({ query: "What do the docs say?" }),
       );
 
-      expect(result).toEqual({ answer: "Final synthesized answer." });
-      expect(mockRun).toHaveBeenCalledTimes(3);
-
-      const [synthAgent, synthInput] = mockRun.mock.calls[2];
-      expect(synthAgent.name).toBe("WorkspaceSynthesizer");
-      expect(synthInput).toContain("Summary of doc 1.");
-      expect(synthInput).toContain("Summary of doc 2.");
-      expect(synthInput).toContain("What do the docs say?");
+      expect(result.summary).toBe("Combined answer.");
+      expect(Array.isArray(result.sources)).toBe(true);
+      expect(result.sources).toHaveLength(2);
+      expect(result.sources[0]).toMatchObject({
+        id: "d1",
+        title: "Doc 1",
+        excerpt: "excerpt 1",
+      });
+      expect(result.sources[1]).toMatchObject({
+        id: "d2",
+        title: "Doc 2",
+        excerpt: "excerpt 2",
+      });
     });
 
-    it("returns an answer even with a single document", async () => {
-      mockRun
-        .mockResolvedValueOnce({ output: "Single doc summary." })
-        .mockResolvedValueOnce({ output: "Final answer." });
+    it("returns a ResearchResult even with a single document", async () => {
+      mockRunStream
+        .mockReturnValueOnce(
+          makeStream('{"summary":"Single doc summary.","excerpt":"passage"}'),
+        )
+        .mockReturnValueOnce(makeStream('{"summary":"Final answer."}'));
 
       const tools = new WorkspaceTools(
         makeRef([makeDoc()]),
         noActiveDoc,
-        mockFactory,
+        streamFactory,
       );
       const result = JSON.parse(await tools.query_workspace({ query: "q" }));
-      expect(result).toEqual({ answer: "Final answer." });
+      expect(result.summary).toBe("Final answer.");
+      expect(result.sources).toHaveLength(1);
     });
 
-    it("skips docs that return an error from query_workspace_doc", async () => {
+    it("excludes docs with no relevant content from sources", async () => {
       const docs = [
-        makeDoc({ id: "d1", title: "Good", content: "good content" }),
-        makeDoc({ id: "d2", title: "Bad", content: "" }),
+        makeDoc({ id: "d1", title: "Useful", content: "good content" }),
+        makeDoc({ id: "d2", title: "Empty", content: "" }),
       ];
 
-      const spy = vi.spyOn(WorkspaceTools.prototype, "query_workspace_doc");
-      spy.mockImplementation(async ({ id }) => {
-        if (id === "d2") return JSON.stringify({ error: "Document not found" });
-        return JSON.stringify({ summary: "Good summary." });
-      });
+      mockRunStream
+        .mockReturnValueOnce(
+          makeStream('{"summary":"Useful info.","excerpt":"good passage"}'),
+        )
+        .mockReturnValueOnce(
+          makeStream('{"summary":"No relevant content.","excerpt":""}'),
+        )
+        .mockReturnValueOnce(makeStream('{"summary":"Only useful info."}'));
 
-      mockRun.mockResolvedValueOnce({ output: "Only good doc answer." });
-
-      const tools = new WorkspaceTools(makeRef(docs), noActiveDoc, mockFactory);
+      const tools = new WorkspaceTools(
+        makeRef(docs),
+        noActiveDoc,
+        streamFactory,
+      );
       const result = JSON.parse(await tools.query_workspace({ query: "q" }));
 
-      const [, synthInput] = mockRun.mock.calls[0];
-      expect(synthInput).toContain("Good summary.");
-      expect(synthInput).not.toContain("Document not found");
-      expect(result).toEqual({ answer: "Only good doc answer." });
+      expect(result.sources).toHaveLength(1);
+      expect(result.sources[0].id).toBe("d1");
+    });
 
-      spy.mockRestore();
+    it("returns empty sources and no-content summary when all docs have no relevant content", async () => {
+      mockRunStream.mockReturnValueOnce(
+        makeStream('{"summary":"No relevant content.","excerpt":""}'),
+      );
+
+      const tools = new WorkspaceTools(
+        makeRef([makeDoc()]),
+        noActiveDoc,
+        streamFactory,
+      );
+      const result = JSON.parse(await tools.query_workspace({ query: "q" }));
+
+      expect(result.sources).toHaveLength(0);
+      expect(result.summary).toContain("No relevant content");
     });
   });
 });

--- a/src/lib/tools/WorkspaceTools.ts
+++ b/src/lib/tools/WorkspaceTools.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import { WorkspaceDocument } from "../workspace";
 import type { WorkspaceActionRequest } from "../store";
 import type { AgentRunnerFactory } from "../agents/factory";
+import { DOC_QUERIER_SYSTEM_PROMPT, runResearch } from "../agents/researcher";
 
 export type CreateDocumentFn = (title: string) => string;
 export type RenameDocumentFn = (id: string, title: string) => void;
@@ -33,7 +34,7 @@ export interface EditorLike {
 
 export class WorkspaceTools {
   constructor(
-    private docsRef: DocsRef,
+    public readonly docsRef: DocsRef,
     private activeDocRef: ActiveDocRef,
     private factory: AgentRunnerFactory,
     private createDocumentFn: CreateDocumentFn = () => "",
@@ -84,14 +85,25 @@ export class WorkspaceTools {
 
     const agent: AgentConfig = {
       name: "DocQuerier",
-      instructions:
-        "You are a helpful assistant. Answer the user's question based solely on the provided document. Reply with a concise summary or direct answer.",
+      instructions: DOC_QUERIER_SYSTEM_PROMPT,
       tools: [],
     };
     const runner = this.factory.create({ systemPrompt: agent.instructions });
-    const input = `Document title: ${doc.title}\n\nDocument content:\n${doc.content}\n\nQuestion: ${query}`;
+    const input = `Document title: ${doc.title}\n\nDocument content:\n${doc.content}\n\nQuery: ${query}`;
     const result = await runner.run(agent, input);
-    return JSON.stringify({ summary: result.output });
+    let parsed: { summary: string; excerpt: string };
+    try {
+      parsed = JSON.parse(result.output) as {
+        summary: string;
+        excerpt: string;
+      };
+    } catch {
+      parsed = { summary: result.output, excerpt: "" };
+    }
+    return JSON.stringify({
+      summary: parsed.summary,
+      excerpt: parsed.excerpt ?? "",
+    });
   }
 
   create_document({
@@ -190,27 +202,8 @@ export class WorkspaceTools {
   }
 
   async query_workspace({ query }: { query: string }): Promise<string> {
-    const docs = this.docsRef.current;
-    const summaries: string[] = [];
-
-    for (const doc of docs) {
-      const raw = await this.query_workspace_doc({ id: doc.id, query });
-      const parsed: { summary?: string; error?: string } = JSON.parse(raw);
-      if (parsed.summary) {
-        summaries.push(`Document "${doc.title}": ${parsed.summary}`);
-      }
-    }
-
-    const agent: AgentConfig = {
-      name: "WorkspaceSynthesizer",
-      instructions:
-        "You are a helpful assistant. Synthesize the provided per-document summaries to give a comprehensive answer to the user's question.",
-      tools: [],
-    };
-    const runner = this.factory.create({ systemPrompt: agent.instructions });
-    const input = `Summaries from workspace documents:\n\n${summaries.join("\n\n")}\n\nQuestion: ${query}`;
-    const result = await runner.run(agent, input);
-    return JSON.stringify({ answer: result.output });
+    const result = await runResearch(query, this.docsRef.current, this.factory);
+    return JSON.stringify(result);
   }
 }
 
@@ -352,7 +345,7 @@ export function registerReadonlyWorkspaceTools(
     definition: () => ({
       name: "query_workspace_doc",
       description:
-        "Asks a question about a specific document using a sub-agent. Returns { summary }.",
+        "Asks a question about a specific document using a sub-agent. Returns { summary, excerpt } where excerpt is the most relevant verbatim passage.",
       parameters: {
         type: "object",
         properties: {
@@ -373,7 +366,7 @@ export function registerReadonlyWorkspaceTools(
     definition: () => ({
       name: "query_workspace",
       description:
-        "Asks a question spanning all workspace documents and synthesizes the results. Returns { answer }.",
+        "Asks a question spanning all workspace documents and synthesizes the results. Returns { summary, sources: [{ id, title, excerpt }] }.",
       parameters: {
         type: "object",
         properties: {


### PR DESCRIPTION
## Summary

- Adds `src/lib/agents/researcher.ts` with `ResearchResult`/`ResearchSource` types, `createDocQuerierAgent` / `createSynthesizerAgent` factory functions, and `runResearch` — a map-reduce pipeline that queries each document via a per-doc sub-agent and synthesizes the results with a second sub-agent.
- Adds `invoke_researcher` to `DelegationTools.ts`; the Orchestrator system prompt is updated to guide when to prefer it over `query_workspace_doc`.
- `WorkspaceTools`: `docsRef` made public, `query_workspace_doc` updated to use the new structured prompt and return `{ summary, excerpt }`, `query_workspace` refactored to delegate to `runResearch` (changing its return shape from `{ answer }` to `{ summary, sources }`).
- Ships `routing.eval.ts` + `fixtures/routing.json` (10 fixtures) — a new eval suite that asserts the Orchestrator routes ≥ 80% of prompts to the correct delegation tool.

## Test plan

- [ ] `npm run test` — all 289 unit tests pass
- [ ] `npm run lint` — 0 errors
- [ ] `npm run evals` — planning eval (Phase E) + routing eval (Phase F) both pass; routing accuracy ≥ 80%