### PR TITLE
chore: update to latest @mast-ai/core tool API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -420,6 +420,7 @@ function App() {
           },
           required: ["skillName", "task"],
         },
+        scope: "write" as const,
       }),
       call: createDelegateToSkillHandler(factory, editorTools, workspaceTools),
     });

--- a/src/lib/agents/factory.ts
+++ b/src/lib/agents/factory.ts
@@ -1,13 +1,13 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { AgentRunner, ToolRegistry } from "@mast-ai/core";
+import { AgentRunner, ToolProvider } from "@mast-ai/core";
 import { GoogleGenAIAdapter } from "@mast-ai/google-genai";
 
 export interface AgentRunnerFactory {
   create(options: {
     systemPrompt?: string;
-    tools?: ToolRegistry;
+    tools?: ToolProvider;
     model?: string;
   }): AgentRunner;
 }
@@ -24,7 +24,7 @@ export class DefaultAgentRunnerFactory implements AgentRunnerFactory {
     model,
   }: {
     systemPrompt?: string;
-    tools?: ToolRegistry;
+    tools?: ToolProvider;
     model?: string;
   }): AgentRunner {
     const adapter = new GoogleGenAIAdapter(

--- a/src/lib/agents/generic.ts
+++ b/src/lib/agents/generic.ts
@@ -1,13 +1,13 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { AgentRunner, ToolRegistry } from "@mast-ai/core";
+import { AgentRunner, ToolProvider } from "@mast-ai/core";
 import type { AgentRunnerFactory } from "./factory";
 
 export function createGenericAgent(
   factory: AgentRunnerFactory,
   systemPrompt: string,
-  tools?: ToolRegistry,
+  tools?: ToolProvider,
 ): AgentRunner {
   return factory.create({ systemPrompt, tools });
 }

--- a/src/lib/agents/planner.test.ts
+++ b/src/lib/agents/planner.test.ts
@@ -35,6 +35,6 @@ describe("createPlannerAgent", () => {
     const { factory, mockCreate } = makeFactory();
     createPlannerAgent(factory);
     const { tools } = mockCreate.mock.calls[0][0] as { tools: ToolRegistry };
-    expect(tools.definitions()).toEqual([]);
+    expect(tools.getTools()).toEqual([]);
   });
 });

--- a/src/lib/agents/reviewer.test.ts
+++ b/src/lib/agents/reviewer.test.ts
@@ -67,7 +67,7 @@ describe("createReviewerAgent", () => {
     const { factory, mockCreate } = makeFactory(JSON.stringify(CLEAN_RESULT));
     createReviewerAgent(factory);
     const { tools } = mockCreate.mock.calls[0][0] as { tools: ToolRegistry };
-    expect(tools.definitions()).toEqual([]);
+    expect(tools.getTools()).toEqual([]);
   });
 });
 

--- a/src/lib/agents/writer.test.ts
+++ b/src/lib/agents/writer.test.ts
@@ -43,7 +43,7 @@ describe("createWriterAgent", () => {
     const { factory, mockCreate } = makeFactory();
     createWriterAgent(factory);
     const { tools } = mockCreate.mock.calls[0][0] as { tools: ToolRegistry };
-    expect(tools.definitions()).toEqual([]);
+    expect(tools.getTools()).toEqual([]);
   });
 });
 

--- a/src/lib/tools/DelegationTools.test.ts
+++ b/src/lib/tools/DelegationTools.test.ts
@@ -36,7 +36,7 @@ async function callTool(
   args: unknown,
   context: { onEvent?: (event: AgentEvent) => void } = {},
 ) {
-  const tool = registry.get(name);
+  const tool = registry.getTool(name);
   if (!tool) throw new Error(`Tool '${name}' not registered`);
   return tool.call(args, context);
 }
@@ -155,7 +155,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
     registerDelegationTools(registry, factory, et, wt, vi.fn());
 
-    const tool = registry.get("invoke_agent");
+    const tool = registry.getTool("invoke_agent");
     expect(tool).toBeDefined();
     expect(tool?.definition().name).toBe("invoke_agent");
   });
@@ -200,7 +200,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
     registerDelegationTools(registry, factory, et, wt, vi.fn());
 
-    const tool = registry.get("invoke_planner");
+    const tool = registry.getTool("invoke_planner");
     expect(tool).toBeDefined();
     expect(tool?.definition().name).toBe("invoke_planner");
   });
@@ -374,7 +374,7 @@ describe("registerDelegationTools / invoke_researcher", () => {
     const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
     registerDelegationTools(registry, factory, et, wt, vi.fn());
 
-    const tool = registry.get("invoke_researcher");
+    const tool = registry.getTool("invoke_researcher");
     expect(tool).toBeDefined();
     expect(tool?.definition().name).toBe("invoke_researcher");
   });

--- a/src/lib/tools/DelegationTools.ts
+++ b/src/lib/tools/DelegationTools.ts
@@ -50,6 +50,7 @@ export function registerDelegationTools(
         },
         required: ["systemPrompt", "task"],
       },
+      scope: "write" as const,
     }),
     call: async (
       args: { systemPrompt: string; task: string; tools?: string[] },
@@ -68,7 +69,7 @@ export function registerDelegationTools(
       const agentConfig: AgentConfig = {
         name: "Agent",
         instructions: args.systemPrompt,
-        tools: resolvedRegistry.definitions().map((d) => d.name),
+        tools: resolvedRegistry.getTools().map((d) => d.name),
       };
 
       for await (const event of runner
@@ -104,6 +105,7 @@ export function registerDelegationTools(
         },
         required: ["task"],
       },
+      scope: "write" as const,
     }),
     call: async (args: { task: string; context?: string }) => {
       const runner = createPlannerAgent(factory);
@@ -173,6 +175,7 @@ export function registerDelegationTools(
         },
         required: ["query"],
       },
+      scope: "read" as const,
     }),
     call: async (args: { query: string; docIds?: string[] }) => {
       const docs = workspaceTools.docsRef.current;
@@ -210,6 +213,7 @@ export function registerDelegationTools(
         },
         required: ["instruction"],
       },
+      scope: "write" as const,
     }),
     call: async (args: {
       instruction: string;
@@ -259,6 +263,7 @@ export function registerDelegationTools(
         },
         required: ["text", "criteria"],
       },
+      scope: "read" as const,
     }),
     call: async (args: { text: string; criteria: string[] }) => {
       const result = await runReview(args.text, args.criteria, factory);

--- a/src/lib/tools/EditorTools.ts
+++ b/src/lib/tools/EditorTools.ts
@@ -6,6 +6,7 @@ import {
   AgentConfig,
   AgentEvent,
   ToolContext,
+  ToolProvider,
   ToolRegistry,
 } from "@mast-ai/core";
 import { Suggestion } from "../store";
@@ -200,7 +201,64 @@ export function registerEditorTools(
   registry: ToolRegistry,
   tools: EditorTools,
 ): void {
-  registerReadonlyEditorTools(registry, tools);
+  registry.register({
+    definition: () => ({
+      name: "read",
+      description: "Reads the complete current editor content.",
+      parameters: { type: "object", properties: {} },
+      scope: "read" as const,
+    }),
+    call: async () => tools.read(),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "read_selection",
+      description: "Reads the currently selected text in the editor.",
+      parameters: { type: "object", properties: {} },
+      scope: "read" as const,
+    }),
+    call: async () => tools.read_selection(),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "search",
+      description:
+        "Finds all occurrences of a query string in the document. Returns the line and column of each match.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "The text to search for." },
+        },
+        required: ["query"],
+      },
+      scope: "read" as const,
+    }),
+    call: async (args: { query: string }) => tools.search(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "get_metadata",
+      description:
+        "Returns metadata about the current document: character count, word count, and line count.",
+      parameters: { type: "object", properties: {} },
+      scope: "read" as const,
+    }),
+    call: async () => tools.get_metadata(),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "get_current_mode",
+      description:
+        "Returns the current UI mode: 'editor' (Monaco editor is visible) or 'preview' (Markdown preview is visible). Check this before making edits to ensure the editor is accessible.",
+      parameters: { type: "object", properties: {} },
+      scope: "read" as const,
+    }),
+    call: async () => tools.get_current_mode(),
+  });
 
   registry.register({
     definition: () => ({
@@ -222,6 +280,7 @@ export function registerEditorTools(
         },
         required: ["originalText", "replacementText"],
       },
+      scope: "write" as const,
     }),
     call: async (args: { originalText: string; replacementText: string }) =>
       tools.edit(args),
@@ -242,6 +301,7 @@ export function registerEditorTools(
         },
         required: ["content"],
       },
+      scope: "write" as const,
     }),
     call: async (args: { content: string }) => tools.write(args),
   });
@@ -252,68 +312,9 @@ export function registerEditorTools(
       description:
         "Requests the user to switch from Preview mode to Editor mode. This will display a prompt to the user and pause until they accept or decline. Call this before attempting edits when in preview mode.",
       parameters: { type: "object", properties: {} },
+      scope: "write" as const,
     }),
     call: async () => tools.request_switch_to_editor(),
-  });
-}
-
-/** Registers read-only editor tools (no edit, write, or request_switch_to_editor). */
-export function registerReadonlyEditorTools(
-  registry: ToolRegistry,
-  tools: EditorTools,
-): void {
-  registry.register({
-    definition: () => ({
-      name: "read",
-      description: "Reads the complete current editor content.",
-      parameters: { type: "object", properties: {} },
-    }),
-    call: async () => tools.read(),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "read_selection",
-      description: "Reads the currently selected text in the editor.",
-      parameters: { type: "object", properties: {} },
-    }),
-    call: async () => tools.read_selection(),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "search",
-      description:
-        "Finds all occurrences of a query string in the document. Returns the line and column of each match.",
-      parameters: {
-        type: "object",
-        properties: {
-          query: { type: "string", description: "The text to search for." },
-        },
-        required: ["query"],
-      },
-    }),
-    call: async (args: { query: string }) => tools.search(args),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "get_metadata",
-      description:
-        "Returns metadata about the current document: character count, word count, and line count.",
-      parameters: { type: "object", properties: {} },
-    }),
-    call: async () => tools.get_metadata(),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "get_current_mode",
-      description:
-        "Returns the current UI mode: 'editor' (Monaco editor is visible) or 'preview' (Markdown preview is visible). Check this before making edits to ensure the editor is accessible.",
-      parameters: { type: "object", properties: {} },
-    }),
-    call: async () => tools.get_current_mode(),
   });
 }
 
@@ -331,7 +332,7 @@ export function createDelegateToSkillHandler(
   factory: AgentRunnerFactory,
   editorTools: EditorTools,
   workspaceTools: WorkspaceTools,
-  runnerFactory: (registry: ToolRegistry, model?: string) => RunnerLike = (
+  runnerFactory: (registry: ToolProvider, model?: string) => RunnerLike = (
     registry,
     model,
   ) => factory.create({ tools: registry, model }),
@@ -348,7 +349,7 @@ export function createDelegateToSkillHandler(
     }
 
     const childRegistry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const readonlyToolNames = childRegistry.definitions().map((d) => d.name);
+    const readonlyToolNames = childRegistry.getTools().map((d) => d.name);
 
     const childRunner = runnerFactory(childRegistry, skill.model);
     const agentConfig: AgentConfig = {

--- a/src/lib/tools/WorkspaceTools.ts
+++ b/src/lib/tools/WorkspaceTools.ts
@@ -211,7 +211,86 @@ export function registerWorkspaceTools(
   registry: ToolRegistry,
   tools: WorkspaceTools,
 ): void {
-  registerReadonlyWorkspaceTools(registry, tools);
+  registry.register({
+    definition: () => ({
+      name: "get_active_doc_info",
+      description:
+        "Returns the id and title of the document currently open in the editor.",
+      parameters: { type: "object", properties: {} },
+      scope: "read" as const,
+    }),
+    call: async () => tools.get_active_doc_info(),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "list_workspace_docs",
+      description:
+        "Lists all documents in the workspace. Returns an array of { id, title } objects.",
+      parameters: { type: "object", properties: {} },
+      scope: "read" as const,
+    }),
+    call: async () => tools.list_workspace_docs(),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "read_workspace_doc",
+      description:
+        "Reads the full content of a specific document. Returns { title, content } or { error }.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "The document ID to read." },
+        },
+        required: ["id"],
+      },
+      scope: "read" as const,
+    }),
+    call: async (args: { id: string }) => tools.read_workspace_doc(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "query_workspace_doc",
+      description:
+        "Asks a question about a specific document using a sub-agent. Returns { summary, excerpt } where excerpt is the most relevant verbatim passage.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "The document ID to query." },
+          query: {
+            type: "string",
+            description: "The question about the document.",
+          },
+        },
+        required: ["id", "query"],
+      },
+      scope: "read" as const,
+    }),
+    call: async (args: { id: string; query: string }) =>
+      tools.query_workspace_doc(args),
+  });
+
+  registry.register({
+    definition: () => ({
+      name: "query_workspace",
+      description:
+        "Asks a question spanning all workspace documents and synthesizes the results. Returns { summary, sources: [{ id, title, excerpt }] }.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "The question to answer across all documents.",
+          },
+        },
+        required: ["query"],
+      },
+      scope: "read" as const,
+    }),
+    call: async (args: { query: string }) => tools.query_workspace(args),
+  });
 
   registry.register({
     definition: () => ({
@@ -233,6 +312,7 @@ export function registerWorkspaceTools(
         },
         required: ["title"],
       },
+      scope: "write" as const,
     }),
     call: async (args: { title: string; content?: string }) =>
       tools.create_document(args),
@@ -257,6 +337,7 @@ export function registerWorkspaceTools(
         },
         required: ["id", "title"],
       },
+      scope: "write" as const,
     }),
     call: async (args: { id: string; title: string }) =>
       tools.rename_document(args),
@@ -277,6 +358,7 @@ export function registerWorkspaceTools(
         },
         required: ["id"],
       },
+      scope: "write" as const,
     }),
     call: async (args: { id: string }) => tools.delete_document(args),
   });
@@ -296,88 +378,9 @@ export function registerWorkspaceTools(
         },
         required: ["id"],
       },
+      scope: "write" as const,
     }),
     call: async (args: { id: string }) => tools.switch_active_document(args),
   });
 }
 
-export function registerReadonlyWorkspaceTools(
-  registry: ToolRegistry,
-  tools: WorkspaceTools,
-): void {
-  registry.register({
-    definition: () => ({
-      name: "get_active_doc_info",
-      description:
-        "Returns the id and title of the document currently open in the editor.",
-      parameters: { type: "object", properties: {} },
-    }),
-    call: async () => tools.get_active_doc_info(),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "list_workspace_docs",
-      description:
-        "Lists all documents in the workspace. Returns an array of { id, title } objects.",
-      parameters: { type: "object", properties: {} },
-    }),
-    call: async () => tools.list_workspace_docs(),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "read_workspace_doc",
-      description:
-        "Reads the full content of a specific document. Returns { title, content } or { error }.",
-      parameters: {
-        type: "object",
-        properties: {
-          id: { type: "string", description: "The document ID to read." },
-        },
-        required: ["id"],
-      },
-    }),
-    call: async (args: { id: string }) => tools.read_workspace_doc(args),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "query_workspace_doc",
-      description:
-        "Asks a question about a specific document using a sub-agent. Returns { summary, excerpt } where excerpt is the most relevant verbatim passage.",
-      parameters: {
-        type: "object",
-        properties: {
-          id: { type: "string", description: "The document ID to query." },
-          query: {
-            type: "string",
-            description: "The question about the document.",
-          },
-        },
-        required: ["id", "query"],
-      },
-    }),
-    call: async (args: { id: string; query: string }) =>
-      tools.query_workspace_doc(args),
-  });
-
-  registry.register({
-    definition: () => ({
-      name: "query_workspace",
-      description:
-        "Asks a question spanning all workspace documents and synthesizes the results. Returns { summary, sources: [{ id, title, excerpt }] }.",
-      parameters: {
-        type: "object",
-        properties: {
-          query: {
-            type: "string",
-            description: "The question to answer across all documents.",
-          },
-        },
-        required: ["query"],
-      },
-    }),
-    call: async (args: { query: string }) => tools.query_workspace(args),
-  });
-}

--- a/src/lib/tools/registries.test.ts
+++ b/src/lib/tools/registries.test.ts
@@ -33,7 +33,7 @@ describe("buildReadonlyRegistry", () => {
   it("includes read, read_selection, search, get_metadata, get_current_mode", () => {
     const { editorTools, workspaceTools } = makeTools();
     const registry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const names = registry.definitions().map((d) => d.name);
+    const names = registry.getTools().map((d) => d.name);
     expect(names).toContain("read");
     expect(names).toContain("read_selection");
     expect(names).toContain("search");
@@ -44,7 +44,7 @@ describe("buildReadonlyRegistry", () => {
   it("excludes edit, write, request_switch_to_editor", () => {
     const { editorTools, workspaceTools } = makeTools();
     const registry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const names = registry.definitions().map((d) => d.name);
+    const names = registry.getTools().map((d) => d.name);
     expect(names).not.toContain("edit");
     expect(names).not.toContain("write");
     expect(names).not.toContain("request_switch_to_editor");
@@ -53,7 +53,7 @@ describe("buildReadonlyRegistry", () => {
   it("includes workspace read tools", () => {
     const { editorTools, workspaceTools } = makeTools();
     const registry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const names = registry.definitions().map((d) => d.name);
+    const names = registry.getTools().map((d) => d.name);
     expect(names).toContain("get_active_doc_info");
     expect(names).toContain("list_workspace_docs");
     expect(names).toContain("read_workspace_doc");
@@ -64,7 +64,7 @@ describe("buildReadonlyRegistry", () => {
   it("excludes workspace write tools", () => {
     const { editorTools, workspaceTools } = makeTools();
     const registry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const names = registry.definitions().map((d) => d.name);
+    const names = registry.getTools().map((d) => d.name);
     expect(names).not.toContain("create_document");
     expect(names).not.toContain("rename_document");
     expect(names).not.toContain("delete_document");
@@ -76,7 +76,7 @@ describe("buildReadWriteRegistry", () => {
   it("includes all read-only tools", () => {
     const { editorTools, workspaceTools } = makeTools();
     const registry = buildReadWriteRegistry(editorTools, workspaceTools);
-    const names = registry.definitions().map((d) => d.name);
+    const names = registry.getTools().map((d) => d.name);
     expect(names).toContain("read");
     expect(names).toContain("read_selection");
     expect(names).toContain("search");
@@ -92,7 +92,7 @@ describe("buildReadWriteRegistry", () => {
   it("includes edit, write, request_switch_to_editor", () => {
     const { editorTools, workspaceTools } = makeTools();
     const registry = buildReadWriteRegistry(editorTools, workspaceTools);
-    const names = registry.definitions().map((d) => d.name);
+    const names = registry.getTools().map((d) => d.name);
     expect(names).toContain("edit");
     expect(names).toContain("write");
     expect(names).toContain("request_switch_to_editor");
@@ -101,7 +101,7 @@ describe("buildReadWriteRegistry", () => {
   it("includes workspace write tools", () => {
     const { editorTools, workspaceTools } = makeTools();
     const registry = buildReadWriteRegistry(editorTools, workspaceTools);
-    const names = registry.definitions().map((d) => d.name);
+    const names = registry.getTools().map((d) => d.name);
     expect(names).toContain("create_document");
     expect(names).toContain("rename_document");
     expect(names).toContain("delete_document");

--- a/src/lib/tools/registries.ts
+++ b/src/lib/tools/registries.ts
@@ -1,26 +1,15 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { ToolRegistry } from "@mast-ai/core";
-import {
-  EditorTools,
-  registerEditorTools,
-  registerReadonlyEditorTools,
-} from "./EditorTools";
-import {
-  WorkspaceTools,
-  registerWorkspaceTools,
-  registerReadonlyWorkspaceTools,
-} from "./WorkspaceTools";
+import { ToolRegistry, ToolRegistryView } from "@mast-ai/core";
+import { EditorTools, registerEditorTools } from "./EditorTools";
+import { WorkspaceTools, registerWorkspaceTools } from "./WorkspaceTools";
 
 export function buildReadonlyRegistry(
   editorTools: EditorTools,
   workspaceTools: WorkspaceTools,
-): ToolRegistry {
-  const registry = new ToolRegistry();
-  registerReadonlyEditorTools(registry, editorTools);
-  registerReadonlyWorkspaceTools(registry, workspaceTools);
-  return registry;
+): ToolRegistryView {
+  return buildReadWriteRegistry(editorTools, workspaceTools).readOnly();
 }
 
 export function buildReadWriteRegistry(


### PR DESCRIPTION
## Summary

- Adds `scope: 'read' | 'write'` to all `ToolDefinition` objects across `EditorTools`, `WorkspaceTools`, `DelegationTools`, and `App.tsx`
- Renames `ToolRegistry.definitions()` → `getTools()` and `.get()` → `.getTool()` at all call sites
- Updates `AgentRunnerFactory` and `createGenericAgent` to accept `ToolProvider` (interface) instead of the concrete `ToolRegistry`, so `ToolRegistryView` can be passed through
- Simplifies `buildReadonlyRegistry` to `buildReadWriteRegistry(...).readOnly()` — scope-based filtering replaces the manual dual-registration approach
- Removes the now-redundant `registerReadonlyEditorTools` and `registerReadonlyWorkspaceTools` functions

Closes #70

## Test plan

- [x] `npm run build` — clean
- [x] `npm run test` — 312 tests pass
- [x] Manual smoke test in browser on port 5173