### PR TITLE
refactor: have WebMCPTools pull tools from ToolProvider

### DIFF
--- a/src/context/AgentContext.tsx
+++ b/src/context/AgentContext.tsx
@@ -149,9 +149,15 @@ export function AgentContextProvider({ children }: { children: ReactNode }) {
     ],
   );
 
-  useEffect(
-    () => registerWebMCPTools(editorCtx, workspaceCtx),
+  const baseRegistry = useMemo(
+    // eslint-disable-next-line react-hooks/refs
+    () => createToolRegistry(editorCtx, workspaceCtx),
     [editorCtx, workspaceCtx],
+  );
+
+  useEffect(
+    () => registerWebMCPTools(baseRegistry),
+    [baseRegistry],
   );
 
   const registry = useMemo(() => {

--- a/src/lib/WebMCPTools.test.ts
+++ b/src/lib/WebMCPTools.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { registerWebMCPTools } from "./WebMCPTools";
+import { createToolRegistry } from "./agents/tools/registries";
 import type { EditorContext } from "./agents/tools/editor/context";
 import type { WorkspaceContext } from "./agents/tools/workspace/context";
 
@@ -93,7 +94,7 @@ describe("registerWebMCPTools", () => {
       }),
     };
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const cleanup = registerWebMCPTools(makeEditorCtx(), makeWorkspaceCtx());
+    const cleanup = registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
     expect(warnSpy).toHaveBeenCalledWith(
       "WebMCP tool registration failed:",
       expect.any(TypeError),
@@ -105,12 +106,12 @@ describe("registerWebMCPTools", () => {
   it("returns a no-op cleanup when navigator.modelContext is undefined", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (navigator as any).modelContext;
-    const cleanup = registerWebMCPTools(makeEditorCtx(), makeWorkspaceCtx());
+    const cleanup = registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
     expect(() => cleanup()).not.toThrow();
   });
 
   it("registers all expected tools", () => {
-    registerWebMCPTools(makeEditorCtx(), makeWorkspaceCtx());
+    registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
     const expected = [
       "read",
       "read_selection",
@@ -137,14 +138,14 @@ describe("registerWebMCPTools", () => {
   });
 
   it("passes an AbortSignal to each registered tool", () => {
-    registerWebMCPTools(makeEditorCtx(), makeWorkspaceCtx());
+    registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
     for (const [, entry] of registeredTools) {
       expect(entry.signal).toBeInstanceOf(AbortSignal);
     }
   });
 
   it("cleanup aborts the shared signal", () => {
-    const cleanup = registerWebMCPTools(makeEditorCtx(), makeWorkspaceCtx());
+    const cleanup = registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
     const signal = registeredTools.get("read")!.signal!;
     expect(signal.aborted).toBe(false);
     cleanup();
@@ -152,12 +153,12 @@ describe("registerWebMCPTools", () => {
   });
 
   it("read execute returns editor content", async () => {
-    registerWebMCPTools(makeEditorCtx(), makeWorkspaceCtx());
+    registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
     expect(await registeredTools.get("read")!.execute({})).toBe("editor content");
   });
 
   it("get_current_mode execute returns current mode", async () => {
-    registerWebMCPTools(makeEditorCtx(), makeWorkspaceCtx());
+    registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
     expect(await registeredTools.get("get_current_mode")!.execute({})).toBe("editor");
   });
 });

--- a/src/lib/WebMCPTools.ts
+++ b/src/lib/WebMCPTools.ts
@@ -1,25 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { EditorContext } from "./agents/tools/editor/context";
-import type { WorkspaceContext } from "./agents/tools/workspace/context";
-import { ReadTool } from "./agents/tools/editor/read";
-import { ReadSelectionTool } from "./agents/tools/editor/read_selection";
-import { SearchTool } from "./agents/tools/editor/search";
-import { GetMetadataTool } from "./agents/tools/editor/get_metadata";
-import { GetCurrentModeTool } from "./agents/tools/editor/get_current_mode";
-import { RequestSwitchToEditorTool } from "./agents/tools/editor/request_switch_to_editor";
-import { EditTool } from "./agents/tools/editor/edit";
-import { WriteTool } from "./agents/tools/editor/write";
-import { GetActiveDocInfoTool } from "./agents/tools/workspace/get_active_doc_info";
-import { ListWorkspaceDocsTool } from "./agents/tools/workspace/list_workspace_docs";
-import { ReadWorkspaceDocTool } from "./agents/tools/workspace/read_workspace_doc";
-import { QueryWorkspaceDocTool } from "./agents/tools/workspace/query_workspace_doc";
-import { QueryWorkspaceTool } from "./agents/tools/workspace/query_workspace";
-import { CreateDocumentTool } from "./agents/tools/workspace/create_document";
-import { RenameDocumentTool } from "./agents/tools/workspace/rename_document";
-import { DeleteDocumentTool } from "./agents/tools/workspace/delete_document";
-import { SwitchActiveDocumentTool } from "./agents/tools/workspace/switch_active_document";
+import type { ToolProvider } from "@mast-ai/core";
 
 interface WebMCPTool {
   name: string;
@@ -38,10 +20,7 @@ declare global {
   }
 }
 
-export function registerWebMCPTools(
-  editorCtx: EditorContext,
-  workspaceCtx: WorkspaceContext,
-): () => void {
+export function registerWebMCPTools(provider: ToolProvider): () => void {
   if (!navigator.modelContext) {
     console.warn("WebMCP not detected in this browser.");
     return () => {};
@@ -51,35 +30,15 @@ export function registerWebMCPTools(
   const { signal } = controller;
   const mc = navigator.modelContext;
 
-  const tools = [
-    new ReadTool(editorCtx),
-    new ReadSelectionTool(editorCtx),
-    new SearchTool(editorCtx),
-    new GetMetadataTool(editorCtx),
-    new GetCurrentModeTool(editorCtx),
-    new RequestSwitchToEditorTool(editorCtx),
-    new EditTool(editorCtx),
-    new WriteTool(editorCtx),
-    new GetActiveDocInfoTool(workspaceCtx),
-    new ListWorkspaceDocsTool(workspaceCtx),
-    new ReadWorkspaceDocTool(workspaceCtx),
-    new QueryWorkspaceDocTool(workspaceCtx),
-    new QueryWorkspaceTool(workspaceCtx),
-    new CreateDocumentTool(workspaceCtx),
-    new RenameDocumentTool(workspaceCtx),
-    new DeleteDocumentTool(workspaceCtx),
-    new SwitchActiveDocumentTool(workspaceCtx),
-  ];
-
   try {
-    for (const tool of tools) {
-      const def = tool.definition();
+    for (const def of provider.getTools()) {
+      const tool = provider.getTool(def.name)!;
       mc.registerTool(
         {
           name: def.name,
           description: def.description,
           inputSchema: def.parameters,
-          execute: (args) => tool.call(args as never, {}),
+          execute: (args) => tool.call(args as never, {}) as Promise<string>,
         },
         { signal },
       );


### PR DESCRIPTION
## Summary

- `registerWebMCPTools` now accepts a `ToolProvider` instead of `EditorContext`/`WorkspaceContext`, iterating `getTools()`/`getTool()` to register whatever is in the registry
- Removes the hardcoded duplicate tool list from `WebMCPTools.ts` (17 individual imports eliminated)
- `AgentContext` creates a `baseRegistry` via `createToolRegistry` and passes it to `registerWebMCPTools`; the agent's full registry (with delegation tools) remains a separate instance

## Test plan

- [x] All 293 existing tests pass (`npm run test`)
- [x] `npm run build` succeeds with no type errors
- [x] Adding or removing a tool from `createToolRegistry` now automatically reflects in WebMCP without touching `WebMCPTools.ts`