### PR TITLE
feat: set requiresApproval on write tools

### DIFF
--- a/src/lib/agents/tools/editor/edit.ts
+++ b/src/lib/agents/tools/editor/edit.ts
@@ -34,6 +34,7 @@ export class EditTool implements Tool<EditArgs, string> {
         required: ["originalText", "replacementText"],
       },
       scope: "write",
+      requiresApproval: true,
     };
   }
 

--- a/src/lib/agents/tools/editor/write.ts
+++ b/src/lib/agents/tools/editor/write.ts
@@ -28,6 +28,7 @@ export class WriteTool implements Tool<WriteArgs, string> {
         required: ["content"],
       },
       scope: "write",
+      requiresApproval: true,
     };
   }
 

--- a/src/lib/agents/tools/workspace/create_document.ts
+++ b/src/lib/agents/tools/workspace/create_document.ts
@@ -34,6 +34,7 @@ export class CreateDocumentTool implements Tool<CreateDocumentArgs, string> {
         required: ["title"],
       },
       scope: "write",
+      requiresApproval: true,
     };
   }
 

--- a/src/lib/agents/tools/workspace/delete_document.ts
+++ b/src/lib/agents/tools/workspace/delete_document.ts
@@ -28,6 +28,7 @@ export class DeleteDocumentTool implements Tool<DeleteDocumentArgs, string> {
         required: ["id"],
       },
       scope: "write",
+      requiresApproval: true,
     };
   }
 

--- a/src/lib/agents/tools/workspace/rename_document.ts
+++ b/src/lib/agents/tools/workspace/rename_document.ts
@@ -33,6 +33,7 @@ export class RenameDocumentTool implements Tool<RenameDocumentArgs, string> {
         required: ["id", "title"],
       },
       scope: "write",
+      requiresApproval: true,
     };
   }
 


### PR DESCRIPTION
## Summary
- Adds `requiresApproval: true` to the five tools that pause for user confirmation before executing: `edit`, `write`, `create_document`, `delete_document`, `rename_document`
- No behaviour change — this is a semantic annotation enabled by [`mast-ai/core#46`](https://github.com/andreban/mast-ai/pull/46) which added the optional `requiresApproval` field to `ToolDefinition`

## Test plan
- [x] Verify lint passes (`npm run lint`)
- [x] Verify existing tests still pass (`npm run test`)