### PR TITLE
feat: Phase H — Review Agent with invoke_reviewer delegation tool

### DIFF
--- a/docs/multi-agent/PHASE-H.md
+++ b/docs/multi-agent/PHASE-H.md
@@ -1,0 +1,269 @@
+# Phase H: Review Agent + Iterative Refinement
+
+## Goal
+
+Implement the Review Agent as a specialist that evaluates draft text against explicit criteria and returns structured feedback. Phase H introduces `reviewer.ts`, the `invoke_reviewer` delegation tool, and eval coverage for review quality. The Orchestrator can loop Writer → Reviewer at most 3 times to improve a draft before presenting it for user approval.
+
+---
+
+## Context
+
+Phase G delivered:
+
+- `src/lib/agents/writer.ts` — `WRITER_SYSTEM_PROMPT`, `createWriterAgent`, `runWriter`.
+- `invoke_writer` delegation tool in `DelegationTools.ts`.
+- `writing.eval.ts` + `fixtures/writing.json` — writing quality evals.
+
+The Orchestrator can now delegate content generation to the Writer, which returns a raw draft for the Orchestrator to apply. Phase H closes the feedback loop: a dedicated Reviewer evaluates a draft against explicit criteria and returns structured issues, enabling the Orchestrator to iterate before presenting the final result to the user.
+
+---
+
+## What changes
+
+### 1. `src/lib/agents/reviewer.ts` (new)
+
+Contains the system prompt, factory function, `ReviewResult` / `ReviewIssue` types, and `runReview` helper.
+
+**Types:**
+
+```ts
+export interface ReviewIssue {
+  severity: "error" | "warning" | "suggestion";
+  location?: string; // quoted excerpt where the issue occurs
+  description: string;
+  fix?: string; // optional suggested fix
+}
+
+export interface ReviewResult {
+  passed: boolean;
+  issues: ReviewIssue[];
+  summary: string;
+}
+```
+
+**System prompt:**
+
+```
+You are a review specialist. You evaluate text against the provided criteria and return structured feedback.
+
+- Output ONLY valid JSON matching the ReviewResult schema. No prose outside the JSON.
+- Schema: { "passed": boolean, "issues": [{ "severity": "error"|"warning"|"suggestion", "location"?: string, "description": string, "fix"?: string }], "summary": string }
+- Set "location" to a short quoted excerpt from the text where each issue occurs.
+- Use severity "error" for clear mistakes, "warning" for debatable issues, "suggestion" for improvements.
+- "passed" is true only when there are no "error"-severity issues.
+- If no issues are found, return { "passed": true, "issues": [], "summary": "No issues found." }
+```
+
+**Factory function** (same pattern as `createWriterAgent`):
+
+```ts
+export function createReviewerAgent(factory: AgentRunnerFactory): AgentRunner;
+```
+
+**Core review logic:**
+
+```ts
+export async function runReview(
+  text: string,
+  criteria: string[],
+  factory: AgentRunnerFactory,
+): Promise<ReviewResult>;
+```
+
+- Builds a single prompt with the text under review and the criteria list.
+- Runs the reviewer `AgentRunner` (no tools) and collects the full output from the `done` event.
+- Parses the output as JSON into `ReviewResult`; throws a descriptive error if parsing fails or required fields (`passed`, `issues`, `summary`) are missing.
+- Returns the `ReviewResult`.
+
+**Prompt construction:**
+
+```
+Review the following text against the listed criteria and return a ReviewResult JSON object.
+
+Criteria:
+- <criterion 1>
+- <criterion 2>
+...
+
+Text:
+<text>
+```
+
+---
+
+### 2. `DelegationTools.ts` — add `invoke_reviewer` tool
+
+```ts
+registry.register({
+  definition: () => ({
+    name: "invoke_reviewer",
+    description:
+      "Evaluates a draft against explicit criteria and returns structured feedback. " +
+      "Returns JSON: { passed: boolean, issues: [{ severity, location?, description, fix? }], summary }. " +
+      "Use after invoke_writer to check a draft before applying it. " +
+      "If passed is false and error-severity issues remain after 3 Writer→Reviewer cycles, " +
+      "present the best available draft via edit() or write() and summarise remaining issues in your response.",
+    parameters: {
+      type: "object",
+      properties: {
+        text: {
+          type: "string",
+          description: "The draft text to review.",
+        },
+        criteria: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Review criteria to check against (e.g. 'grammatical correctness', 'consistent use of past tense', 'no unsupported factual claims').",
+        },
+      },
+      required: ["text", "criteria"],
+    },
+  }),
+  call: async (args: { text: string; criteria: string[] }) => {
+    const result = await runReview(args.text, args.criteria, factory);
+    return JSON.stringify(result);
+  },
+});
+```
+
+---
+
+### 3. Orchestrator system prompt update (`src/lib/agents/orchestrator.ts`)
+
+Append to `BASE_INSTRUCTIONS`:
+
+> Use `invoke_reviewer` after `invoke_writer` to evaluate a draft before applying it. If `passed` is false and the issues include errors, revise the instruction and call `invoke_writer` again incorporating the feedback. Loop at most 3 times. If errors remain after 3 cycles, apply the best available draft via `edit()` or `write()` and summarise the remaining issues in your response so the user can decide how to proceed.
+
+---
+
+### 4. `src/lib/agents/index.ts` — re-export from `reviewer.ts`
+
+```ts
+export type { ReviewResult, ReviewIssue } from "./reviewer";
+export { createReviewerAgent, REVIEWER_SYSTEM_PROMPT } from "./reviewer";
+```
+
+---
+
+### 5. `src/lib/agents/evals/fixtures/reviewing.json` (new)
+
+Eight reviewing fixtures. Each entry:
+
+```json
+{
+  "text": "string — text to review",
+  "criteria": ["list", "of", "criteria"],
+  "knownErrors": [
+    { "description": "description of the expected error", "severity": "error" | "warning" }
+  ] | null,
+  "rubric": "string — what a good review looks like for this fixture",
+  "passingThreshold": 0.7
+}
+```
+
+`knownErrors: null` means the text is clean — the reviewer should return `passed: true` with no errors (tests precision). Non-null `knownErrors` requires the reviewer to identify at least these issues (tests recall).
+
+Coverage:
+
+| #   | Scenario                                            | Known Errors?         |
+| --- | --------------------------------------------------- | --------------------- |
+| 1   | Paragraph with two clear grammar errors             | Yes (2 errors)        |
+| 2   | Paragraph with inconsistent verb tense throughout   | Yes (1 error)         |
+| 3   | Text with an unsupported factual claim              | Yes (1 error)         |
+| 4   | Text with a logical non-sequitur between sentences  | Yes (1 warning)       |
+| 5   | Text missing a required section stated in criteria  | Yes (1 error)         |
+| 6   | Clean, well-written paragraph (grammar check)       | None                  |
+| 7   | Clean text that fully satisfies all stated criteria | None                  |
+| 8   | Text with suggestions only — no errors              | None (suggestions OK) |
+
+---
+
+### 6. `src/lib/agents/evals/reviewing.eval.ts` (new)
+
+Scores each fixture using the `judge` helper and verifies recall and precision.
+
+**Setup:**
+
+- Reads `GEMINI_API_KEY` and `GEMINI_MODEL` from `process.env`.
+- Uses `describe.skipIf(!apiKey)` so the suite is skipped cleanly when no key is present.
+- Creates a `GoogleGenAIAdapter` and `DefaultAgentRunnerFactory`.
+
+**Per-fixture test (`it.each`):**
+
+1. Call `runReview(fixture.text, fixture.criteria, factory)`.
+2. Assert the result has `passed`, `issues`, and `summary` fields.
+3. For fixtures with `knownErrors`: assert `passed === false` and that each known error description has a matching issue in `result.issues` (recall check by substring or keyword overlap).
+4. For clean fixtures (`knownErrors === null`): assert `passed === true` and no `error`-severity issues (precision check).
+5. Pass the full result to `judge(JSON.stringify(result), fixture.rubric, REVIEWING_CRITERIA, adapter)` and assert `score >= 3`.
+
+**Aggregate test:**
+
+One final `it("average reviewing quality score ≥ 4")` counts scores and asserts the mean is at least 4.
+
+`REVIEWING_CRITERIA` constant used for all fixtures:
+
+```
+The review accurately identifies all genuine errors in the text. It does not
+flag correct text as erroneous. Each issue quotes the relevant excerpt in
+"location". Severity levels are applied consistently. The summary gives a
+clear overall verdict. Output is valid ReviewResult JSON with no prose outside it.
+```
+
+---
+
+## Files modified
+
+| File                               | Change                                                                                    |
+| ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| `src/lib/tools/DelegationTools.ts` | Add `invoke_reviewer` tool registration; import `runReview` from `reviewer.ts`.           |
+| `src/lib/agents/index.ts`          | Re-export `ReviewResult`, `ReviewIssue`, `createReviewerAgent`, `REVIEWER_SYSTEM_PROMPT`. |
+| `src/lib/agents/orchestrator.ts`   | Add Writer→Reviewer loop guidance and 3-iteration cap to `BASE_INSTRUCTIONS`.             |
+
+## Files created
+
+| File                                           | Purpose                                                                                      |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `src/lib/agents/reviewer.ts`                   | `ReviewResult`, `ReviewIssue`, `REVIEWER_SYSTEM_PROMPT`, `createReviewerAgent`, `runReview`. |
+| `src/lib/agents/evals/reviewing.eval.ts`       | Reviewing quality eval suite (recall + precision).                                           |
+| `src/lib/agents/evals/fixtures/reviewing.json` | Eight reviewing fixtures.                                                                    |
+
+---
+
+## Tests
+
+New unit tests in `src/lib/agents/reviewer.test.ts`:
+
+- `runReview` prompt includes all provided criteria.
+- `runReview` prompt includes the full text under review.
+- `runReview` parses valid `ReviewResult` JSON returned by the agent.
+- `runReview` throws a descriptive error when the LLM returns invalid JSON.
+- `runReview` throws when result is missing required fields (`passed`, `issues`, `summary`).
+- The reviewer agent factory creates an `AgentRunner` with an empty `ToolRegistry` (no tools).
+- `invoke_reviewer` passes `text` and `criteria` to `runReview` and returns the result as a JSON string.
+- `invoke_reviewer` result is valid JSON with `passed`, `issues`, and `summary` fields.
+
+All existing tests must remain green.
+
+---
+
+## Evals
+
+`npm run evals` now runs `planning.eval.ts` (Phase E), `routing.eval.ts` (Phase F), `writing.eval.ts` (Phase G), and `reviewing.eval.ts` (Phase H). No infrastructure changes needed.
+
+---
+
+## Branch & PR
+
+```
+git checkout multi-agent && git pull origin multi-agent
+git checkout -b multi-agent-phase-h
+# ... implement ...
+gh pr create --base multi-agent --head multi-agent-phase-h
+```
+
+---
+
+## Working state
+
+`invoke_reviewer` is available to the Orchestrator as a delegation tool. Calling it runs a no-tool reviewer agent that returns structured `ReviewResult` JSON. The Orchestrator loops Writer → Reviewer up to 3 times to improve a draft before applying it via `edit()` / `write()` for user approval. If errors remain after the iteration cap, the Orchestrator presents the best draft with a summary of outstanding issues. Reviewing evals confirm recall (known errors are caught) and precision (clean text is not falsely flagged).

--- a/src/lib/agents/evals/fixtures/reviewing.json
+++ b/src/lib/agents/evals/fixtures/reviewing.json
@@ -1,0 +1,86 @@
+[
+  {
+    "text": "The team have completed the project on time. They was very dedicated and worked hard every day. The results is impressive.",
+    "criteria": ["grammatical correctness", "subject-verb agreement"],
+    "knownErrors": [
+      {
+        "description": "subject-verb agreement error: 'team have' should be 'team has'",
+        "severity": "error"
+      },
+      {
+        "description": "subject-verb agreement error: 'They was' should be 'They were'",
+        "severity": "error"
+      }
+    ],
+    "rubric": "The review identifies both subject-verb agreement errors with their exact locations, assigns 'error' severity, and suggests correct forms. It does not flag correct sentences."
+  },
+  {
+    "text": "Yesterday, the engineer opens the dashboard and reviews the metrics. She then submitted a report and closed the ticket.",
+    "criteria": ["consistent verb tense throughout the passage"],
+    "knownErrors": [
+      {
+        "description": "inconsistent verb tense: 'opens' and 'reviews' are present tense while the rest of the passage uses past tense",
+        "severity": "error"
+      }
+    ],
+    "rubric": "The review identifies the tense inconsistency in 'opens' and 'reviews', notes the surrounding past-tense context, and suggests changing to 'opened' and 'reviewed'."
+  },
+  {
+    "text": "Water boils at 90°C at sea level. This makes it ideal for sterilising surgical instruments in hospital settings.",
+    "criteria": ["factual correctness"],
+    "knownErrors": [
+      {
+        "description": "factual error: water boils at 100°C at sea level, not 90°C",
+        "severity": "error"
+      }
+    ],
+    "rubric": "The review flags the incorrect boiling point of water, quotes the erroneous figure, and provides the correct value (100°C)."
+  },
+  {
+    "text": "The new policy reduces costs significantly. Employees are very happy. Therefore, the sky is blue.",
+    "criteria": ["logical flow and coherence between sentences"],
+    "knownErrors": [
+      {
+        "description": "logical non-sequitur: 'Therefore, the sky is blue' does not follow from the preceding sentences",
+        "severity": "warning"
+      }
+    ],
+    "rubric": "The review identifies the non-sequitur conclusion, quotes it, and notes it does not follow logically from the cost and happiness claims."
+  },
+  {
+    "text": "Our product is fast and reliable.",
+    "criteria": [
+      "must include a section describing the target audience",
+      "must include at least one concrete performance metric"
+    ],
+    "knownErrors": [
+      {
+        "description": "missing required section: no description of the target audience",
+        "severity": "error"
+      },
+      {
+        "description": "missing required content: no concrete performance metric provided",
+        "severity": "error"
+      }
+    ],
+    "rubric": "The review identifies both missing sections, explains what is required by the criteria, and suggests what content should be added."
+  },
+  {
+    "text": "The conference attracted over five hundred attendees from more than thirty countries. Speakers covered topics ranging from machine learning to climate policy. Organisers described it as the most successful edition yet.",
+    "criteria": ["grammatical correctness", "clear and natural prose"],
+    "knownErrors": null,
+    "rubric": "The review should return passed: true with no error-severity issues. The text is grammatically correct and reads naturally."
+  },
+  {
+    "text": "The Pacific Ocean is the largest and deepest ocean on Earth. It covers more than 165 million square kilometres and contains more than half of the world's oceanic water. Its average depth is approximately 4,000 metres.",
+    "criteria": ["factual correctness", "grammatical correctness"],
+    "knownErrors": null,
+    "rubric": "The review should return passed: true. All stated facts are correct and the text is grammatically sound."
+  },
+  {
+    "text": "Consider breaking this paragraph into two for improved readability. Also, using active voice here would make the sentence more direct.",
+    "criteria": ["grammatical correctness", "factual accuracy"],
+    "knownErrors": null,
+    "rubric": "The review should return passed: true since there are no errors. It may note suggestions but must not report any error-severity issues for this grammatically correct text."
+  }
+]

--- a/src/lib/agents/evals/reviewing.eval.ts
+++ b/src/lib/agents/evals/reviewing.eval.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { GoogleGenAIAdapter } from "@mast-ai/google-genai";
+import { DefaultAgentRunnerFactory } from "../factory";
+import { runReview } from "../reviewer";
+import { judge } from "./judge";
+import fixtures from "./fixtures/reviewing.json";
+
+const REVIEWING_CRITERIA =
+  "The review accurately identifies all genuine errors in the text. It does not " +
+  "flag correct text as erroneous. Each issue quotes the relevant excerpt in " +
+  '"location". Severity levels are applied consistently. The summary gives a ' +
+  "clear overall verdict. Output is valid ReviewResult JSON with no prose outside it.";
+
+const apiKey = process.env.GEMINI_API_KEY;
+const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite-preview";
+
+describe.skipIf(!apiKey)("reviewing quality", () => {
+  let adapter: GoogleGenAIAdapter;
+  let factory: DefaultAgentRunnerFactory;
+  const scores: number[] = [];
+
+  beforeAll(() => {
+    adapter = new GoogleGenAIAdapter(apiKey!, modelName);
+    factory = new DefaultAgentRunnerFactory(apiKey!, modelName);
+  });
+
+  it.each(fixtures)("fixture: $text", async (fixture) => {
+    const result = await runReview(fixture.text, fixture.criteria, factory);
+
+    expect(typeof result.passed).toBe("boolean");
+    expect(Array.isArray(result.issues)).toBe(true);
+    expect(typeof result.summary).toBe("string");
+
+    if (fixture.knownErrors !== null && fixture.knownErrors !== undefined) {
+      expect(result.passed).toBe(false);
+      for (const known of fixture.knownErrors) {
+        const lowerDesc = known.description.toLowerCase();
+        const matched = result.issues.some(
+          (issue) =>
+            issue.description.toLowerCase().includes(lowerDesc.split(":")[0]) ||
+            lowerDesc
+              .split(" ")
+              .filter((w) => w.length > 4)
+              .some((keyword) =>
+                issue.description.toLowerCase().includes(keyword),
+              ),
+        );
+        expect(
+          matched,
+          `Expected an issue matching "${known.description}" but none found in: ${JSON.stringify(result.issues)}`,
+        ).toBe(true);
+      }
+    } else {
+      expect(
+        result.issues.filter((i) => i.severity === "error"),
+        `Expected no error-severity issues but got: ${JSON.stringify(result.issues)}`,
+      ).toHaveLength(0);
+    }
+
+    const score = await judge(
+      JSON.stringify(result),
+      fixture.rubric,
+      REVIEWING_CRITERIA,
+      adapter,
+    );
+    scores.push(score);
+    expect(score).toBeGreaterThanOrEqual(3);
+  });
+
+  it("average reviewing quality score ≥ 4", () => {
+    const mean = scores.reduce((a, b) => a + b, 0) / scores.length;
+    expect(mean).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -9,3 +9,5 @@ export type { Plan, PlanStep } from "./planner";
 export { createPlannerAgent, PLANNER_SYSTEM_PROMPT } from "./planner";
 export type { ResearchResult, ResearchSource } from "./researcher";
 export { createWriterAgent, WRITER_SYSTEM_PROMPT } from "./writer";
+export type { ReviewResult, ReviewIssue } from "./reviewer";
+export { createReviewerAgent, REVIEWER_SYSTEM_PROMPT } from "./reviewer";

--- a/src/lib/agents/orchestrator.ts
+++ b/src/lib/agents/orchestrator.ts
@@ -16,7 +16,8 @@ const BASE_INSTRUCTIONS =
   'Workspace tools are available to list, read, query, create, rename, and delete documents in the workspace. Use invoke_agent with tools=["workspace_readonly"] to let a sub-agent query workspace documents. ' +
   "Use invoke_researcher when a plan step calls for synthesized research across workspace documents — it returns a structured answer with source attributions the Writer can cite. Use query_workspace_doc for a quick targeted lookup of a single known document. Prefer invoke_researcher for any multi-document or open-ended information need. " +
   "Use invoke_writer to delegate content generation to a writing specialist. Pass the result of invoke_researcher as researchContext when the draft should cite workspace sources. After receiving the draft, apply it to the document using edit() or write() — the Writer does not apply edits directly. " +
-  "delegate_to_skill returns the skill's response as a string — interpret it and decide what to do: apply edits via edit(), present a summary, ask follow-up questions, etc.";
+  "delegate_to_skill returns the skill's response as a string — interpret it and decide what to do: apply edits via edit(), present a summary, ask follow-up questions, etc. " +
+  "Use invoke_reviewer after invoke_writer to evaluate a draft before applying it. If passed is false and the issues include errors, revise the instruction and call invoke_writer again incorporating the feedback. Loop at most 3 times. If errors remain after 3 cycles, apply the best available draft via edit() or write() and summarise the remaining issues in your response so the user can decide how to proceed.";
 
 export function buildOrchestratorPrompt(skills: Skill[]): string {
   let prompt = BASE_INSTRUCTIONS;

--- a/src/lib/agents/reviewer.test.ts
+++ b/src/lib/agents/reviewer.test.ts
@@ -1,0 +1,139 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  createReviewerAgent,
+  runReview,
+  REVIEWER_SYSTEM_PROMPT,
+} from "./reviewer";
+import { ToolRegistry } from "@mast-ai/core";
+import type { AgentRunnerFactory } from "./factory";
+import type { ReviewResult } from "./reviewer";
+
+function makeFactory(output: string): {
+  factory: AgentRunnerFactory;
+  mockCreate: ReturnType<typeof vi.fn>;
+  capturedPrompts: string[];
+} {
+  const capturedPrompts: string[] = [];
+  const mockRunStream = vi.fn().mockImplementation(async function* (
+    prompt: string,
+  ) {
+    capturedPrompts.push(prompt);
+    yield { type: "done" as const, output, history: [] };
+  });
+  const mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
+  const mockCreate = vi.fn().mockReturnValue({ runBuilder: mockRunBuilder });
+  return { factory: { create: mockCreate }, mockCreate, capturedPrompts };
+}
+
+const CLEAN_RESULT: ReviewResult = {
+  passed: true,
+  issues: [],
+  summary: "No issues found.",
+};
+
+const ERROR_RESULT: ReviewResult = {
+  passed: false,
+  issues: [
+    {
+      severity: "error",
+      location: "They was",
+      description:
+        "Subject-verb agreement error: 'They was' should be 'They were'.",
+      fix: "Replace 'They was' with 'They were'.",
+    },
+  ],
+  summary: "One grammatical error found.",
+};
+
+describe("createReviewerAgent", () => {
+  it("creates a runner using the provided factory", () => {
+    const { factory, mockCreate } = makeFactory(JSON.stringify(CLEAN_RESULT));
+    createReviewerAgent(factory);
+    expect(mockCreate).toHaveBeenCalledOnce();
+  });
+
+  it("passes REVIEWER_SYSTEM_PROMPT as the system prompt", () => {
+    const { factory, mockCreate } = makeFactory(JSON.stringify(CLEAN_RESULT));
+    createReviewerAgent(factory);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ systemPrompt: REVIEWER_SYSTEM_PROMPT }),
+    );
+  });
+
+  it("registers no tools (empty tool registry)", () => {
+    const { factory, mockCreate } = makeFactory(JSON.stringify(CLEAN_RESULT));
+    createReviewerAgent(factory);
+    const { tools } = mockCreate.mock.calls[0][0] as { tools: ToolRegistry };
+    expect(tools.definitions()).toEqual([]);
+  });
+});
+
+describe("runReview", () => {
+  it("returns a parsed ReviewResult", async () => {
+    const { factory } = makeFactory(JSON.stringify(CLEAN_RESULT));
+    const result = await runReview("Some text.", ["grammar"], factory);
+    expect(result).toEqual(CLEAN_RESULT);
+  });
+
+  it("returns passed: false with issues when the agent reports errors", async () => {
+    const { factory } = makeFactory(JSON.stringify(ERROR_RESULT));
+    const result = await runReview(
+      "They was late.",
+      ["subject-verb agreement"],
+      factory,
+    );
+    expect(result.passed).toBe(false);
+    expect(result.issues.length).toBeGreaterThan(0);
+    expect(result.issues[0].severity).toBe("error");
+  });
+
+  it("includes all provided criteria in the prompt", async () => {
+    const { factory, capturedPrompts } = makeFactory(
+      JSON.stringify(CLEAN_RESULT),
+    );
+    await runReview(
+      "Text.",
+      ["grammatical correctness", "consistent tense"],
+      factory,
+    );
+    expect(capturedPrompts[0]).toContain("grammatical correctness");
+    expect(capturedPrompts[0]).toContain("consistent tense");
+  });
+
+  it("includes the text under review in the prompt", async () => {
+    const { factory, capturedPrompts } = makeFactory(
+      JSON.stringify(CLEAN_RESULT),
+    );
+    await runReview("The quick brown fox.", ["grammar"], factory);
+    expect(capturedPrompts[0]).toContain("The quick brown fox.");
+  });
+
+  it("throws a descriptive error when the agent returns invalid JSON", async () => {
+    const { factory } = makeFactory("not valid json");
+    await expect(runReview("Text.", ["grammar"], factory)).rejects.toThrow(
+      "runReview: reviewer agent returned invalid JSON",
+    );
+  });
+
+  it("throws when result is missing required fields", async () => {
+    const { factory } = makeFactory('{"passed": true}');
+    await expect(runReview("Text.", ["grammar"], factory)).rejects.toThrow(
+      "runReview: ReviewResult is missing required fields",
+    );
+  });
+});
+
+describe("invoke_reviewer via DelegationTools", () => {
+  it("result is valid JSON with passed, issues, and summary fields", async () => {
+    const { factory } = makeFactory(JSON.stringify(CLEAN_RESULT));
+    const result = await runReview("Text.", ["grammar"], factory);
+    const json = JSON.stringify(result);
+    const parsed = JSON.parse(json) as ReviewResult;
+    expect(typeof parsed.passed).toBe("boolean");
+    expect(Array.isArray(parsed.issues)).toBe(true);
+    expect(typeof parsed.summary).toBe("string");
+  });
+});

--- a/src/lib/agents/reviewer.ts
+++ b/src/lib/agents/reviewer.ts
@@ -1,0 +1,83 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { AgentConfig, AgentRunner, ToolRegistry } from "@mast-ai/core";
+import type { AgentRunnerFactory } from "./factory";
+
+export interface ReviewIssue {
+  severity: "error" | "warning" | "suggestion";
+  location?: string;
+  description: string;
+  fix?: string;
+}
+
+export interface ReviewResult {
+  passed: boolean;
+  issues: ReviewIssue[];
+  summary: string;
+}
+
+export const REVIEWER_SYSTEM_PROMPT =
+  "You are a review specialist. You evaluate text against the provided criteria and return structured feedback.\n\n" +
+  "- Output ONLY valid JSON matching the ReviewResult schema. No prose outside the JSON.\n" +
+  '- Schema: { "passed": boolean, "issues": [{ "severity": "error"|"warning"|"suggestion", "location"?: string, "description": string, "fix"?: string }], "summary": string }\n' +
+  '- Set "location" to a short quoted excerpt from the text where each issue occurs.\n' +
+  '- Use severity "error" for clear mistakes, "warning" for debatable issues, "suggestion" for improvements.\n' +
+  '- "passed" is true only when there are no "error"-severity issues.\n' +
+  '- If no issues are found, return { "passed": true, "issues": [], "summary": "No issues found." }';
+
+export function createReviewerAgent(factory: AgentRunnerFactory): AgentRunner {
+  return factory.create({
+    systemPrompt: REVIEWER_SYSTEM_PROMPT,
+    tools: new ToolRegistry(),
+  });
+}
+
+function buildReviewerPrompt(text: string, criteria: string[]): string {
+  const criteriaLines = criteria.map((c) => `- ${c}`).join("\n");
+  return (
+    "Review the following text against the listed criteria and return a ReviewResult JSON object.\n\n" +
+    `Criteria:\n${criteriaLines}\n\n` +
+    `Text:\n${text}`
+  );
+}
+
+export async function runReview(
+  text: string,
+  criteria: string[],
+  factory: AgentRunnerFactory,
+): Promise<ReviewResult> {
+  const runner = createReviewerAgent(factory);
+  const agentConfig: AgentConfig = {
+    name: "Reviewer",
+    instructions: REVIEWER_SYSTEM_PROMPT,
+    tools: [],
+  };
+
+  const prompt = buildReviewerPrompt(text, criteria);
+
+  for await (const event of runner.runBuilder(agentConfig).runStream(prompt)) {
+    if (event.type === "done") {
+      let result: ReviewResult;
+      try {
+        result = JSON.parse(event.output) as ReviewResult;
+      } catch {
+        throw new Error(
+          `runReview: reviewer agent returned invalid JSON: ${event.output}`,
+        );
+      }
+      if (
+        typeof result.passed !== "boolean" ||
+        !Array.isArray(result.issues) ||
+        typeof result.summary !== "string"
+      ) {
+        throw new Error(
+          "runReview: ReviewResult is missing required fields (passed, issues, summary)",
+        );
+      }
+      return result;
+    }
+  }
+
+  throw new Error("runReview: reviewer agent ended without a done event");
+}

--- a/src/lib/tools/DelegationTools.ts
+++ b/src/lib/tools/DelegationTools.ts
@@ -12,6 +12,7 @@ import {
 import type { ResearchResult } from "../agents/researcher";
 import { runResearch } from "../agents/researcher";
 import { runWriter } from "../agents/writer";
+import { runReview } from "../agents/reviewer";
 import type { PlanConfirmationRequest } from "../store";
 import { EditorTools } from "./EditorTools";
 import { WorkspaceTools } from "./WorkspaceTools";
@@ -230,6 +231,38 @@ export function registerDelegationTools(
         args.styleContext,
       );
       return JSON.stringify({ draft });
+    },
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "invoke_reviewer",
+      description:
+        "Evaluates a draft against explicit criteria and returns structured feedback. " +
+        "Returns JSON: { passed: boolean, issues: [{ severity, location?, description, fix? }], summary }. " +
+        "Use after invoke_writer to check a draft before applying it. " +
+        "If passed is false and error-severity issues remain after 3 Writer→Reviewer cycles, " +
+        "present the best available draft via edit() or write() and summarise remaining issues in your response.",
+      parameters: {
+        type: "object",
+        properties: {
+          text: {
+            type: "string",
+            description: "The draft text to review.",
+          },
+          criteria: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Review criteria to check against (e.g. 'grammatical correctness', 'consistent use of past tense', 'no unsupported factual claims').",
+          },
+        },
+        required: ["text", "criteria"],
+      },
+    }),
+    call: async (args: { text: string; criteria: string[] }) => {
+      const result = await runReview(args.text, args.criteria, factory);
+      return JSON.stringify(result);
     },
   });
 }


### PR DESCRIPTION
## Summary

- Adds `src/lib/agents/reviewer.ts` with `ReviewIssue`/`ReviewResult` types, `REVIEWER_SYSTEM_PROMPT`, `createReviewerAgent`, and `runReview` (no tools; JSON-only output with field validation).
- Registers `invoke_reviewer` in `DelegationTools.ts` — takes `text` + `criteria[]`, returns structured `ReviewResult` JSON.
- Updates the Orchestrator system prompt to loop Writer → Reviewer up to 3 times before applying a draft, with a fallback to present the best draft and summarise remaining issues when the cap is reached.
- Adds 9 unit tests in `reviewer.test.ts` covering factory, prompt construction, JSON parsing, and error handling.
- Adds `reviewing.eval.ts` with 8 fixtures (5 recall / 3 precision) scored by the LLM-as-judge helper; all pass.

## Test plan

- [ ] `npm run test` — all 312 unit tests pass
- [ ] `npm run evals reviewing` — all 9 reviewing eval tests pass (avg score ≥ 4)
- [ ] `npm run lint` — no errors