### PR TITLE
refactor: introduce AgentModel and AgentContext for model/view separation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import { useState } from "react";
 import { EditorPanel } from "@/components/EditorPanel";
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { WorkspacePanel } from "@/components/WorkspacePanel";
@@ -26,21 +26,8 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { AgentRunner, AgentConfig, Conversation } from "@mast-ai/core";
-import { GoogleGenAIAdapter } from "@mast-ai/google-genai";
-import {
-  EditorTools,
-  createDelegateToSkillHandler,
-} from "@/lib/tools/EditorTools";
-import { WorkspaceTools } from "@/lib/tools/WorkspaceTools";
-import { buildReadWriteRegistry } from "@/lib/tools/registries";
-import { registerDelegationTools } from "@/lib/tools/DelegationTools";
-import {
-  DefaultAgentRunnerFactory,
-  buildOrchestratorPrompt,
-} from "@/lib/agents";
-import { registerWebMCPTools } from "@/lib/WebMCPTools";
-import { addAllBuiltInAITools } from "@mast-ai/built-in-ai";
+import { AgentContextProvider } from "@/context/AgentContext";
+import { useEffect, useRef } from "react";
 
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(
@@ -55,12 +42,7 @@ function useIsMobile() {
   return isMobile;
 }
 
-interface LayoutProps {
-  conversation: Conversation | null;
-  onBeforeSend?: () => void;
-}
-
-function DesktopLayout({ conversation, onBeforeSend }: LayoutProps) {
+function DesktopLayout() {
   const [refOpen, setRefOpen] = useState(false);
   const [chatOpen, setChatOpen] = useState(true);
   const { index, activeWorkspaceId, closeWorkspace } = useWorkspaces();
@@ -149,10 +131,7 @@ function DesktopLayout({ conversation, onBeforeSend }: LayoutProps) {
         </div>
         {chatOpen && (
           <div className="flex-1 min-h-0 overflow-hidden">
-            <ChatSidebar
-              conversation={conversation}
-              onBeforeSend={onBeforeSend}
-            />
+            <ChatSidebar />
           </div>
         )}
       </aside>
@@ -160,7 +139,7 @@ function DesktopLayout({ conversation, onBeforeSend }: LayoutProps) {
   );
 }
 
-function MobileLayout({ conversation, onBeforeSend }: LayoutProps) {
+function MobileLayout() {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetMode, setSheetMode] = useState<"chat" | "reference">("chat");
   const { index, activeWorkspaceId, closeWorkspace } = useWorkspaces();
@@ -252,215 +231,21 @@ function MobileLayout({ conversation, onBeforeSend }: LayoutProps) {
           </button>
         </div>
         <div className="flex-1 min-h-0 overflow-hidden">
-          {sheetMode === "chat" ? (
-            <ChatSidebar
-              conversation={conversation}
-              onBeforeSend={onBeforeSend}
-            />
-          ) : (
-            <WorkspacePanel />
-          )}
+          {sheetMode === "chat" ? <ChatSidebar /> : <WorkspacePanel />}
         </div>
       </div>
     </div>
   );
 }
 
-function App() {
-  const {
-    activeWorkspaceId,
-    activeWorkspace,
-    activeDocument,
-    createDocumentWithTitle,
-    updateDocument,
-    deleteDocument,
-    setActiveDocumentId,
-  } = useWorkspaces();
-  const { apiKey, setApiKey, modelName, setTotalTokens, skills } =
-    useAgentConfig();
-  const {
-    editorInstance,
-    setSuggestions,
-    approveAll,
-    activeTab,
-    editorContent,
-    setPendingTabSwitchRequest,
-    pendingWorkspaceAction,
-    setPendingWorkspaceAction,
-    setPendingPlanConfirmation,
-  } = useEditorUI();
+function AppContent() {
+  const { apiKey, setApiKey } = useAgentConfig();
+  const { pendingWorkspaceAction, setPendingWorkspaceAction } = useEditorUI();
+  const { activeWorkspaceId } = useWorkspaces();
   const [tempKey, setTempKey] = useState("");
   const [showKeyDialog, setShowKeyDialog] = useState(!apiKey);
 
-  const docsRef = useRef(activeWorkspace?.documents ?? []);
-  useEffect(() => {
-    docsRef.current = activeWorkspace?.documents ?? [];
-  }, [activeWorkspace]);
-
-  const activeDocRef = useRef(
-    activeDocument
-      ? { id: activeDocument.id, title: activeDocument.title }
-      : null,
-  );
-  useEffect(() => {
-    activeDocRef.current = activeDocument
-      ? { id: activeDocument.id, title: activeDocument.title }
-      : null;
-  }, [activeDocument]);
-
-  const editorInstanceRef = useRef(editorInstance);
-  useEffect(() => {
-    editorInstanceRef.current = editorInstance;
-  }, [editorInstance]);
-
-  const editorContentRef = useRef(editorContent);
-  useEffect(() => {
-    editorContentRef.current = editorContent;
-  }, [editorContent]);
-
-  const activeTabRef = useRef(activeTab);
-  useEffect(() => {
-    activeTabRef.current = activeTab;
-  }, [activeTab]);
-
-  const approveAllRef = useRef(approveAll);
-  useEffect(() => {
-    approveAllRef.current = approveAll;
-  }, [approveAll]);
-
-  const requestTabSwitch = useCallback(
-    () =>
-      new Promise<boolean>((resolve) => {
-        setPendingTabSwitchRequest({ resolve });
-      }),
-    [setPendingTabSwitchRequest],
-  );
-
-  const editorTools = useMemo(
-    () =>
-      new EditorTools(
-        editorInstanceRef,
-        setSuggestions,
-        approveAllRef,
-        editorContentRef,
-        activeTabRef,
-        requestTabSwitch,
-      ),
-    [setSuggestions, requestTabSwitch],
-  );
-
-  const factory = useMemo(
-    () =>
-      apiKey
-        ? new DefaultAgentRunnerFactory(apiKey, modelName, (usage) =>
-            setTotalTokens((prev) => prev + (usage.totalTokenCount || 0)),
-          )
-        : null,
-    [apiKey, modelName, setTotalTokens],
-  );
-
-  const workspaceTools = useMemo(
-    () =>
-      new WorkspaceTools(
-        docsRef,
-        activeDocRef,
-        factory ?? new DefaultAgentRunnerFactory("", ""),
-        (title) => createDocumentWithTitle(title),
-        (id, title) => updateDocument(id, { title }),
-        (id) => deleteDocument(id),
-        (id) => setActiveDocumentId(id),
-        (id, content) => updateDocument(id, { content }),
-        editorInstanceRef,
-        editorContentRef,
-        setPendingWorkspaceAction,
-        approveAllRef,
-      ),
-    [
-      docsRef,
-      activeDocRef,
-      factory,
-      createDocumentWithTitle,
-      updateDocument,
-      deleteDocument,
-      setActiveDocumentId,
-      setPendingWorkspaceAction,
-    ],
-  );
-
-  useEffect(
-    () => registerWebMCPTools(editorTools, workspaceTools),
-    [editorTools, workspaceTools],
-  );
-
-  const runner = useMemo(() => {
-    if (!apiKey || !factory) return null;
-    const adapter = new GoogleGenAIAdapter(apiKey, modelName, (usage) => {
-      setTotalTokens((prev) => prev + (usage.totalTokenCount || 0));
-    });
-    const registry = buildReadWriteRegistry(editorTools, workspaceTools);
-    addAllBuiltInAITools(registry).catch(() => {});
-
-    registry.register({
-      definition: () => ({
-        name: "delegate_to_skill",
-        description:
-          "Delegates a task to a named skill (sub-agent). The skill runs with read-only access and returns its response as a string. Interpret the response and act on it accordingly.",
-        parameters: {
-          type: "object",
-          properties: {
-            skillName: {
-              type: "string",
-              description: "The exact name of the skill to invoke.",
-            },
-            task: {
-              type: "string",
-              description:
-                "The specific task or instructions to pass to the skill.",
-            },
-          },
-          required: ["skillName", "task"],
-        },
-        scope: "write" as const,
-      }),
-      call: createDelegateToSkillHandler(factory, editorTools, workspaceTools),
-    });
-
-    registerDelegationTools(
-      registry,
-      factory,
-      editorTools,
-      workspaceTools,
-      setPendingPlanConfirmation,
-    );
-
-    return new AgentRunner(adapter, registry);
-  }, [
-    apiKey,
-    factory,
-    modelName,
-    setTotalTokens,
-    editorTools,
-    workspaceTools,
-    setPendingPlanConfirmation,
-  ]);
-
-  const conversation = useMemo(() => {
-    if (!runner) return null;
-    const agent: AgentConfig = {
-      name: "EditorAssistant",
-      instructions: buildOrchestratorPrompt(skills),
-    };
-    return runner.conversation(agent);
-  }, [runner, skills]);
-
   const isMobile = useIsMobile();
-
-  const flushEditorContent = useCallback(() => {
-    if (activeDocument) {
-      const content = editorInstance?.getValue() ?? editorContent;
-      updateDocument(activeDocument.id, { content });
-    }
-  }, [activeDocument, editorInstance, editorContent, updateDocument]);
 
   const handleSaveKey = () => {
     if (tempKey.trim()) {
@@ -475,17 +260,7 @@ function App() {
 
   return (
     <>
-      {isMobile ? (
-        <MobileLayout
-          conversation={conversation}
-          onBeforeSend={flushEditorContent}
-        />
-      ) : (
-        <DesktopLayout
-          conversation={conversation}
-          onBeforeSend={flushEditorContent}
-        />
-      )}
+      {isMobile ? <MobileLayout /> : <DesktopLayout />}
 
       <Dialog
         open={!!pendingWorkspaceAction}
@@ -555,4 +330,10 @@ function App() {
   );
 }
 
-export default App;
+export default function App() {
+  return (
+    <AgentContextProvider>
+      <AppContent />
+    </AgentContextProvider>
+  );
+}

--- a/src/components/ChatItem.tsx
+++ b/src/components/ChatItem.tsx
@@ -11,55 +11,9 @@ import {
   Wrench,
 } from "lucide-react";
 import { MarkdownContent } from "./MarkdownContent";
+import type { ChildItem, StreamItem } from "@/lib/agent/types";
 
-export type ChildItem =
-  | { kind: "thought"; id: string; text: string }
-  | { kind: "text"; id: string; text: string }
-  | {
-      kind: "tool";
-      id: string;
-      name: string;
-      pending: boolean;
-      params?: unknown;
-      result?: unknown;
-    };
-
-export type StreamItem =
-  | { kind: "user"; id: string; text: string }
-  | {
-      kind: "assistant";
-      id: string;
-      text: string;
-      thought: string;
-      isStreaming: boolean;
-      agentRole?: string;
-      parentMessageId?: string;
-    }
-  | {
-      kind: "tool";
-      id: string;
-      name: string;
-      pending: boolean;
-      params?: unknown;
-      result?: unknown;
-    }
-  | {
-      kind: "skill";
-      id: string;
-      name: string;
-      task: string;
-      pending: boolean;
-      childItems: ChildItem[];
-    }
-  | {
-      kind: "agent";
-      id: string;
-      agentRole: string;
-      task: string;
-      pending: boolean;
-      childItems: ChildItem[];
-      parentMessageId?: string;
-    };
+export type { ChildItem, StreamItem };
 
 function formatValue(value: unknown): string {
   if (typeof value === "string") return value;

--- a/src/components/ChatSidebar.test.tsx
+++ b/src/components/ChatSidebar.test.tsx
@@ -1,13 +1,16 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ChatSidebar } from "./ChatSidebar";
 import { AppProvider } from "@/lib/store";
 import { ThemeProvider } from "@/lib/ThemeProvider";
 import { WorkspacesProvider } from "@/lib/WorkspacesContext";
-import type { Conversation } from "@mast-ai/core";
+import { useAgentContext } from "@/context/AgentContext";
+import type { StreamItem } from "@/lib/agent/types";
+
+vi.mock("@/context/AgentContext");
 
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: (opts: {
@@ -28,26 +31,36 @@ vi.mock("@tanstack/react-virtual", () => ({
   }),
 }));
 
-function makeConversation(
-  events: object[] = [],
-  history: object[] = [],
-): Conversation {
+function makeContext(
+  overrides: {
+    items?: StreamItem[];
+    isLoading?: boolean;
+    sendMessage?: (prompt: string, displayText?: string) => Promise<void>;
+    cancel?: () => void;
+  } = {},
+) {
   return {
-    history: history as Conversation["history"],
-    runStream: async function* () {
-      for (const event of events) {
-        yield event as never;
-      }
-    },
-  } as unknown as Conversation;
+    items: overrides.items ?? [],
+    isLoading: overrides.isLoading ?? false,
+    sendMessage:
+      overrides.sendMessage ??
+      (vi.fn() as unknown as (
+        prompt: string,
+        displayText?: string,
+      ) => Promise<void>),
+    cancel: overrides.cancel ?? (vi.fn() as () => void),
+  };
 }
 
-function renderSidebar(conversation: Conversation | null = null) {
+function renderSidebar(
+  context: ReturnType<typeof makeContext> = makeContext(),
+) {
+  vi.mocked(useAgentContext).mockReturnValue(context);
   return render(
     <ThemeProvider>
       <WorkspacesProvider>
         <AppProvider>
-          <ChatSidebar conversation={conversation} />
+          <ChatSidebar />
         </AppProvider>
       </WorkspacesProvider>
     </ThemeProvider>,
@@ -61,6 +74,7 @@ function getInput() {
 describe("ChatSidebar", () => {
   beforeEach(() => {
     localStorage.clear();
+    vi.clearAllMocks();
   });
 
   it("shows empty state when there are no messages", () => {
@@ -71,101 +85,88 @@ describe("ChatSidebar", () => {
   });
 
   it("disables send button when input is empty", () => {
-    renderSidebar(makeConversation());
+    renderSidebar();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
   });
 
   it("enables send button when input has text", async () => {
     const user = userEvent.setup();
-    renderSidebar(makeConversation());
+    renderSidebar();
     await user.type(getInput(), "Hello");
     expect(screen.getByRole("button", { name: "Send" })).not.toBeDisabled();
   });
 
-  it("renders user message after send", async () => {
+  it("calls sendMessage with the typed text on send", async () => {
     const user = userEvent.setup();
-    renderSidebar(makeConversation([{ type: "done" }]));
+    const sendMessage = vi.fn();
+    renderSidebar(makeContext({ sendMessage }));
     await user.type(getInput(), "Hello AI");
     await user.click(screen.getByRole("button", { name: "Send" }));
-    await waitFor(() => {
-      expect(screen.getByText("Hello AI")).toBeInTheDocument();
-    });
+    expect(sendMessage).toHaveBeenCalledWith("Hello AI", "Hello AI");
   });
 
-  it("renders thinking section from thinking events", async () => {
+  it("shows cancel button while loading", () => {
+    renderSidebar(makeContext({ isLoading: true }));
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("calls cancel when cancel button is clicked", async () => {
     const user = userEvent.setup();
+    const cancel = vi.fn();
+    renderSidebar(makeContext({ isLoading: true, cancel }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it("renders a user message from items", () => {
     renderSidebar(
-      makeConversation([
-        { type: "thinking", delta: "Thinking hard..." },
-        { type: "done" },
-      ]),
+      makeContext({
+        items: [{ kind: "user", id: "u1", text: "Hello from user" }],
+      }),
     );
-    await user.type(getInput(), "test");
-    await user.click(screen.getByRole("button", { name: "Send" }));
-    await waitFor(() => {
-      expect(screen.getByText("Thinking Process")).toBeInTheDocument();
-    });
+    expect(screen.getByText("Hello from user")).toBeInTheDocument();
   });
 
-  it("renders accumulated assistant text from text_delta events", async () => {
-    const user = userEvent.setup();
+  it("renders an assistant message from items", () => {
     renderSidebar(
-      makeConversation([
-        { type: "text_delta", delta: "Hello " },
-        { type: "text_delta", delta: "world" },
-        { type: "done" },
-      ]),
-    );
-    await user.type(getInput(), "test");
-    await user.click(screen.getByRole("button", { name: "Send" }));
-    await waitFor(() => {
-      expect(screen.getByText("Hello world")).toBeInTheDocument();
-    });
-  });
-
-  it("renders tool item for tool_call_started events", async () => {
-    const user = userEvent.setup();
-    renderSidebar(
-      makeConversation([
-        { type: "tool_call_started", name: "read" },
-        { type: "tool_call_completed" },
-        { type: "done" },
-      ]),
-    );
-    await user.type(getInput(), "test");
-    await user.click(screen.getByRole("button", { name: "Send" }));
-    await waitFor(() => {
-      expect(screen.getByText("read")).toBeInTheDocument();
-    });
-  });
-
-  it("reconstructs user and assistant messages from conversation history", () => {
-    const conversation = makeConversation(
-      [],
-      [
-        { role: "user", content: { type: "text", text: "Hello from history" } },
-        { role: "assistant", content: { type: "text", text: "Hi there" } },
-      ],
-    );
-    renderSidebar(conversation);
-    expect(screen.getByText("Hello from history")).toBeInTheDocument();
-    expect(screen.getByText("Hi there")).toBeInTheDocument();
-  });
-
-  it("reconstructs tool call items from conversation history", () => {
-    const conversation = makeConversation(
-      [],
-      [
-        {
-          role: "assistant",
-          content: {
-            type: "tool_calls",
-            calls: [{ id: "1", name: "edit", args: {} }],
+      makeContext({
+        items: [
+          {
+            kind: "assistant",
+            id: "a1",
+            text: "Hello from assistant",
+            thought: "",
+            isStreaming: false,
           },
-        },
-      ],
+        ],
+      }),
     );
-    renderSidebar(conversation);
-    expect(screen.getByText("edit")).toBeInTheDocument();
+    expect(screen.getByText("Hello from assistant")).toBeInTheDocument();
+  });
+
+  it("renders a thinking section when thought is present", () => {
+    renderSidebar(
+      makeContext({
+        items: [
+          {
+            kind: "assistant",
+            id: "a1",
+            text: "",
+            thought: "Thinking hard...",
+            isStreaming: true,
+          },
+        ],
+      }),
+    );
+    expect(screen.getByText("Thinking Process")).toBeInTheDocument();
+  });
+
+  it("renders a tool item from items", () => {
+    renderSidebar(
+      makeContext({
+        items: [{ kind: "tool", id: "t1", name: "read", pending: false }],
+      }),
+    );
+    expect(screen.getByText("read")).toBeInTheDocument();
   });
 });

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -5,14 +5,13 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { Button } from "./ui/button";
 import { Switch } from "./ui/switch";
 import { Label } from "./ui/label";
-import { Conversation } from "@mast-ai/core";
 import { Settings, Wand2, Sun, Moon, X } from "lucide-react";
 import { useEditorUI } from "@/lib/store";
 import { useTheme } from "@/lib/ThemeProvider";
 import { useWorkspaces } from "@/lib/WorkspacesContext";
 import { SettingsDialog } from "./SettingsDialog";
 import { SkillsDialog } from "./SkillsDialog";
-import { ChatItem, ChildItem, StreamItem } from "./ChatItem";
+import { ChatItem } from "./ChatItem";
 import { PlanConfirmationWidget } from "./PlanConfirmationWidget";
 import {
   DocRef,
@@ -20,26 +19,19 @@ import {
   buildPromptWithMentions,
   extractMentionQuery,
 } from "@/lib/mentionUtils";
+import { useAgentContext } from "@/context/AgentContext";
+import type { StreamItem } from "@/lib/agent/types";
 
-interface ChatSidebarProps {
-  conversation: Conversation | null;
-  onBeforeSend?: () => void;
-}
+export function ChatSidebar() {
+  const { items, isLoading, sendMessage, cancel } = useAgentContext();
 
-export function ChatSidebar({ conversation, onBeforeSend }: ChatSidebarProps) {
   const [trailingInput, setTrailingInput] = useState("");
   const [segments, setSegments] = useState<Segment[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [items, setItems] = useState<StreamItem[]>([]);
   const [expandedThoughts, setExpandedThoughts] = useState<Set<string>>(
     new Set(),
   );
-  const [prevConversation, setPrevConversation] = useState<Conversation | null>(
-    null,
-  );
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [pickerIndex, setPickerIndex] = useState(0);
-  const abortControllerRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -59,38 +51,30 @@ export function ChatSidebar({ conversation, onBeforeSend }: ChatSidebarProps) {
         )
       : [];
 
-  // Rebuild display items when the conversation instance changes (e.g. new session)
-  if (conversation !== prevConversation) {
-    setPrevConversation(conversation);
-    if (conversation && conversation.history.length > 0) {
-      const rebuilt: StreamItem[] = conversation.history.flatMap((m, i) => {
-        if (m.content.type === "text") {
-          return [
-            {
-              kind: m.role === "user" ? "user" : "assistant",
-              id: `hist-${i}`,
-              text: m.content.text,
-              ...(m.role === "assistant"
-                ? { thought: "", isStreaming: false }
-                : {}),
-            } as StreamItem,
-          ];
+  // Sync expandedThoughts with streaming assistant items.
+  const prevItemsRef = useRef<readonly StreamItem[]>([]);
+  useEffect(() => {
+    const prevItems = prevItemsRef.current;
+    prevItemsRef.current = items;
+    setExpandedThoughts((prev) => {
+      const next = new Set(prev);
+      for (const item of items) {
+        if (item.kind !== "assistant") continue;
+        const prevItem = prevItems.find((p) => p.id === item.id);
+        if (!prevItem && item.isStreaming) {
+          next.add(item.id);
+        } else if (
+          prevItem &&
+          prevItem.kind === "assistant" &&
+          prevItem.isStreaming &&
+          !item.isStreaming
+        ) {
+          next.delete(item.id);
         }
-        if (m.content.type === "tool_calls") {
-          return m.content.calls.map(
-            (c, j): StreamItem => ({
-              kind: "tool",
-              id: `hist-${i}-${j}`,
-              name: c.name,
-              pending: false,
-            }),
-          );
-        }
-        return [];
-      });
-      setItems(rebuilt);
-    }
-  }
+      }
+      return next;
+    });
+  }, [items]);
 
   const virtualizer = useVirtualizer({
     count: items.length,
@@ -189,274 +173,19 @@ export function ChatSidebar({ conversation, onBeforeSend }: ChatSidebarProps) {
     }
   };
 
-  const handleSend = async () => {
+  const handleSend = () => {
     const displayText =
       segments.map((s) => `${s.text}@${s.doc.title}`).join("") + trailingInput;
-    if (!displayText.trim() || !conversation || isLoading) return;
+    if (!displayText.trim() || isLoading) return;
 
     const prompt = buildPromptWithMentions(segments, trailingInput);
 
     setTrailingInput("");
     setSegments([]);
     setMentionQuery(null);
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
-    setIsLoading(true);
     if (inputRef.current) inputRef.current.style.height = "";
 
-    setItems((prev) => [
-      ...prev,
-      {
-        kind: "user",
-        id: `user-${crypto.randomUUID()}`,
-        text: displayText.trim(),
-      },
-    ]);
-
-    // IDs of in-flight items — local vars are sufficient since this all runs
-    // within a single async invocation.
-    let assistantId: string | null = null;
-    let toolId: string | null = null;
-
-    // Tracks the active skill item and its pending child tool ID.
-    const activeSkillRef = {
-      id: null as string | null,
-      toolId: null as string | null,
-    };
-
-    const ensureAssistant = (): string => {
-      if (assistantId) return assistantId;
-      const id = `asst-${crypto.randomUUID()}`;
-      assistantId = id;
-      setItems((prev) => [
-        ...prev,
-        { kind: "assistant", id, text: "", thought: "", isStreaming: true },
-      ]);
-      setExpandedThoughts((prev) => new Set(prev).add(id));
-      return id;
-    };
-
-    const onToolEvent = (
-      _toolName: string,
-      event: import("@mast-ai/core").AgentEvent,
-    ) => {
-      const skillId = activeSkillRef.id;
-      if (!skillId) return;
-
-      if (event.type === "thinking" || event.type === "text_delta") {
-        const kind =
-          event.type === "thinking" ? ("thought" as const) : ("text" as const);
-        const delta = event.delta;
-        setItems((prev) =>
-          prev.map((it) => {
-            if (
-              (it.kind !== "skill" && it.kind !== "agent") ||
-              it.id !== skillId
-            )
-              return it;
-            const last = it.childItems[it.childItems.length - 1];
-            if (last && last.kind === kind) {
-              return {
-                ...it,
-                childItems: it.childItems.map((c, i) =>
-                  i === it.childItems.length - 1
-                    ? { ...c, text: (c as { text: string }).text + delta }
-                    : c,
-                ),
-              };
-            }
-            return {
-              ...it,
-              childItems: [
-                ...it.childItems,
-                { kind, id: `child-${crypto.randomUUID()}`, text: delta },
-              ],
-            };
-          }),
-        );
-      } else if (event.type === "tool_call_started") {
-        const tid = `child-tool-${crypto.randomUUID()}`;
-        activeSkillRef.toolId = tid;
-        const childTool: ChildItem = {
-          kind: "tool",
-          id: tid,
-          name: event.name,
-          pending: true,
-          params: event.args,
-        };
-        setItems((prev) =>
-          prev.map((it) =>
-            (it.kind === "skill" || it.kind === "agent") && it.id === skillId
-              ? { ...it, childItems: [...it.childItems, childTool] }
-              : it,
-          ),
-        );
-      } else if (event.type === "tool_call_completed") {
-        const tid = activeSkillRef.toolId;
-        if (tid) {
-          const toolResult = event.result;
-          setItems((prev) =>
-            prev.map((it) => {
-              if (
-                (it.kind !== "skill" && it.kind !== "agent") ||
-                it.id !== skillId
-              )
-                return it;
-              return {
-                ...it,
-                childItems: it.childItems.map((c) =>
-                  c.kind === "tool" && c.id === tid
-                    ? { ...c, pending: false, result: toolResult }
-                    : c,
-                ),
-              };
-            }),
-          );
-          activeSkillRef.toolId = null;
-        }
-      }
-    };
-
-    try {
-      onBeforeSend?.();
-      for await (const event of conversation.runStream(
-        prompt,
-        abortController.signal,
-        onToolEvent,
-      )) {
-        if (event.type === "thinking") {
-          const id = ensureAssistant();
-          const delta = event.delta;
-          setItems((prev) =>
-            prev.map((it) =>
-              it.kind === "assistant" && it.id === id
-                ? { ...it, thought: it.thought + delta }
-                : it,
-            ),
-          );
-        } else if (event.type === "text_delta") {
-          const id = ensureAssistant();
-          const delta = event.delta;
-          setItems((prev) =>
-            prev.map((it) =>
-              it.kind === "assistant" && it.id === id
-                ? { ...it, text: it.text + delta }
-                : it,
-            ),
-          );
-        } else if (event.type === "tool_call_started") {
-          // Finalize any open assistant bubble, then open a pending tool/skill item.
-          if (assistantId) {
-            const closeId = assistantId;
-            setItems((prev) =>
-              prev.map((it) =>
-                it.kind === "assistant" && it.id === closeId
-                  ? { ...it, isStreaming: false }
-                  : it,
-              ),
-            );
-            assistantId = null;
-          }
-          const tid = `tool-${crypto.randomUUID()}`;
-          toolId = tid;
-          if (event.name === "invoke_agent") {
-            const args = event.args as { systemPrompt?: string; task?: string };
-            activeSkillRef.id = tid;
-            activeSkillRef.toolId = null;
-            setItems((prev) => [
-              ...prev,
-              {
-                kind: "agent",
-                id: tid,
-                agentRole: "Agent",
-                task: args.task ?? "",
-                pending: true,
-                childItems: [],
-              },
-            ]);
-          } else if (event.name === "delegate_to_skill") {
-            const args = event.args as { skillName?: string; task?: string };
-            activeSkillRef.id = tid;
-            activeSkillRef.toolId = null;
-            setItems((prev) => [
-              ...prev,
-              {
-                kind: "skill",
-                id: tid,
-                name: args.skillName ?? "skill",
-                task: args.task ?? "",
-                pending: true,
-                childItems: [],
-              },
-            ]);
-          } else {
-            const name = event.name;
-            const params = event.args;
-            setItems((prev) => [
-              ...prev,
-              { kind: "tool", id: tid, name, pending: true, params },
-            ]);
-          }
-        } else if (event.type === "tool_call_completed") {
-          // Mark the tool/skill as done. Next content will lazily open a new assistant bubble.
-          if (toolId) {
-            const closeToolId = toolId;
-            if (activeSkillRef.id === closeToolId) {
-              setItems((prev) =>
-                prev.map((it) =>
-                  (it.kind === "skill" || it.kind === "agent") &&
-                  it.id === closeToolId
-                    ? { ...it, pending: false }
-                    : it,
-                ),
-              );
-              activeSkillRef.id = null;
-            } else {
-              const toolResult = event.result;
-              setItems((prev) =>
-                prev.map((it) =>
-                  it.kind === "tool" && it.id === closeToolId
-                    ? { ...it, pending: false, result: toolResult }
-                    : it,
-                ),
-              );
-            }
-            toolId = null;
-          }
-          assistantId = null;
-        } else if (event.type === "done") {
-          // Finalize the last assistant bubble and auto-collapse its thought.
-          if (assistantId) {
-            const closeId = assistantId;
-            setItems((prev) =>
-              prev.map((it) =>
-                it.kind === "assistant" && it.id === closeId
-                  ? { ...it, isStreaming: false }
-                  : it,
-              ),
-            );
-            setExpandedThoughts((prev) => {
-              const next = new Set(prev);
-              next.delete(closeId);
-              return next;
-            });
-            assistantId = null;
-          }
-        }
-      }
-    } catch (error) {
-      if ((error as { name?: string }).name !== "AbortError") {
-        console.error("Chat Error:", error);
-      }
-      // Remove any open (empty) assistant bubble on failure/cancel.
-      if (assistantId) {
-        const removeId = assistantId;
-        setItems((prev) => prev.filter((it) => it.id !== removeId));
-      }
-    } finally {
-      abortControllerRef.current = null;
-      setIsLoading(false);
-    }
+    sendMessage(prompt, displayText.trim());
   };
 
   const canSend =
@@ -621,11 +350,7 @@ export function ChatSidebar({ conversation, onBeforeSend }: ChatSidebarProps) {
           </div>
         </div>
         {isLoading ? (
-          <Button
-            variant="outline"
-            onClick={() => abortControllerRef.current?.abort()}
-            className="min-h-11"
-          >
+          <Button variant="outline" onClick={cancel} className="min-h-11">
             Cancel
           </Button>
         ) : (

--- a/src/context/AgentContext.tsx
+++ b/src/context/AgentContext.tsx
@@ -1,0 +1,257 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  type ReactNode,
+} from "react";
+import { addAllBuiltInAITools } from "@mast-ai/built-in-ai";
+import { DefaultAgentRunnerFactory } from "@/lib/agents";
+import {
+  EditorTools,
+  createDelegateToSkillHandler,
+} from "@/lib/tools/EditorTools";
+import { WorkspaceTools } from "@/lib/tools/WorkspaceTools";
+import { buildReadWriteRegistry } from "@/lib/tools/registries";
+import { registerDelegationTools } from "@/lib/tools/DelegationTools";
+import { registerWebMCPTools } from "@/lib/WebMCPTools";
+import { useAgentConfig, useEditorUI } from "@/lib/store";
+import { useWorkspaces } from "@/lib/WorkspacesContext";
+import { AgentModel } from "@/lib/agent/AgentModel";
+import type { StreamItem } from "@/lib/agent/types";
+
+interface AgentContextValue {
+  items: readonly StreamItem[];
+  isLoading: boolean;
+  sendMessage: (prompt: string, displayText?: string) => Promise<void>;
+  cancel: () => void;
+}
+
+const AgentContext = createContext<AgentContextValue | undefined>(undefined);
+
+export function AgentContextProvider({ children }: { children: ReactNode }) {
+  const { apiKey, modelName, setTotalTokens, skills } = useAgentConfig();
+  const {
+    setSuggestions,
+    approveAll,
+    activeTab,
+    editorContent,
+    editorInstance,
+    setPendingTabSwitchRequest,
+    setPendingWorkspaceAction,
+    setPendingPlanConfirmation,
+  } = useEditorUI();
+  const {
+    activeWorkspace,
+    activeDocument,
+    createDocumentWithTitle,
+    updateDocument,
+    deleteDocument,
+    setActiveDocumentId,
+  } = useWorkspaces();
+
+  // Stable refs updated on every render so tool callbacks always see latest values.
+  const docsRef = useRef(activeWorkspace?.documents ?? []);
+  useEffect(() => {
+    docsRef.current = activeWorkspace?.documents ?? [];
+  }, [activeWorkspace]);
+
+  const activeDocRef = useRef<{ id: string; title: string } | null>(
+    activeDocument
+      ? { id: activeDocument.id, title: activeDocument.title }
+      : null,
+  );
+  useEffect(() => {
+    activeDocRef.current = activeDocument
+      ? { id: activeDocument.id, title: activeDocument.title }
+      : null;
+  }, [activeDocument]);
+
+  const editorInstanceRef = useRef(editorInstance);
+  useEffect(() => {
+    editorInstanceRef.current = editorInstance;
+  }, [editorInstance]);
+
+  const editorContentRef = useRef(editorContent);
+  useEffect(() => {
+    editorContentRef.current = editorContent;
+  }, [editorContent]);
+
+  const activeTabRef = useRef(activeTab);
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab]);
+
+  const approveAllRef = useRef(approveAll);
+  useEffect(() => {
+    approveAllRef.current = approveAll;
+  }, [approveAll]);
+
+  const requestTabSwitch = useCallback(
+    () =>
+      new Promise<boolean>((resolve) => {
+        setPendingTabSwitchRequest({ resolve });
+      }),
+    [setPendingTabSwitchRequest],
+  );
+
+  const editorTools = useMemo(
+    () =>
+      new EditorTools(
+        editorInstanceRef,
+        setSuggestions,
+        approveAllRef,
+        editorContentRef,
+        activeTabRef,
+        requestTabSwitch,
+      ),
+    [setSuggestions, requestTabSwitch],
+  );
+
+  const usageCallback = useCallback(
+    (usage: { totalTokenCount?: number }) =>
+      setTotalTokens((prev) => prev + (usage.totalTokenCount || 0)),
+    [setTotalTokens],
+  );
+
+  const factory = useMemo(
+    () =>
+      apiKey
+        ? new DefaultAgentRunnerFactory(apiKey, modelName, usageCallback)
+        : null,
+    [apiKey, modelName, usageCallback],
+  );
+
+  const workspaceTools = useMemo(
+    () =>
+      new WorkspaceTools(
+        docsRef,
+        activeDocRef,
+        factory ?? new DefaultAgentRunnerFactory("", ""),
+        (title) => createDocumentWithTitle(title),
+        (id, title) => updateDocument(id, { title }),
+        (id) => deleteDocument(id),
+        (id) => setActiveDocumentId(id),
+        (id, content) => updateDocument(id, { content }),
+        editorInstanceRef,
+        editorContentRef,
+        setPendingWorkspaceAction,
+        approveAllRef,
+      ),
+    [
+      factory,
+      createDocumentWithTitle,
+      updateDocument,
+      deleteDocument,
+      setActiveDocumentId,
+      setPendingWorkspaceAction,
+    ],
+  );
+
+  useEffect(
+    () => registerWebMCPTools(editorTools, workspaceTools),
+    [editorTools, workspaceTools],
+  );
+
+  const registry = useMemo(() => {
+    if (!apiKey || !factory) return null;
+    const r = buildReadWriteRegistry(editorTools, workspaceTools);
+    addAllBuiltInAITools(r).catch(() => {});
+    r.register({
+      definition: () => ({
+        name: "delegate_to_skill",
+        description:
+          "Delegates a task to a named skill (sub-agent). The skill runs with read-only access and returns its response as a string. Interpret the response and act on it accordingly.",
+        parameters: {
+          type: "object",
+          properties: {
+            skillName: {
+              type: "string",
+              description: "The exact name of the skill to invoke.",
+            },
+            task: {
+              type: "string",
+              description:
+                "The specific task or instructions to pass to the skill.",
+            },
+          },
+          required: ["skillName", "task"],
+        },
+        scope: "write" as const,
+      }),
+      call: createDelegateToSkillHandler(factory, editorTools, workspaceTools),
+    });
+    registerDelegationTools(
+      r,
+      factory,
+      editorTools,
+      workspaceTools,
+      setPendingPlanConfirmation,
+    );
+    return r;
+  }, [
+    apiKey,
+    factory,
+    editorTools,
+    workspaceTools,
+    setPendingPlanConfirmation,
+  ]);
+
+  const model = useMemo(
+    () =>
+      apiKey && registry
+        ? new AgentModel(apiKey, modelName, skills, registry, usageCallback)
+        : null,
+    [apiKey, modelName, skills, registry, usageCallback],
+  );
+
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => {
+    if (!model) return;
+    return model.subscribe(() => forceUpdate());
+  }, [model]);
+
+  const flushEditorContent = useCallback(() => {
+    const doc = activeDocRef.current;
+    if (doc) {
+      const content =
+        editorInstanceRef.current?.getValue() ?? editorContentRef.current;
+      updateDocument(doc.id, { content });
+    }
+  }, [updateDocument]);
+
+  const sendMessage = useCallback(
+    (prompt: string, displayText?: string) =>
+      model?.sendMessage(prompt, displayText, flushEditorContent) ??
+      Promise.resolve(),
+    [model, flushEditorContent],
+  );
+
+  const cancel = useCallback(() => model?.cancel(), [model]);
+
+  return (
+    <AgentContext.Provider
+      value={{
+        items: model?.items ?? [],
+        isLoading: model?.isLoading ?? false,
+        sendMessage,
+        cancel,
+      }}
+    >
+      {children}
+    </AgentContext.Provider>
+  );
+}
+
+export function useAgentContext(): AgentContextValue {
+  const ctx = useContext(AgentContext);
+  if (!ctx)
+    throw new Error("useAgentContext must be used within AgentContextProvider");
+  return ctx;
+}

--- a/src/lib/agent/AgentModel.ts
+++ b/src/lib/agent/AgentModel.ts
@@ -1,0 +1,347 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AgentRunner,
+  AgentConfig,
+  AgentEvent,
+  Conversation,
+  ToolProvider,
+} from "@mast-ai/core";
+import { GoogleGenAIAdapter } from "@mast-ai/google-genai";
+import { buildOrchestratorPrompt } from "../agents";
+import type { Skill } from "../skills";
+import type { StreamItem, ChildItem } from "./types";
+
+export class AgentModel {
+  private _items: StreamItem[] = [];
+  private _isLoading = false;
+  private _listeners = new Set<() => void>();
+  private _abortController: AbortController | null = null;
+  private _conversation: Conversation;
+
+  constructor(
+    apiKey: string,
+    modelName: string,
+    skills: Skill[],
+    registry: ToolProvider,
+    usageCallback?: (usage: { totalTokenCount?: number }) => void,
+  ) {
+    const adapter = new GoogleGenAIAdapter(apiKey, modelName, usageCallback);
+    const runner = new AgentRunner(adapter, registry);
+    const agentConfig: AgentConfig = {
+      name: "EditorAssistant",
+      instructions: buildOrchestratorPrompt(skills),
+    };
+    this._conversation = runner.conversation(agentConfig);
+    this._initFromHistory();
+  }
+
+  private _initFromHistory(): void {
+    const history = this._conversation.history;
+    if (history.length === 0) return;
+    this._items = history.flatMap((m, i) => {
+      if (m.content.type === "text") {
+        const item: StreamItem =
+          m.role === "user"
+            ? { kind: "user", id: `hist-${i}`, text: m.content.text }
+            : {
+                kind: "assistant",
+                id: `hist-${i}`,
+                text: m.content.text,
+                thought: "",
+                isStreaming: false,
+              };
+        return [item];
+      }
+      if (m.content.type === "tool_calls") {
+        return m.content.calls.map(
+          (c, j): StreamItem => ({
+            kind: "tool",
+            id: `hist-${i}-${j}`,
+            name: c.name,
+            pending: false,
+          }),
+        );
+      }
+      return [];
+    });
+  }
+
+  get items(): readonly StreamItem[] {
+    return this._items;
+  }
+
+  get isLoading(): boolean {
+    return this._isLoading;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this._listeners.add(listener);
+    return () => this._listeners.delete(listener);
+  }
+
+  cancel(): void {
+    this._abortController?.abort();
+  }
+
+  async sendMessage(
+    prompt: string,
+    displayText?: string,
+    onBeforeSend?: () => void,
+  ): Promise<void> {
+    if (!prompt.trim() || this._isLoading) return;
+
+    const abortController = new AbortController();
+    this._abortController = abortController;
+    this._isLoading = true;
+    this._items = [
+      ...this._items,
+      {
+        kind: "user",
+        id: `user-${crypto.randomUUID()}`,
+        text: (displayText ?? prompt).trim(),
+      },
+    ];
+    this._notify();
+
+    onBeforeSend?.();
+
+    let assistantId: string | null = null;
+    let toolId: string | null = null;
+    const activeSkillRef = {
+      id: null as string | null,
+      toolId: null as string | null,
+    };
+
+    const mutateItems = (fn: (prev: StreamItem[]) => StreamItem[]) => {
+      this._items = fn(this._items);
+      this._notify();
+    };
+
+    const ensureAssistant = (): string => {
+      if (assistantId) return assistantId;
+      const id = `asst-${crypto.randomUUID()}`;
+      assistantId = id;
+      mutateItems((prev) => [
+        ...prev,
+        { kind: "assistant", id, text: "", thought: "", isStreaming: true },
+      ]);
+      return id;
+    };
+
+    const onToolEvent = (_toolName: string, event: AgentEvent) => {
+      const skillId = activeSkillRef.id;
+      if (!skillId) return;
+
+      if (event.type === "thinking" || event.type === "text_delta") {
+        const kind =
+          event.type === "thinking" ? ("thought" as const) : ("text" as const);
+        const delta = event.delta;
+        mutateItems((prev) =>
+          prev.map((it) => {
+            if (
+              (it.kind !== "skill" && it.kind !== "agent") ||
+              it.id !== skillId
+            )
+              return it;
+            const last = it.childItems[it.childItems.length - 1];
+            if (last && last.kind === kind) {
+              return {
+                ...it,
+                childItems: it.childItems.map((c, i) =>
+                  i === it.childItems.length - 1
+                    ? { ...c, text: (c as { text: string }).text + delta }
+                    : c,
+                ),
+              };
+            }
+            return {
+              ...it,
+              childItems: [
+                ...it.childItems,
+                { kind, id: `child-${crypto.randomUUID()}`, text: delta },
+              ],
+            };
+          }),
+        );
+      } else if (event.type === "tool_call_started") {
+        const tid = `child-tool-${crypto.randomUUID()}`;
+        activeSkillRef.toolId = tid;
+        const childTool: ChildItem = {
+          kind: "tool",
+          id: tid,
+          name: event.name,
+          pending: true,
+          params: event.args,
+        };
+        mutateItems((prev) =>
+          prev.map((it) =>
+            (it.kind === "skill" || it.kind === "agent") && it.id === skillId
+              ? { ...it, childItems: [...it.childItems, childTool] }
+              : it,
+          ),
+        );
+      } else if (event.type === "tool_call_completed") {
+        const tid = activeSkillRef.toolId;
+        if (tid) {
+          const toolResult = event.result;
+          mutateItems((prev) =>
+            prev.map((it) => {
+              if (
+                (it.kind !== "skill" && it.kind !== "agent") ||
+                it.id !== skillId
+              )
+                return it;
+              return {
+                ...it,
+                childItems: it.childItems.map((c) =>
+                  c.kind === "tool" && c.id === tid
+                    ? { ...c, pending: false, result: toolResult }
+                    : c,
+                ),
+              };
+            }),
+          );
+          activeSkillRef.toolId = null;
+        }
+      }
+    };
+
+    try {
+      for await (const event of this._conversation.runStream(
+        prompt,
+        abortController.signal,
+        onToolEvent,
+      )) {
+        if (event.type === "thinking") {
+          const id = ensureAssistant();
+          const delta = event.delta;
+          mutateItems((prev) =>
+            prev.map((it) =>
+              it.kind === "assistant" && it.id === id
+                ? { ...it, thought: it.thought + delta }
+                : it,
+            ),
+          );
+        } else if (event.type === "text_delta") {
+          const id = ensureAssistant();
+          const delta = event.delta;
+          mutateItems((prev) =>
+            prev.map((it) =>
+              it.kind === "assistant" && it.id === id
+                ? { ...it, text: it.text + delta }
+                : it,
+            ),
+          );
+        } else if (event.type === "tool_call_started") {
+          if (assistantId) {
+            const closeId = assistantId;
+            mutateItems((prev) =>
+              prev.map((it) =>
+                it.kind === "assistant" && it.id === closeId
+                  ? { ...it, isStreaming: false }
+                  : it,
+              ),
+            );
+            assistantId = null;
+          }
+          const tid = `tool-${crypto.randomUUID()}`;
+          toolId = tid;
+          if (event.name === "invoke_agent") {
+            const args = event.args as { systemPrompt?: string; task?: string };
+            activeSkillRef.id = tid;
+            activeSkillRef.toolId = null;
+            mutateItems((prev) => [
+              ...prev,
+              {
+                kind: "agent",
+                id: tid,
+                agentRole: "Agent",
+                task: args.task ?? "",
+                pending: true,
+                childItems: [],
+              },
+            ]);
+          } else if (event.name === "delegate_to_skill") {
+            const args = event.args as { skillName?: string; task?: string };
+            activeSkillRef.id = tid;
+            activeSkillRef.toolId = null;
+            mutateItems((prev) => [
+              ...prev,
+              {
+                kind: "skill",
+                id: tid,
+                name: args.skillName ?? "skill",
+                task: args.task ?? "",
+                pending: true,
+                childItems: [],
+              },
+            ]);
+          } else {
+            const name = event.name;
+            const params = event.args;
+            mutateItems((prev) => [
+              ...prev,
+              { kind: "tool", id: tid, name, pending: true, params },
+            ]);
+          }
+        } else if (event.type === "tool_call_completed") {
+          if (toolId) {
+            const closeToolId = toolId;
+            if (activeSkillRef.id === closeToolId) {
+              mutateItems((prev) =>
+                prev.map((it) =>
+                  (it.kind === "skill" || it.kind === "agent") &&
+                  it.id === closeToolId
+                    ? { ...it, pending: false }
+                    : it,
+                ),
+              );
+              activeSkillRef.id = null;
+            } else {
+              const toolResult = event.result;
+              mutateItems((prev) =>
+                prev.map((it) =>
+                  it.kind === "tool" && it.id === closeToolId
+                    ? { ...it, pending: false, result: toolResult }
+                    : it,
+                ),
+              );
+            }
+            toolId = null;
+          }
+          assistantId = null;
+        } else if (event.type === "done") {
+          if (assistantId) {
+            const closeId = assistantId;
+            mutateItems((prev) =>
+              prev.map((it) =>
+                it.kind === "assistant" && it.id === closeId
+                  ? { ...it, isStreaming: false }
+                  : it,
+              ),
+            );
+            assistantId = null;
+          }
+        }
+      }
+    } catch (error) {
+      if ((error as { name?: string }).name !== "AbortError") {
+        console.error("Chat Error:", error);
+      }
+      if (assistantId) {
+        const removeId = assistantId;
+        mutateItems((prev) => prev.filter((it) => it.id !== removeId));
+      }
+    } finally {
+      this._abortController = null;
+      this._isLoading = false;
+      this._notify();
+    }
+  }
+
+  private _notify(): void {
+    this._listeners.forEach((l) => l());
+  }
+}

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export type ChildItem =
+  | { kind: "thought"; id: string; text: string }
+  | { kind: "text"; id: string; text: string }
+  | {
+      kind: "tool";
+      id: string;
+      name: string;
+      pending: boolean;
+      params?: unknown;
+      result?: unknown;
+    };
+
+export type StreamItem =
+  | { kind: "user"; id: string; text: string }
+  | {
+      kind: "assistant";
+      id: string;
+      text: string;
+      thought: string;
+      isStreaming: boolean;
+      agentRole?: string;
+      parentMessageId?: string;
+    }
+  | {
+      kind: "tool";
+      id: string;
+      name: string;
+      pending: boolean;
+      params?: unknown;
+      result?: unknown;
+    }
+  | {
+      kind: "skill";
+      id: string;
+      name: string;
+      task: string;
+      pending: boolean;
+      childItems: ChildItem[];
+    }
+  | {
+      kind: "agent";
+      id: string;
+      agentRole: string;
+      task: string;
+      pending: boolean;
+      childItems: ChildItem[];
+      parentMessageId?: string;
+    };

--- a/src/lib/tools/WorkspaceTools.ts
+++ b/src/lib/tools/WorkspaceTools.ts
@@ -383,4 +383,3 @@ export function registerWorkspaceTools(
     call: async (args: { id: string }) => tools.switch_active_document(args),
   });
 }
-


### PR DESCRIPTION
## Summary

- Extracts all agent orchestration logic from `App.tsx` (a React component) into a plain TypeScript `AgentModel` class with no React imports, following the MVC pattern described in the [`bandarrame_rs` admin-agent spec](https://github.com/andreban/bandarrame_rs/blob/admin-agent/docs/admin-agent/SPEC.md#architecture-model--view-separation)
- Adds `AgentContextProvider` as a React ViewModel layer that owns tool/registry construction, instantiates `AgentModel`, and bridges its state to the component tree
- `ChatSidebar` is now purely presentational — no props, no MAST imports, reads everything from `useAgentContext()`

## Changes

| File | Change |
|---|---|
| `src/lib/agent/types.ts` | New — `StreamItem`/`ChildItem` types extracted from `ChatItem.tsx` |
| `src/lib/agent/AgentModel.ts` | New — plain TS class; owns `Conversation`, full streaming loop, history init, `subscribe()` |
| `src/context/AgentContext.tsx` | New — React ViewModel; creates tools/factory/registry, instantiates model, exposes context |
| `src/App.tsx` | All agent setup removed; layouts take no props; wrapped in `<AgentContextProvider>` |
| `src/components/ChatSidebar.tsx` | `conversation` prop removed; reads from `useAgentContext()`; `handleSend` reduced to ~10 lines |
| `src/components/ChatItem.tsx` | Imports types from new location, re-exports for backward compat |
| `src/components/ChatSidebar.test.tsx` | Mocks `useAgentContext`; tests display behaviour via static `items` |

## Test plan

- [ ] All 313 existing tests pass (`npm run test`)
- [ ] Build compiles cleanly with no type errors (`npm run build`)
- [ ] Lint passes with 0 errors (`npm run lint`)
- [ ] Chat UI works end-to-end: send a message, see streaming response, accept/reject suggestions