### PR TITLE
feat: add Gemma 4 model options

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -25,6 +25,8 @@ const MODELS = [
   },
   { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro (Preview)" },
   { id: "gemini-3-flash-preview", label: "Gemini 3 Flash (Preview)" },
+  { id: "gemma-4-26b-a4b-it", label: "Gemma 4 26B A4B IT" },
+  { id: "gemma-4-31b-it", label: "Gemma 4 31B IT" },
 ];
 
 interface SettingsDialogProps {


### PR DESCRIPTION
## Summary
- Adds **Gemma 4 26B A4B IT** (`gemma-4-26b-a4b-it`) to the model selector
- Adds **Gemma 4 31B IT** (`gemma-4-31b-it`) to the model selector

## Test plan
- [x] Open Settings dialog and verify both Gemma 4 models appear in the dropdown
- [x] Select each model and confirm the selection persists after saving