### PR TITLE
refactor: replace buildReadonlyRegistry with ToolRegistry.readOnly()

### DIFF
--- a/src/context/AgentContext.tsx
+++ b/src/context/AgentContext.tsx
@@ -184,12 +184,12 @@ export function AgentContextProvider({ children }: { children: ReactNode }) {
         },
         scope: "write" as const,
       }),
-      call: createDelegateToSkillHandler(factory, editorTools, workspaceTools),
+      call: createDelegateToSkillHandler(factory, r.readOnly()),
     });
     registerDelegationTools(
       r,
       factory,
-      editorTools,
+      r.readOnly(),
       workspaceTools,
       setPendingPlanConfirmation,
     );

--- a/src/lib/tools/DelegationTools.test.ts
+++ b/src/lib/tools/DelegationTools.test.ts
@@ -8,6 +8,7 @@ import type { AgentRunnerFactory } from "../agents";
 import type { AgentEvent } from "@mast-ai/core";
 import { EditorTools } from "./EditorTools";
 import { WorkspaceTools } from "./WorkspaceTools";
+import { buildReadWriteRegistry } from "./registries";
 import type { PlanConfirmationRequest } from "../store";
 
 function makeMockStream(
@@ -74,7 +75,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     registerDelegationTools(
       registry,
       factory,
-      editorTools,
+      buildReadWriteRegistry(editorTools, workspaceTools).readOnly(),
       workspaceTools,
       vi.fn(),
     );
@@ -94,7 +95,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     const raw = await callTool(registry, "invoke_agent", {
       systemPrompt: "Help.",
@@ -113,7 +114,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     const onEvent = vi.fn();
     await callTool(
@@ -137,7 +138,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory, mockRunBuilder } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     await callTool(registry, "invoke_agent", {
       systemPrompt: "s",
@@ -153,7 +154,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     const tool = registry.getTool("invoke_agent");
     expect(tool).toBeDefined();
@@ -164,7 +165,7 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory, mockRunBuilder } = makeFactory(mockRunStream);
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     await callTool(registry, "invoke_agent", {
       systemPrompt: "s",
@@ -198,7 +199,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     const tool = registry.getTool("invoke_planner");
     expect(tool).toBeDefined();
@@ -217,7 +218,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, autoConfirm);
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, autoConfirm);
 
     const raw = await callTool(registry, "invoke_planner", {
       task: "Write a blog post about AI",
@@ -235,7 +236,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, autoConfirm);
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, autoConfirm);
 
     await callTool(registry, "invoke_planner", {
       task: "Write a blog post",
@@ -254,7 +255,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     await expect(
       callTool(registry, "invoke_planner", { task: "t" }),
@@ -268,7 +269,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     await expect(
       callTool(registry, "invoke_planner", { task: "t" }),
@@ -282,7 +283,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, autoConfirm);
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, autoConfirm);
 
     await callTool(registry, "invoke_planner", { task: "Write a blog post" });
 
@@ -298,7 +299,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, autoConfirm);
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, autoConfirm);
 
     await callTool(registry, "invoke_planner", { task: "t" });
 
@@ -315,7 +316,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, rejectConfirm);
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, rejectConfirm);
 
     await expect(
       callTool(registry, "invoke_planner", { task: "t" }),
@@ -332,7 +333,7 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeTools(factory);
-    registerDelegationTools(registry, factory, et, wt, rejectConfirm);
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, rejectConfirm);
 
     await expect(
       callTool(registry, "invoke_planner", { task: "t" }),
@@ -372,7 +373,7 @@ describe("registerDelegationTools / invoke_researcher", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     const tool = registry.getTool("invoke_researcher");
     expect(tool).toBeDefined();
@@ -395,7 +396,7 @@ describe("registerDelegationTools / invoke_researcher", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     const raw = await callTool(registry, "invoke_researcher", {
       query: "What do the docs say?",
@@ -424,7 +425,7 @@ describe("registerDelegationTools / invoke_researcher", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     const raw = await callTool(registry, "invoke_researcher", { query: "q" });
     const result = JSON.parse(raw as string);
@@ -457,7 +458,7 @@ describe("registerDelegationTools / invoke_researcher", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     const raw = await callTool(registry, "invoke_researcher", {
       query: "q",
@@ -484,7 +485,7 @@ describe("registerDelegationTools / invoke_researcher", () => {
     const { factory } = makeFactory(mockRunStream);
     const registry = new ToolRegistry();
     const { editorTools: et, workspaceTools: wt } = makeResearchTools(factory);
-    registerDelegationTools(registry, factory, et, wt, vi.fn());
+    registerDelegationTools(registry, factory, buildReadWriteRegistry(et, wt).readOnly(), wt, vi.fn());
 
     const raw = await callTool(registry, "invoke_researcher", { query: "q" });
     const result = JSON.parse(raw as string);

--- a/src/lib/tools/DelegationTools.ts
+++ b/src/lib/tools/DelegationTools.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { AgentConfig, ToolContext, ToolRegistry } from "@mast-ai/core";
+import { AgentConfig, ToolContext, ToolProvider, ToolRegistry } from "@mast-ai/core";
 import type { AgentRunnerFactory } from "../agents";
 import { createGenericAgent } from "../agents";
 import {
@@ -14,14 +14,12 @@ import { runResearch } from "../agents";
 import { runWriter } from "../agents";
 import { runReview } from "../agents";
 import type { PlanConfirmationRequest } from "../store";
-import { EditorTools } from "./EditorTools";
 import { WorkspaceTools } from "./WorkspaceTools";
-import { buildReadonlyRegistry } from "./registries";
 
 export function registerDelegationTools(
   registry: ToolRegistry,
   factory: AgentRunnerFactory,
-  editorTools: EditorTools,
+  readonlyRegistry: ToolProvider,
   workspaceTools: WorkspaceTools,
   setPendingPlanConfirmation: (req: PlanConfirmationRequest | null) => void,
 ): void {
@@ -58,7 +56,7 @@ export function registerDelegationTools(
     ) => {
       const groups = args.tools ?? [];
       const resolvedRegistry = groups.includes("workspace_readonly")
-        ? buildReadonlyRegistry(editorTools, workspaceTools)
+        ? readonlyRegistry
         : new ToolRegistry();
 
       const runner = createGenericAgent(

--- a/src/lib/tools/EditorTools.test.ts
+++ b/src/lib/tools/EditorTools.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EditorTools, createDelegateToSkillHandler } from "./EditorTools";
 import { WorkspaceTools } from "./WorkspaceTools";
+import { buildReadWriteRegistry } from "./registries";
 import { saveSkills } from "../skills";
 import type { AgentRunnerFactory } from "../agents";
 
@@ -432,8 +433,7 @@ describe("EditorTools", () => {
     function makeHandler(factory = mockFactory) {
       return createDelegateToSkillHandler(
         factory,
-        editorToolsInstance,
-        mockWorkspaceTools,
+        buildReadWriteRegistry(editorToolsInstance, mockWorkspaceTools).readOnly(),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => ({ runBuilder: mockRunBuilder }) as any,
       );
@@ -554,8 +554,7 @@ describe("EditorTools", () => {
         .mockReturnValue({ runBuilder: mockRunBuilder });
       const handler = createDelegateToSkillHandler(
         mockFactory,
-        editorToolsInstance,
-        mockWorkspaceTools,
+        buildReadWriteRegistry(editorToolsInstance, mockWorkspaceTools).readOnly(),
         customRunnerFactory,
       );
       await handler({ skillName: "Proofreader", task: "t" }, {});

--- a/src/lib/tools/EditorTools.ts
+++ b/src/lib/tools/EditorTools.ts
@@ -12,8 +12,6 @@ import {
 import { Suggestion } from "../store";
 import type { AgentRunnerFactory } from "../agents";
 import { loadSkills } from "../skills";
-import { WorkspaceTools } from "./WorkspaceTools";
-import { buildReadonlyRegistry } from "./registries";
 import { v4 as uuidv4 } from "uuid";
 
 export class EditorTools {
@@ -330,8 +328,7 @@ type RunnerLike = {
 
 export function createDelegateToSkillHandler(
   factory: AgentRunnerFactory,
-  editorTools: EditorTools,
-  workspaceTools: WorkspaceTools,
+  readonlyRegistry: ToolProvider,
   runnerFactory: (registry: ToolProvider, model?: string) => RunnerLike = (
     registry,
     model,
@@ -348,10 +345,9 @@ export function createDelegateToSkillHandler(
       return `Error: skill "${skillName}" not found. Available skills: ${names || "none"}`;
     }
 
-    const childRegistry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const readonlyToolNames = childRegistry.getTools().map((d) => d.name);
+    const readonlyToolNames = readonlyRegistry.getTools().map((d) => d.name);
 
-    const childRunner = runnerFactory(childRegistry, skill.model);
+    const childRunner = runnerFactory(readonlyRegistry, skill.model);
     const agentConfig: AgentConfig = {
       name: skill.name,
       instructions: skill.instructions,

--- a/src/lib/tools/registries.test.ts
+++ b/src/lib/tools/registries.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi } from "vitest";
-import { buildReadonlyRegistry, buildReadWriteRegistry } from "./registries";
+import { buildReadWriteRegistry } from "./registries";
 import { EditorTools } from "./EditorTools";
 import { WorkspaceTools } from "./WorkspaceTools";
 import type { AgentRunnerFactory } from "../agents";
@@ -28,49 +28,6 @@ function makeTools() {
   );
   return { editorTools, workspaceTools };
 }
-
-describe("buildReadonlyRegistry", () => {
-  it("includes read, read_selection, search, get_metadata, get_current_mode", () => {
-    const { editorTools, workspaceTools } = makeTools();
-    const registry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const names = registry.getTools().map((d) => d.name);
-    expect(names).toContain("read");
-    expect(names).toContain("read_selection");
-    expect(names).toContain("search");
-    expect(names).toContain("get_metadata");
-    expect(names).toContain("get_current_mode");
-  });
-
-  it("excludes edit, write, request_switch_to_editor", () => {
-    const { editorTools, workspaceTools } = makeTools();
-    const registry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const names = registry.getTools().map((d) => d.name);
-    expect(names).not.toContain("edit");
-    expect(names).not.toContain("write");
-    expect(names).not.toContain("request_switch_to_editor");
-  });
-
-  it("includes workspace read tools", () => {
-    const { editorTools, workspaceTools } = makeTools();
-    const registry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const names = registry.getTools().map((d) => d.name);
-    expect(names).toContain("get_active_doc_info");
-    expect(names).toContain("list_workspace_docs");
-    expect(names).toContain("read_workspace_doc");
-    expect(names).toContain("query_workspace_doc");
-    expect(names).toContain("query_workspace");
-  });
-
-  it("excludes workspace write tools", () => {
-    const { editorTools, workspaceTools } = makeTools();
-    const registry = buildReadonlyRegistry(editorTools, workspaceTools);
-    const names = registry.getTools().map((d) => d.name);
-    expect(names).not.toContain("create_document");
-    expect(names).not.toContain("rename_document");
-    expect(names).not.toContain("delete_document");
-    expect(names).not.toContain("switch_active_document");
-  });
-});
 
 describe("buildReadWriteRegistry", () => {
   it("includes all read-only tools", () => {

--- a/src/lib/tools/registries.ts
+++ b/src/lib/tools/registries.ts
@@ -1,16 +1,9 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { ToolRegistry, ToolRegistryView } from "@mast-ai/core";
+import { ToolRegistry } from "@mast-ai/core";
 import { EditorTools, registerEditorTools } from "./EditorTools";
 import { WorkspaceTools, registerWorkspaceTools } from "./WorkspaceTools";
-
-export function buildReadonlyRegistry(
-  editorTools: EditorTools,
-  workspaceTools: WorkspaceTools,
-): ToolRegistryView {
-  return buildReadWriteRegistry(editorTools, workspaceTools).readOnly();
-}
 
 export function buildReadWriteRegistry(
   editorTools: EditorTools,


### PR DESCRIPTION
## Summary

- Removes `buildReadonlyRegistry` — it was constructing a new `ToolRegistry` just to call `.readOnly()` on it, when a live view of the existing registry was already available
- `createDelegateToSkillHandler` and `registerDelegationTools` now accept a `ToolProvider` (the read-only view) instead of `editorTools` + `workspaceTools`
- Callers in `AgentContext` pass `r.readOnly()`, which is a live filtered view of the already-built registry

## Test plan

- [x] `npm run build` passes (verified locally)
- [x] Existing tests updated to construct the read-only registry directly via `buildReadWriteRegistry(...).readOnly()`