### PR TITLE
chore: add .gitattributes and apply prettier reformat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Auto-detect text files; normalise to LF in the repo and in working trees on
+# every platform. This overrides any per-machine `core.autocrlf` setting and
+# eliminates the recurring "LF will be replaced by CRLF" phantom diffs on
+# Windows checkouts.
+* text=auto eol=lf
+
+# Windows-only scripts must keep CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary files — never touch.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.webp binary
+*.ico  binary
+*.pdf  binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary
+*.otf   binary

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,10 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
-      "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_" },
+      ],
     },
   },
 );

--- a/src/context/AgentContext.tsx
+++ b/src/context/AgentContext.tsx
@@ -155,10 +155,7 @@ export function AgentContextProvider({ children }: { children: ReactNode }) {
     [editorCtx, workspaceCtx],
   );
 
-  useEffect(
-    () => registerWebMCPTools(baseRegistry),
-    [baseRegistry],
-  );
+  useEffect(() => registerWebMCPTools(baseRegistry), [baseRegistry]);
 
   const registry = useMemo(() => {
     if (!apiKey || !factory) return null;
@@ -175,13 +172,7 @@ export function AgentContextProvider({ children }: { children: ReactNode }) {
       setPendingPlanConfirmation,
     );
     return r;
-  }, [
-    apiKey,
-    factory,
-    editorCtx,
-    workspaceCtx,
-    setPendingPlanConfirmation,
-  ]);
+  }, [apiKey, factory, editorCtx, workspaceCtx, setPendingPlanConfirmation]);
 
   const model = useMemo(
     () =>

--- a/src/lib/WebMCPTools.test.ts
+++ b/src/lib/WebMCPTools.test.ts
@@ -94,7 +94,9 @@ describe("registerWebMCPTools", () => {
       }),
     };
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const cleanup = registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
+    const cleanup = registerWebMCPTools(
+      createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()),
+    );
     expect(warnSpy).toHaveBeenCalledWith(
       "WebMCP tool registration failed:",
       expect.any(TypeError),
@@ -106,12 +108,16 @@ describe("registerWebMCPTools", () => {
   it("returns a no-op cleanup when navigator.modelContext is undefined", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (navigator as any).modelContext;
-    const cleanup = registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
+    const cleanup = registerWebMCPTools(
+      createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()),
+    );
     expect(() => cleanup()).not.toThrow();
   });
 
   it("registers all expected tools", () => {
-    registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
+    registerWebMCPTools(
+      createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()),
+    );
     const expected = [
       "read",
       "read_selection",
@@ -138,14 +144,18 @@ describe("registerWebMCPTools", () => {
   });
 
   it("passes an AbortSignal to each registered tool", () => {
-    registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
+    registerWebMCPTools(
+      createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()),
+    );
     for (const [, entry] of registeredTools) {
       expect(entry.signal).toBeInstanceOf(AbortSignal);
     }
   });
 
   it("cleanup aborts the shared signal", () => {
-    const cleanup = registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
+    const cleanup = registerWebMCPTools(
+      createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()),
+    );
     const signal = registeredTools.get("read")!.signal!;
     expect(signal.aborted).toBe(false);
     cleanup();
@@ -153,12 +163,20 @@ describe("registerWebMCPTools", () => {
   });
 
   it("read execute returns editor content", async () => {
-    registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
-    expect(await registeredTools.get("read")!.execute({})).toBe("editor content");
+    registerWebMCPTools(
+      createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()),
+    );
+    expect(await registeredTools.get("read")!.execute({})).toBe(
+      "editor content",
+    );
   });
 
   it("get_current_mode execute returns current mode", async () => {
-    registerWebMCPTools(createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()));
-    expect(await registeredTools.get("get_current_mode")!.execute({})).toBe("editor");
+    registerWebMCPTools(
+      createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()),
+    );
+    expect(await registeredTools.get("get_current_mode")!.execute({})).toBe(
+      "editor",
+    );
   });
 });

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -10,11 +10,12 @@ export { createGenericAgent } from "./roles/generic";
 export type { Plan, PlanStep } from "./roles/planner";
 export { createPlannerAgent, PLANNER_SYSTEM_PROMPT } from "./roles/planner";
 export type { ResearchResult, ResearchSource } from "./roles/researcher";
+export { DOC_QUERIER_SYSTEM_PROMPT, runResearch } from "./roles/researcher";
 export {
-  DOC_QUERIER_SYSTEM_PROMPT,
-  runResearch,
-} from "./roles/researcher";
-export { createWriterAgent, WRITER_SYSTEM_PROMPT, runWriter } from "./roles/writer";
+  createWriterAgent,
+  WRITER_SYSTEM_PROMPT,
+  runWriter,
+} from "./roles/writer";
 export type { ReviewResult, ReviewIssue } from "./roles/reviewer";
 export {
   createReviewerAgent,

--- a/src/lib/agents/tools/delegation/delegate_to_skill.test.ts
+++ b/src/lib/agents/tools/delegation/delegate_to_skill.test.ts
@@ -38,7 +38,9 @@ describe("DelegateToSkillTool", () => {
     };
     mockRunStream = vi.fn().mockReturnValue(makeMockStream("done"));
     mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
-    mockFactory = { create: vi.fn().mockReturnValue({ runBuilder: mockRunBuilder }) };
+    mockFactory = {
+      create: vi.fn().mockReturnValue({ runBuilder: mockRunBuilder }),
+    };
 
     editorCtx = {
       editorRef: { current: mockEditor },
@@ -74,21 +76,39 @@ describe("DelegateToSkillTool", () => {
   }
 
   it("returns error string when skill name is not found", async () => {
-    saveSkills([{ id: "1", name: "Other", description: "d", instructions: "i" }]);
-    const result = await makeTool().call({ skillName: "Missing", task: "do it" }, {});
+    saveSkills([
+      { id: "1", name: "Other", description: "d", instructions: "i" },
+    ]);
+    const result = await makeTool().call(
+      { skillName: "Missing", task: "do it" },
+      {},
+    );
     expect(result).toContain('skill "Missing" not found');
     expect(result).toContain("Other");
   });
 
   it("returns error listing 'none' when no skills exist", async () => {
-    const result = await makeTool().call({ skillName: "Any", task: "do it" }, {});
+    const result = await makeTool().call(
+      { skillName: "Any", task: "do it" },
+      {},
+    );
     expect(result).toContain("none");
   });
 
   it("calls runBuilder with skill instructions and returns raw output", async () => {
     mockRunStream.mockReturnValue(makeMockStream("Proofreading complete."));
-    saveSkills([{ id: "1", name: "Proofreader", description: "d", instructions: "Check it" }]);
-    const result = await makeTool().call({ skillName: "Proofreader", task: "check spelling" }, {});
+    saveSkills([
+      {
+        id: "1",
+        name: "Proofreader",
+        description: "d",
+        instructions: "Check it",
+      },
+    ]);
+    const result = await makeTool().call(
+      { skillName: "Proofreader", task: "check spelling" },
+      {},
+    );
     expect(mockRunBuilder).toHaveBeenCalledOnce();
     const [agentConfig] = mockRunBuilder.mock.calls[0];
     expect(agentConfig.instructions).toBe("Check it");
@@ -96,31 +116,52 @@ describe("DelegateToSkillTool", () => {
   });
 
   it("does not include delegate_to_skill in child agent tool list", async () => {
-    saveSkills([{ id: "1", name: "Proofreader", description: "d", instructions: "i" }]);
+    saveSkills([
+      { id: "1", name: "Proofreader", description: "d", instructions: "i" },
+    ]);
     await makeTool().call({ skillName: "Proofreader", task: "t" }, {});
     const [agentConfig] = mockRunBuilder.mock.calls[0];
     expect(agentConfig.tools).not.toContain("delegate_to_skill");
   });
 
   it("does not call factory.create when a custom runnerFactory override is used", async () => {
-    saveSkills([{ id: "1", name: "Proofreader", description: "d", instructions: "i" }]);
+    saveSkills([
+      { id: "1", name: "Proofreader", description: "d", instructions: "i" },
+    ]);
     await makeTool().call({ skillName: "Proofreader", task: "t" }, {});
     expect(mockRunBuilder).toHaveBeenCalledOnce();
   });
 
   it("forwards non-done child events via context.onEvent", async () => {
-    mockRunStream.mockReturnValue(makeMockStream("done", [{ type: "text_delta", delta: "hello" }, { type: "thinking", delta: "hmm" }]));
-    saveSkills([{ id: "1", name: "Proofreader", description: "d", instructions: "i" }]);
+    mockRunStream.mockReturnValue(
+      makeMockStream("done", [
+        { type: "text_delta", delta: "hello" },
+        { type: "thinking", delta: "hmm" },
+      ]),
+    );
+    saveSkills([
+      { id: "1", name: "Proofreader", description: "d", instructions: "i" },
+    ]);
     const onEvent = vi.fn();
     await makeTool().call({ skillName: "Proofreader", task: "t" }, { onEvent });
-    expect(onEvent).toHaveBeenCalledWith({ type: "text_delta", delta: "hello" });
+    expect(onEvent).toHaveBeenCalledWith({
+      type: "text_delta",
+      delta: "hello",
+    });
     expect(onEvent).toHaveBeenCalledWith({ type: "thinking", delta: "hmm" });
-    expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ type: "done" }));
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "done" }),
+    );
   });
 
   it("gives skill read-only workspace tools (no create_document, switch_active_document)", async () => {
-    saveSkills([{ id: "1", name: "Research Skill", description: "d", instructions: "i" }]);
-    await makeTool().call({ skillName: "Research Skill", task: "check docs" }, {});
+    saveSkills([
+      { id: "1", name: "Research Skill", description: "d", instructions: "i" },
+    ]);
+    await makeTool().call(
+      { skillName: "Research Skill", task: "check docs" },
+      {},
+    );
     const [agentConfig] = mockRunBuilder.mock.calls[0];
     expect(agentConfig.tools).toContain("list_workspace_docs");
     expect(agentConfig.tools).toContain("read_workspace_doc");
@@ -129,19 +170,34 @@ describe("DelegateToSkillTool", () => {
   });
 
   it("passes model to runnerFactory when skill specifies a model", async () => {
-    saveSkills([{ id: "1", name: "Proofreader", description: "d", instructions: "i", model: "gemini-2.5-pro" }]);
-    const customRunnerFactory = vi.fn().mockReturnValue({ runBuilder: mockRunBuilder });
+    saveSkills([
+      {
+        id: "1",
+        name: "Proofreader",
+        description: "d",
+        instructions: "i",
+        model: "gemini-2.5-pro",
+      },
+    ]);
+    const customRunnerFactory = vi
+      .fn()
+      .mockReturnValue({ runBuilder: mockRunBuilder });
     const tool = new DelegateToSkillTool(
       mockFactory,
       createToolRegistry(editorCtx, workspaceCtx).readOnly(),
       customRunnerFactory,
     );
     await tool.call({ skillName: "Proofreader", task: "t" }, {});
-    expect(customRunnerFactory).toHaveBeenCalledWith(expect.anything(), "gemini-2.5-pro");
+    expect(customRunnerFactory).toHaveBeenCalledWith(
+      expect.anything(),
+      "gemini-2.5-pro",
+    );
   });
 
   it("gives skill a read-only registry (no edit, no write tool registered)", async () => {
-    saveSkills([{ id: "1", name: "Proofreader", description: "d", instructions: "i" }]);
+    saveSkills([
+      { id: "1", name: "Proofreader", description: "d", instructions: "i" },
+    ]);
     await makeTool().call({ skillName: "Proofreader", task: "t" }, {});
     const [agentConfig] = mockRunBuilder.mock.calls[0];
     expect(agentConfig.tools).not.toContain("edit");

--- a/src/lib/agents/tools/delegation/delegate_to_skill.ts
+++ b/src/lib/agents/tools/delegation/delegate_to_skill.ts
@@ -1,7 +1,14 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AgentConfig, AgentEvent, Tool, ToolContext, ToolDefinition, ToolProvider } from "@mast-ai/core";
+import type {
+  AgentConfig,
+  AgentEvent,
+  Tool,
+  ToolContext,
+  ToolDefinition,
+  ToolProvider,
+} from "@mast-ai/core";
 import type { AgentRunnerFactory } from "../../";
 import { loadSkills } from "../../../skills";
 
@@ -25,7 +32,8 @@ export class DelegateToSkillTool implements Tool<DelegateToSkillArgs, string> {
     runnerFactory?: (registry: ToolProvider, model?: string) => RunnerLike,
   ) {
     this.runnerFactory =
-      runnerFactory ?? ((registry, model) => factory.create({ tools: registry, model }));
+      runnerFactory ??
+      ((registry, model) => factory.create({ tools: registry, model }));
   }
 
   definition(): ToolDefinition {
@@ -42,7 +50,8 @@ export class DelegateToSkillTool implements Tool<DelegateToSkillArgs, string> {
           },
           task: {
             type: "string",
-            description: "The specific task or instructions to pass to the skill.",
+            description:
+              "The specific task or instructions to pass to the skill.",
           },
         },
         required: ["skillName", "task"],
@@ -62,7 +71,9 @@ export class DelegateToSkillTool implements Tool<DelegateToSkillArgs, string> {
       return `Error: skill "${skillName}" not found. Available skills: ${names || "none"}`;
     }
 
-    const readonlyToolNames = this.readonlyRegistry.getTools().map((d) => d.name);
+    const readonlyToolNames = this.readonlyRegistry
+      .getTools()
+      .map((d) => d.name);
     const childRunner = this.runnerFactory(this.readonlyRegistry, skill.model);
     const agentConfig: AgentConfig = {
       name: skill.name,
@@ -70,7 +81,9 @@ export class DelegateToSkillTool implements Tool<DelegateToSkillArgs, string> {
       tools: readonlyToolNames,
     };
 
-    for await (const event of childRunner.runBuilder(agentConfig).runStream(task)) {
+    for await (const event of childRunner
+      .runBuilder(agentConfig)
+      .runStream(task)) {
       if (event.type === "done") {
         return event.output;
       }

--- a/src/lib/agents/tools/delegation/delegation.test.ts
+++ b/src/lib/agents/tools/delegation/delegation.test.ts
@@ -42,9 +42,22 @@ async function callTool(
   return tool.call(args, context);
 }
 
-function makeContexts(factory: AgentRunnerFactory, docs: { id: string; title: string; content: string; updatedAt: number }[] = []) {
+function makeContexts(
+  factory: AgentRunnerFactory,
+  docs: {
+    id: string;
+    title: string;
+    content: string;
+    updatedAt: number;
+  }[] = [],
+) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mockEditor: any = { getValue: vi.fn().mockReturnValue(""), setValue: vi.fn(), getModel: vi.fn().mockReturnValue(null), getSelection: vi.fn().mockReturnValue(null) };
+  const mockEditor: any = {
+    getValue: vi.fn().mockReturnValue(""),
+    setValue: vi.fn(),
+    getModel: vi.fn().mockReturnValue(null),
+    getSelection: vi.fn().mockReturnValue(null),
+  };
   const editorCtx: EditorContext = {
     editorRef: { current: mockEditor },
     editorContentRef: { current: "" },
@@ -81,10 +94,21 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory, mockCreate } = makeFactory(mockRunStream);
     const { editorCtx, workspaceCtx } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(editorCtx, workspaceCtx).readOnly(), workspaceCtx.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(editorCtx, workspaceCtx).readOnly(),
+      workspaceCtx.docsRef,
+      vi.fn(),
+    );
 
-    await callTool(registry, "invoke_agent", { systemPrompt: "Be brief.", task: "Summarize AI." });
-    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ systemPrompt: "Be brief." }));
+    await callTool(registry, "invoke_agent", {
+      systemPrompt: "Be brief.",
+      task: "Summarize AI.",
+    });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ systemPrompt: "Be brief." }),
+    );
   });
 
   it("returns { result } with the sub-agent output", async () => {
@@ -92,34 +116,74 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
-    const raw = await callTool(registry, "invoke_agent", { systemPrompt: "Help.", task: "Summarize." });
+    const raw = await callTool(registry, "invoke_agent", {
+      systemPrompt: "Help.",
+      task: "Summarize.",
+    });
     expect(JSON.parse(raw as string)).toEqual({ result: "Great summary." });
   });
 
   it("relays non-done child events via context.onEvent", async () => {
-    mockRunStream.mockReturnValue(makeMockStream("done", [{ type: "text_delta", delta: "hello" }, { type: "thinking", delta: "hmm" }]));
+    mockRunStream.mockReturnValue(
+      makeMockStream("done", [
+        { type: "text_delta", delta: "hello" },
+        { type: "thinking", delta: "hmm" },
+      ]),
+    );
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
     const onEvent = vi.fn();
-    await callTool(registry, "invoke_agent", { systemPrompt: "s", task: "t" }, { onEvent });
+    await callTool(
+      registry,
+      "invoke_agent",
+      { systemPrompt: "s", task: "t" },
+      { onEvent },
+    );
 
-    expect(onEvent).toHaveBeenCalledWith({ type: "text_delta", delta: "hello" });
+    expect(onEvent).toHaveBeenCalledWith({
+      type: "text_delta",
+      delta: "hello",
+    });
     expect(onEvent).toHaveBeenCalledWith({ type: "thinking", delta: "hmm" });
-    expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ type: "done" }));
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "done" }),
+    );
   });
 
   it("uses empty tools list when no tool groups are requested", async () => {
     const { factory, mockRunBuilder } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
-    await callTool(registry, "invoke_agent", { systemPrompt: "s", task: "t", tools: [] });
+    await callTool(registry, "invoke_agent", {
+      systemPrompt: "s",
+      task: "t",
+      tools: [],
+    });
     const [agentConfig] = mockRunBuilder.mock.calls[0];
     expect(agentConfig.tools).toEqual([]);
   });
@@ -128,7 +192,13 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
     const tool = registry.getTool("invoke_agent");
     expect(tool).toBeDefined();
@@ -139,9 +209,19 @@ describe("registerDelegationTools / invoke_agent", () => {
     const { factory, mockRunBuilder } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
-    await callTool(registry, "invoke_agent", { systemPrompt: "s", task: "t", tools: ["workspace_readonly"] });
+    await callTool(registry, "invoke_agent", {
+      systemPrompt: "s",
+      task: "t",
+      tools: ["workspace_readonly"],
+    });
 
     const [agentConfig] = mockRunBuilder.mock.calls[0];
     expect(agentConfig.tools).toContain("list_workspace_docs");
@@ -157,9 +237,11 @@ describe("registerDelegationTools / invoke_planner", () => {
   let autoConfirm: Mock<(req: PlanConfirmationRequest | null) => void>;
 
   beforeEach(() => {
-    autoConfirm = vi.fn<(req: PlanConfirmationRequest | null) => void>().mockImplementation((req) => {
-      if (req) req.resolve(true);
-    });
+    autoConfirm = vi
+      .fn<(req: PlanConfirmationRequest | null) => void>()
+      .mockImplementation((req) => {
+        if (req) req.resolve(true);
+      });
   });
 
   const validPlan = {
@@ -172,7 +254,13 @@ describe("registerDelegationTools / invoke_planner", () => {
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
     const tool = registry.getTool("invoke_planner");
     expect(tool).toBeDefined();
@@ -180,13 +268,23 @@ describe("registerDelegationTools / invoke_planner", () => {
   });
 
   it("returns a JSON string that parses to a Plan with goal and steps", async () => {
-    const mockRunStream = vi.fn().mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, autoConfirm);
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      autoConfirm,
+    );
 
-    const raw = await callTool(registry, "invoke_planner", { task: "Write a blog post about AI" });
+    const raw = await callTool(registry, "invoke_planner", {
+      task: "Write a blog post about AI",
+    });
     const parsed = JSON.parse(raw as string);
     expect(parsed.goal).toBe("Write a blog post");
     expect(Array.isArray(parsed.steps)).toBe(true);
@@ -194,78 +292,153 @@ describe("registerDelegationTools / invoke_planner", () => {
   });
 
   it("appends context to the task prompt when context is provided", async () => {
-    const mockRunStream = vi.fn().mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, autoConfirm);
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      autoConfirm,
+    );
 
-    await callTool(registry, "invoke_planner", { task: "Write a blog post", context: "Style: formal" });
-    expect(mockRunStream).toHaveBeenCalledWith("Write a blog post\n\nStyle: formal");
+    await callTool(registry, "invoke_planner", {
+      task: "Write a blog post",
+      context: "Style: formal",
+    });
+    expect(mockRunStream).toHaveBeenCalledWith(
+      "Write a blog post\n\nStyle: formal",
+    );
   });
 
   it("throws when agent output is not valid JSON", async () => {
-    const mockRunStream = vi.fn().mockReturnValue(makeMockStream("not json at all"));
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream("not json at all"));
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
-    await expect(callTool(registry, "invoke_planner", { task: "t" })).rejects.toThrow("invalid JSON");
+    await expect(
+      callTool(registry, "invoke_planner", { task: "t" }),
+    ).rejects.toThrow("invalid JSON");
   });
 
   it("throws when parsed JSON is missing required Plan fields", async () => {
-    const mockRunStream = vi.fn().mockReturnValue(makeMockStream(JSON.stringify({ steps: [] })));
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify({ steps: [] })));
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
-    await expect(callTool(registry, "invoke_planner", { task: "t" })).rejects.toThrow("missing required fields");
+    await expect(
+      callTool(registry, "invoke_planner", { task: "t" }),
+    ).rejects.toThrow("missing required fields");
   });
 
   it("calls setPendingPlanConfirmation with the plan before awaiting", async () => {
-    const mockRunStream = vi.fn().mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, autoConfirm);
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      autoConfirm,
+    );
 
     await callTool(registry, "invoke_planner", { task: "Write a blog post" });
-    expect(autoConfirm).toHaveBeenCalledWith(expect.objectContaining({ plan: validPlan }));
+    expect(autoConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: validPlan }),
+    );
   });
 
   it("clears pendingPlanConfirmation with null after resolution", async () => {
-    const mockRunStream = vi.fn().mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, autoConfirm);
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      autoConfirm,
+    );
 
     await callTool(registry, "invoke_planner", { task: "t" });
     expect(autoConfirm).toHaveBeenCalledWith(null);
   });
 
   it("throws 'Plan rejected by user.' when confirmation resolves with false", async () => {
-    const rejectConfirm = vi.fn().mockImplementation((req) => { if (req) req.resolve(false); });
-    const mockRunStream = vi.fn().mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const rejectConfirm = vi.fn().mockImplementation((req) => {
+      if (req) req.resolve(false);
+    });
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, rejectConfirm);
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      rejectConfirm,
+    );
 
-    await expect(callTool(registry, "invoke_planner", { task: "t" })).rejects.toThrow("Plan rejected by user.");
+    await expect(
+      callTool(registry, "invoke_planner", { task: "t" }),
+    ).rejects.toThrow("Plan rejected by user.");
   });
 
   it("clears pendingPlanConfirmation with null even when rejected", async () => {
-    const rejectConfirm = vi.fn().mockImplementation((req) => { if (req) req.resolve(false); });
-    const mockRunStream = vi.fn().mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
+    const rejectConfirm = vi.fn().mockImplementation((req) => {
+      if (req) req.resolve(false);
+    });
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValue(makeMockStream(JSON.stringify(validPlan)));
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, rejectConfirm);
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      rejectConfirm,
+    );
 
-    await expect(callTool(registry, "invoke_planner", { task: "t" })).rejects.toThrow();
+    await expect(
+      callTool(registry, "invoke_planner", { task: "t" }),
+    ).rejects.toThrow();
     expect(rejectConfirm).toHaveBeenCalledWith(null);
   });
 });
@@ -281,7 +454,13 @@ describe("registerDelegationTools / invoke_researcher", () => {
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory, docs);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
     const tool = registry.getTool("invoke_researcher");
     expect(tool).toBeDefined();
@@ -289,17 +468,32 @@ describe("registerDelegationTools / invoke_researcher", () => {
   });
 
   it("returns ResearchResult with summary string and sources array for two docs", async () => {
-    const mockRunStream = vi.fn()
-      .mockReturnValueOnce(makeMockStream('{"summary":"Alpha summary.","excerpt":"alpha passage"}'))
-      .mockReturnValueOnce(makeMockStream('{"summary":"Beta summary.","excerpt":"beta passage"}'))
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeMockStream(
+          '{"summary":"Alpha summary.","excerpt":"alpha passage"}',
+        ),
+      )
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"Beta summary.","excerpt":"beta passage"}'),
+      )
       .mockReturnValueOnce(makeMockStream('{"summary":"Combined answer."}'));
 
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory, docs);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
-    const raw = await callTool(registry, "invoke_researcher", { query: "What do the docs say?" });
+    const raw = await callTool(registry, "invoke_researcher", {
+      query: "What do the docs say?",
+    });
     const result = JSON.parse(raw as string);
 
     expect(typeof result.summary).toBe("string");
@@ -309,15 +503,28 @@ describe("registerDelegationTools / invoke_researcher", () => {
   });
 
   it("each source has id, title, and excerpt fields", async () => {
-    const mockRunStream = vi.fn()
-      .mockReturnValueOnce(makeMockStream('{"summary":"Alpha summary.","excerpt":"alpha excerpt"}'))
-      .mockReturnValueOnce(makeMockStream('{"summary":"Beta summary.","excerpt":"beta excerpt"}'))
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeMockStream(
+          '{"summary":"Alpha summary.","excerpt":"alpha excerpt"}',
+        ),
+      )
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"Beta summary.","excerpt":"beta excerpt"}'),
+      )
       .mockReturnValueOnce(makeMockStream('{"summary":"Combined."}'));
 
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory, docs);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
     const raw = await callTool(registry, "invoke_researcher", { query: "q" });
     const result = JSON.parse(raw as string);
@@ -327,21 +534,41 @@ describe("registerDelegationTools / invoke_researcher", () => {
       expect(typeof source.title).toBe("string");
       expect(typeof source.excerpt).toBe("string");
     }
-    expect(result.sources[0]).toMatchObject({ id: "doc1", title: "Doc One", excerpt: "alpha excerpt" });
-    expect(result.sources[1]).toMatchObject({ id: "doc2", title: "Doc Two", excerpt: "beta excerpt" });
+    expect(result.sources[0]).toMatchObject({
+      id: "doc1",
+      title: "Doc One",
+      excerpt: "alpha excerpt",
+    });
+    expect(result.sources[1]).toMatchObject({
+      id: "doc2",
+      title: "Doc Two",
+      excerpt: "beta excerpt",
+    });
   });
 
   it("filters to only docIds when provided", async () => {
-    const mockRunStream = vi.fn()
-      .mockReturnValueOnce(makeMockStream('{"summary":"Doc Two only.","excerpt":"beta"}'))
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"Doc Two only.","excerpt":"beta"}'),
+      )
       .mockReturnValueOnce(makeMockStream('{"summary":"Only doc two."}'));
 
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory, docs);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
-    const raw = await callTool(registry, "invoke_researcher", { query: "q", docIds: ["doc2"] });
+    const raw = await callTool(registry, "invoke_researcher", {
+      query: "q",
+      docIds: ["doc2"],
+    });
     const result = JSON.parse(raw as string);
 
     expect(result.sources).toHaveLength(1);
@@ -350,14 +577,25 @@ describe("registerDelegationTools / invoke_researcher", () => {
   });
 
   it("returns empty sources and no-content summary when no docs have relevant content", async () => {
-    const mockRunStream = vi.fn()
-      .mockReturnValueOnce(makeMockStream('{"summary":"No relevant content.","excerpt":""}'))
-      .mockReturnValueOnce(makeMockStream('{"summary":"No relevant content.","excerpt":""}'));
+    const mockRunStream = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"No relevant content.","excerpt":""}'),
+      )
+      .mockReturnValueOnce(
+        makeMockStream('{"summary":"No relevant content.","excerpt":""}'),
+      );
 
     const { factory } = makeFactory(mockRunStream);
     const { editorCtx: et, workspaceCtx: wt } = makeContexts(factory, docs);
     const registry = new ToolRegistry();
-    registerDelegationTools(registry, factory, createToolRegistry(et, wt).readOnly(), wt.docsRef, vi.fn());
+    registerDelegationTools(
+      registry,
+      factory,
+      createToolRegistry(et, wt).readOnly(),
+      wt.docsRef,
+      vi.fn(),
+    );
 
     const raw = await callTool(registry, "invoke_researcher", { query: "q" });
     const result = JSON.parse(raw as string);

--- a/src/lib/agents/tools/delegation/invoke_agent.ts
+++ b/src/lib/agents/tools/delegation/invoke_agent.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ToolRegistry } from "@mast-ai/core";
-import type { AgentConfig, Tool, ToolContext, ToolDefinition, ToolProvider } from "@mast-ai/core";
+import type {
+  AgentConfig,
+  Tool,
+  ToolContext,
+  ToolDefinition,
+  ToolProvider,
+} from "@mast-ai/core";
 import type { AgentRunnerFactory } from "../../";
 import { createGenericAgent } from "../../";
 
@@ -53,14 +59,20 @@ export class InvokeAgentTool implements Tool<InvokeAgentArgs, string> {
       ? this.readonlyRegistry
       : new ToolRegistry();
 
-    const runner = createGenericAgent(this.factory, args.systemPrompt, resolvedRegistry);
+    const runner = createGenericAgent(
+      this.factory,
+      args.systemPrompt,
+      resolvedRegistry,
+    );
     const agentConfig: AgentConfig = {
       name: "Agent",
       instructions: args.systemPrompt,
       tools: resolvedRegistry.getTools().map((d) => d.name),
     };
 
-    for await (const event of runner.runBuilder(agentConfig).runStream(args.task)) {
+    for await (const event of runner
+      .runBuilder(agentConfig)
+      .runStream(args.task)) {
       if (event.type === "done") {
         return JSON.stringify({ result: event.output });
       }

--- a/src/lib/agents/tools/delegation/invoke_planner.ts
+++ b/src/lib/agents/tools/delegation/invoke_planner.ts
@@ -14,7 +14,9 @@ interface InvokePlannerArgs {
 export class InvokePlannerTool implements Tool<InvokePlannerArgs, string> {
   constructor(
     private factory: AgentRunnerFactory,
-    private setPendingPlanConfirmation: (req: PlanConfirmationRequest | null) => void,
+    private setPendingPlanConfirmation: (
+      req: PlanConfirmationRequest | null,
+    ) => void,
   ) {}
 
   definition(): ToolDefinition {
@@ -50,7 +52,9 @@ export class InvokePlannerTool implements Tool<InvokePlannerArgs, string> {
       tools: [],
     };
 
-    for await (const event of runner.runBuilder(agentConfig).runStream(prompt)) {
+    for await (const event of runner
+      .runBuilder(agentConfig)
+      .runStream(prompt)) {
       if (event.type === "done") {
         let plan: Plan;
         try {

--- a/src/lib/agents/tools/delegation/invoke_researcher.ts
+++ b/src/lib/agents/tools/delegation/invoke_researcher.ts
@@ -11,7 +11,10 @@ interface InvokeResearcherArgs {
   docIds?: string[];
 }
 
-export class InvokeResearcherTool implements Tool<InvokeResearcherArgs, string> {
+export class InvokeResearcherTool implements Tool<
+  InvokeResearcherArgs,
+  string
+> {
   constructor(
     private factory: AgentRunnerFactory,
     private docsRef: { current: WorkspaceDocument[] },
@@ -43,7 +46,12 @@ export class InvokeResearcherTool implements Tool<InvokeResearcherArgs, string> 
   }
 
   async call(args: InvokeResearcherArgs): Promise<string> {
-    const result = await runResearch(args.query, this.docsRef.current, this.factory, args.docIds);
+    const result = await runResearch(
+      args.query,
+      this.docsRef.current,
+      this.factory,
+      args.docIds,
+    );
     return JSON.stringify(result);
   }
 }

--- a/src/lib/agents/tools/editor/edit.ts
+++ b/src/lib/agents/tools/editor/edit.ts
@@ -47,12 +47,20 @@ export class EditTool implements Tool<EditArgs, string> {
     const fullText = editor.getValue();
     if (
       args.originalText.length > 3000 ||
-      (fullText.length > 200 && args.originalText.length > fullText.length * 0.8)
+      (fullText.length > 200 &&
+        args.originalText.length > fullText.length * 0.8)
     ) {
       return "Error: `originalText` is too large. The `edit()` tool is for targeted changes. If you must rewrite the entire document, use `write()`. Otherwise, provide a smaller snippet of text to replace.";
     }
 
-    const matches = model.findMatches(args.originalText, true, false, true, null, false);
+    const matches = model.findMatches(
+      args.originalText,
+      true,
+      false,
+      true,
+      null,
+      false,
+    );
     if (matches.length === 0) {
       return `Error: Could not find the text "${args.originalText}" in the document.`;
     }
@@ -69,7 +77,12 @@ export class EditTool implements Tool<EditArgs, string> {
           endColumn: range.endColumn,
         },
       },
-      () => model.pushEditOperations([], [{ range, text: args.replacementText }], () => null),
+      () =>
+        model.pushEditOperations(
+          [],
+          [{ range, text: args.replacementText }],
+          () => null,
+        ),
       "Change applied automatically (Approve All is ON).",
       this.ctx.setSuggestions,
       this.ctx.approveAllRef,

--- a/src/lib/agents/tools/editor/editor.test.ts
+++ b/src/lib/agents/tools/editor/editor.test.ts
@@ -247,14 +247,12 @@ describe("EditTool", () => {
     mockModel = {
       findMatches: vi.fn(),
       pushEditOperations: vi.fn(),
-      getFullModelRange: vi
-        .fn()
-        .mockReturnValue({
-          startLineNumber: 1,
-          startColumn: 1,
-          endLineNumber: 10,
-          endColumn: 10,
-        }),
+      getFullModelRange: vi.fn().mockReturnValue({
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 10,
+        endColumn: 10,
+      }),
     };
     mockEditor = {
       getValue: vi.fn().mockReturnValue("Initial content"),
@@ -340,14 +338,12 @@ describe("WriteTool", () => {
 
   beforeEach(() => {
     mockModel = {
-      getFullModelRange: vi
-        .fn()
-        .mockReturnValue({
-          startLineNumber: 1,
-          startColumn: 1,
-          endLineNumber: 10,
-          endColumn: 10,
-        }),
+      getFullModelRange: vi.fn().mockReturnValue({
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 10,
+        endColumn: 10,
+      }),
     };
     mockEditor = {
       getValue: vi.fn().mockReturnValue("Initial content"),

--- a/src/lib/agents/tools/editor/editor.test.ts
+++ b/src/lib/agents/tools/editor/editor.test.ts
@@ -12,9 +12,12 @@ import { EditTool } from "./edit";
 import { WriteTool } from "./write";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeCtx(overrides: Partial<EditorContext> = {}, mockEditor?: any): EditorContext {
+function makeCtx(
+  overrides: Partial<EditorContext> = {},
+  mockEditor?: any,
+): EditorContext {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const editor = mockEditor ?? null as any;
+  const editor = mockEditor ?? (null as any);
   return {
     editorRef: { current: editor },
     editorContentRef: { current: "" },
@@ -35,7 +38,9 @@ describe("ReadTool", () => {
   });
 
   it("returns editor content", async () => {
-    expect(await new ReadTool(makeCtx({}, mockEditor)).call({}, {})).toBe("Initial content");
+    expect(await new ReadTool(makeCtx({}, mockEditor)).call({}, {})).toBe(
+      "Initial content",
+    );
   });
 
   it("returns empty string if editor not initialized and no fallback", async () => {
@@ -49,12 +54,18 @@ describe("ReadTool", () => {
 
   it("falls back to editorContentRef when editor returns empty string", async () => {
     mockEditor.getValue.mockReturnValue("");
-    const ctx = makeCtx({ editorContentRef: { current: "fallback content" } }, mockEditor);
+    const ctx = makeCtx(
+      { editorContentRef: { current: "fallback content" } },
+      mockEditor,
+    );
     expect(await new ReadTool(ctx).call({}, {})).toBe("fallback content");
   });
 
   it("prefers editor content over fallback when editor has content", async () => {
-    const ctx = makeCtx({ editorContentRef: { current: "fallback content" } }, mockEditor);
+    const ctx = makeCtx(
+      { editorContentRef: { current: "fallback content" } },
+      mockEditor,
+    );
     expect(await new ReadTool(ctx).call({}, {})).toBe("Initial content");
   });
 });
@@ -72,7 +83,9 @@ describe("GetCurrentModeTool", () => {
 
 describe("RequestSwitchToEditorTool", () => {
   it("returns already-in-editor message when in editor mode", async () => {
-    expect(await new RequestSwitchToEditorTool(makeCtx()).call({}, {})).toBe("Already in editor mode.");
+    expect(await new RequestSwitchToEditorTool(makeCtx()).call({}, {})).toBe(
+      "Already in editor mode.",
+    );
   });
 
   it("returns success message when user accepts switch", async () => {
@@ -80,7 +93,9 @@ describe("RequestSwitchToEditorTool", () => {
       activeTabRef: { current: "preview" },
       requestTabSwitch: vi.fn().mockResolvedValue(true),
     });
-    expect(await new RequestSwitchToEditorTool(ctx).call({}, {})).toBe("Switched to editor mode.");
+    expect(await new RequestSwitchToEditorTool(ctx).call({}, {})).toBe(
+      "Switched to editor mode.",
+    );
   });
 
   it("returns declined message when user rejects switch", async () => {
@@ -88,7 +103,9 @@ describe("RequestSwitchToEditorTool", () => {
       activeTabRef: { current: "preview" },
       requestTabSwitch: vi.fn().mockResolvedValue(false),
     });
-    expect(await new RequestSwitchToEditorTool(ctx).call({}, {})).toBe("User declined to switch to editor mode.");
+    expect(await new RequestSwitchToEditorTool(ctx).call({}, {})).toBe(
+      "User declined to switch to editor mode.",
+    );
   });
 });
 
@@ -104,21 +121,31 @@ describe("SearchTool", () => {
   });
 
   it("returns error if editor not initialized", async () => {
-    expect(await new SearchTool(makeCtx()).call({ query: "hello" }, {})).toBe("Error: Editor not initialized.");
+    expect(await new SearchTool(makeCtx()).call({ query: "hello" }, {})).toBe(
+      "Error: Editor not initialized.",
+    );
   });
 
   it("returns error for empty query", async () => {
-    expect(await new SearchTool(makeCtx({}, mockEditor)).call({ query: "" }, {})).toBe("Error: query parameter is required.");
+    expect(
+      await new SearchTool(makeCtx({}, mockEditor)).call({ query: "" }, {}),
+    ).toBe("Error: query parameter is required.");
   });
 
   it("returns not-found message when no matches", async () => {
     mockModel.findMatches.mockReturnValue([]);
-    expect(await new SearchTool(makeCtx({}, mockEditor)).call({ query: "xyz" }, {})).toBe('No occurrences of "xyz" found.');
+    expect(
+      await new SearchTool(makeCtx({}, mockEditor)).call({ query: "xyz" }, {}),
+    ).toBe('No occurrences of "xyz" found.');
   });
 
   it("returns location of a single match", async () => {
-    mockModel.findMatches.mockReturnValue([{ range: { startLineNumber: 3, startColumn: 5 } }]);
-    expect(await new SearchTool(makeCtx({}, mockEditor)).call({ query: "foo" }, {})).toBe('Found 1 occurrence(s) of "foo": line 3, col 5.');
+    mockModel.findMatches.mockReturnValue([
+      { range: { startLineNumber: 3, startColumn: 5 } },
+    ]);
+    expect(
+      await new SearchTool(makeCtx({}, mockEditor)).call({ query: "foo" }, {}),
+    ).toBe('Found 1 occurrence(s) of "foo": line 3, col 5.');
   });
 
   it("returns locations of multiple matches", async () => {
@@ -126,7 +153,9 @@ describe("SearchTool", () => {
       { range: { startLineNumber: 1, startColumn: 1 } },
       { range: { startLineNumber: 5, startColumn: 10 } },
     ]);
-    expect(await new SearchTool(makeCtx({}, mockEditor)).call({ query: "foo" }, {})).toBe('Found 2 occurrence(s) of "foo": line 1, col 1; line 5, col 10.');
+    expect(
+      await new SearchTool(makeCtx({}, mockEditor)).call({ query: "foo" }, {}),
+    ).toBe('Found 2 occurrence(s) of "foo": line 1, col 1; line 5, col 10.');
   });
 });
 
@@ -149,14 +178,23 @@ describe("ReadSelectionTool", () => {
   });
 
   it("returns empty string when selection is null", async () => {
-    expect(await new ReadSelectionTool(makeCtx({}, mockEditor)).call({}, {})).toBe("");
+    expect(
+      await new ReadSelectionTool(makeCtx({}, mockEditor)).call({}, {}),
+    ).toBe("");
   });
 
   it("returns the selected text", async () => {
-    const selection = { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 6 };
+    const selection = {
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: 1,
+      endColumn: 6,
+    };
     mockEditor.getSelection.mockReturnValue(selection);
     mockModel.getValueInRange.mockReturnValue("hello");
-    expect(await new ReadSelectionTool(makeCtx({}, mockEditor)).call({}, {})).toBe("hello");
+    expect(
+      await new ReadSelectionTool(makeCtx({}, mockEditor)).call({}, {}),
+    ).toBe("hello");
     expect(mockModel.getValueInRange).toHaveBeenCalledWith(selection);
   });
 });
@@ -170,22 +208,30 @@ describe("GetMetadataTool", () => {
   });
 
   it("returns error if editor not initialized", async () => {
-    expect(await new GetMetadataTool(makeCtx()).call({}, {})).toBe("Error: Editor not initialized.");
+    expect(await new GetMetadataTool(makeCtx()).call({}, {})).toBe(
+      "Error: Editor not initialized.",
+    );
   });
 
   it("returns zero counts for empty document", async () => {
     mockEditor.getValue.mockReturnValue("");
-    expect(await new GetMetadataTool(makeCtx({}, mockEditor)).call({}, {})).toBe("Characters: 0, Words: 0, Lines: 0.");
+    expect(
+      await new GetMetadataTool(makeCtx({}, mockEditor)).call({}, {}),
+    ).toBe("Characters: 0, Words: 0, Lines: 0.");
   });
 
   it("returns correct counts for single-line document", async () => {
     mockEditor.getValue.mockReturnValue("hello world");
-    expect(await new GetMetadataTool(makeCtx({}, mockEditor)).call({}, {})).toBe("Characters: 11, Words: 2, Lines: 1.");
+    expect(
+      await new GetMetadataTool(makeCtx({}, mockEditor)).call({}, {}),
+    ).toBe("Characters: 11, Words: 2, Lines: 1.");
   });
 
   it("returns correct line count for multi-line document", async () => {
     mockEditor.getValue.mockReturnValue("line one\nline two\nline three");
-    expect(await new GetMetadataTool(makeCtx({}, mockEditor)).call({}, {})).toBe("Characters: 28, Words: 6, Lines: 3.");
+    expect(
+      await new GetMetadataTool(makeCtx({}, mockEditor)).call({}, {}),
+    ).toBe("Characters: 28, Words: 6, Lines: 3.");
   });
 });
 
@@ -201,7 +247,14 @@ describe("EditTool", () => {
     mockModel = {
       findMatches: vi.fn(),
       pushEditOperations: vi.fn(),
-      getFullModelRange: vi.fn().mockReturnValue({ startLineNumber: 1, startColumn: 1, endLineNumber: 10, endColumn: 10 }),
+      getFullModelRange: vi
+        .fn()
+        .mockReturnValue({
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 10,
+          endColumn: 10,
+        }),
     };
     mockEditor = {
       getValue: vi.fn().mockReturnValue("Initial content"),
@@ -214,14 +267,31 @@ describe("EditTool", () => {
   it("returns error if text not found", async () => {
     mockModel.findMatches.mockReturnValue([]);
     const ctx = makeCtx({ setSuggestions }, mockEditor);
-    const result = await new EditTool(ctx).call({ originalText: "missing", replacementText: "found" }, {});
-    expect(result).toBe('Error: Could not find the text "missing" in the document.');
+    const result = await new EditTool(ctx).call(
+      { originalText: "missing", replacementText: "found" },
+      {},
+    );
+    expect(result).toBe(
+      'Error: Could not find the text "missing" in the document.',
+    );
   });
 
   it("creates a suggestion and resolves when not approveAll", async () => {
-    mockModel.findMatches.mockReturnValue([{ range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 5 } }]);
+    mockModel.findMatches.mockReturnValue([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 1,
+          endColumn: 5,
+        },
+      },
+    ]);
     const ctx = makeCtx({ setSuggestions }, mockEditor);
-    const promise = new EditTool(ctx).call({ originalText: "old", replacementText: "new" }, {});
+    const promise = new EditTool(ctx).call(
+      { originalText: "old", replacementText: "new" },
+      {},
+    );
 
     expect(setSuggestions).toHaveBeenCalled();
     const updateFn = setSuggestions.mock.calls[0][0];
@@ -236,9 +306,24 @@ describe("EditTool", () => {
   });
 
   it("applies edit immediately if approveAll is true", async () => {
-    mockModel.findMatches.mockReturnValue([{ range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 5 } }]);
-    const ctx = makeCtx({ setSuggestions, approveAllRef: { current: true } }, mockEditor);
-    const result = await new EditTool(ctx).call({ originalText: "old", replacementText: "new" }, {});
+    mockModel.findMatches.mockReturnValue([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 1,
+          endColumn: 5,
+        },
+      },
+    ]);
+    const ctx = makeCtx(
+      { setSuggestions, approveAllRef: { current: true } },
+      mockEditor,
+    );
+    const result = await new EditTool(ctx).call(
+      { originalText: "old", replacementText: "new" },
+      {},
+    );
     expect(result).toBe("Change applied automatically (Approve All is ON).");
     expect(mockModel.pushEditOperations).toHaveBeenCalled();
     expect(setSuggestions).not.toHaveBeenCalled();
@@ -255,7 +340,14 @@ describe("WriteTool", () => {
 
   beforeEach(() => {
     mockModel = {
-      getFullModelRange: vi.fn().mockReturnValue({ startLineNumber: 1, startColumn: 1, endLineNumber: 10, endColumn: 10 }),
+      getFullModelRange: vi
+        .fn()
+        .mockReturnValue({
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 10,
+          endColumn: 10,
+        }),
     };
     mockEditor = {
       getValue: vi.fn().mockReturnValue("Initial content"),
@@ -267,7 +359,10 @@ describe("WriteTool", () => {
 
   it("creates a suggestion for the full document if not approveAll", async () => {
     const ctx = makeCtx({ setSuggestions }, mockEditor);
-    const promise = new WriteTool(ctx).call({ content: "New document content" }, {});
+    const promise = new WriteTool(ctx).call(
+      { content: "New document content" },
+      {},
+    );
 
     expect(setSuggestions).toHaveBeenCalled();
     const updateFn = setSuggestions.mock.calls[0][0];
@@ -282,8 +377,14 @@ describe("WriteTool", () => {
   });
 
   it("applies full replacement immediately if approveAll is true", async () => {
-    const ctx = makeCtx({ setSuggestions, approveAllRef: { current: true } }, mockEditor);
-    const result = await new WriteTool(ctx).call({ content: "New document content" }, {});
+    const ctx = makeCtx(
+      { setSuggestions, approveAllRef: { current: true } },
+      mockEditor,
+    );
+    const result = await new WriteTool(ctx).call(
+      { content: "New document content" },
+      {},
+    );
     expect(result).toBe("Document updated automatically (Approve All is ON).");
     expect(mockEditor.setValue).toHaveBeenCalledWith("New document content");
     expect(setSuggestions).not.toHaveBeenCalled();

--- a/src/lib/agents/tools/editor/request_switch_to_editor.ts
+++ b/src/lib/agents/tools/editor/request_switch_to_editor.ts
@@ -4,7 +4,10 @@
 import type { Tool, ToolContext, ToolDefinition } from "@mast-ai/core";
 import type { EditorContext } from "./context";
 
-export class RequestSwitchToEditorTool implements Tool<Record<string, never>, string> {
+export class RequestSwitchToEditorTool implements Tool<
+  Record<string, never>,
+  string
+> {
   constructor(private ctx: EditorContext) {}
 
   definition(): ToolDefinition {

--- a/src/lib/agents/tools/editor/search.ts
+++ b/src/lib/agents/tools/editor/search.ts
@@ -34,7 +34,14 @@ export class SearchTool implements Tool<SearchArgs, string> {
     const model = editor.getModel();
     if (!model) return "Error: Model not found.";
 
-    const matches = model.findMatches(args.query, true, false, false, null, false);
+    const matches = model.findMatches(
+      args.query,
+      true,
+      false,
+      false,
+      null,
+      false,
+    );
     if (matches.length === 0) return `No occurrences of "${args.query}" found.`;
 
     const locations = matches

--- a/src/lib/agents/tools/workspace/create_document.ts
+++ b/src/lib/agents/tools/workspace/create_document.ts
@@ -48,7 +48,8 @@ export class CreateDocumentTool implements Tool<CreateDocumentArgs, string> {
         const currentDoc = this.ctx.activeDocRef.current;
         if (currentDoc) {
           const content =
-            this.ctx.editorRef.current?.getValue() ?? this.ctx.editorContentRef.current;
+            this.ctx.editorRef.current?.getValue() ??
+            this.ctx.editorContentRef.current;
           this.ctx.saveDocContentFn(currentDoc.id, content);
         }
         const newId = this.ctx.createDocumentFn(args.title);

--- a/src/lib/agents/tools/workspace/get_active_doc_info.ts
+++ b/src/lib/agents/tools/workspace/get_active_doc_info.ts
@@ -4,7 +4,10 @@
 import type { Tool, ToolContext, ToolDefinition } from "@mast-ai/core";
 import type { WorkspaceContext } from "./context";
 
-export class GetActiveDocInfoTool implements Tool<Record<string, never>, string> {
+export class GetActiveDocInfoTool implements Tool<
+  Record<string, never>,
+  string
+> {
   constructor(private ctx: WorkspaceContext) {}
 
   definition(): ToolDefinition {

--- a/src/lib/agents/tools/workspace/list_workspace_docs.ts
+++ b/src/lib/agents/tools/workspace/list_workspace_docs.ts
@@ -4,7 +4,10 @@
 import type { Tool, ToolContext, ToolDefinition } from "@mast-ai/core";
 import type { WorkspaceContext } from "./context";
 
-export class ListWorkspaceDocsTool implements Tool<Record<string, never>, string> {
+export class ListWorkspaceDocsTool implements Tool<
+  Record<string, never>,
+  string
+> {
   constructor(private ctx: WorkspaceContext) {}
 
   definition(): ToolDefinition {
@@ -18,6 +21,8 @@ export class ListWorkspaceDocsTool implements Tool<Record<string, never>, string
   }
 
   async call(_args: Record<string, never>, _ctx: ToolContext): Promise<string> {
-    return JSON.stringify(this.ctx.docsRef.current.map((d) => ({ id: d.id, title: d.title })));
+    return JSON.stringify(
+      this.ctx.docsRef.current.map((d) => ({ id: d.id, title: d.title })),
+    );
   }
 }

--- a/src/lib/agents/tools/workspace/query_workspace.ts
+++ b/src/lib/agents/tools/workspace/query_workspace.ts
@@ -32,7 +32,11 @@ export class QueryWorkspaceTool implements Tool<QueryWorkspaceArgs, string> {
   }
 
   async call(args: QueryWorkspaceArgs, _ctx: ToolContext): Promise<string> {
-    const result = await runResearch(args.query, this.ctx.docsRef.current, this.ctx.factory);
+    const result = await runResearch(
+      args.query,
+      this.ctx.docsRef.current,
+      this.ctx.factory,
+    );
     return JSON.stringify(result);
   }
 }

--- a/src/lib/agents/tools/workspace/query_workspace_doc.ts
+++ b/src/lib/agents/tools/workspace/query_workspace_doc.ts
@@ -1,7 +1,12 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AgentConfig, Tool, ToolContext, ToolDefinition } from "@mast-ai/core";
+import type {
+  AgentConfig,
+  Tool,
+  ToolContext,
+  ToolDefinition,
+} from "@mast-ai/core";
 import { DOC_QUERIER_SYSTEM_PROMPT } from "../../";
 import type { WorkspaceContext } from "./context";
 
@@ -10,7 +15,10 @@ interface QueryWorkspaceDocArgs {
   query: string;
 }
 
-export class QueryWorkspaceDocTool implements Tool<QueryWorkspaceDocArgs, string> {
+export class QueryWorkspaceDocTool implements Tool<
+  QueryWorkspaceDocArgs,
+  string
+> {
   constructor(private ctx: WorkspaceContext) {}
 
   definition(): ToolDefinition {
@@ -42,15 +50,23 @@ export class QueryWorkspaceDocTool implements Tool<QueryWorkspaceDocArgs, string
       instructions: DOC_QUERIER_SYSTEM_PROMPT,
       tools: [],
     };
-    const runner = this.ctx.factory.create({ systemPrompt: agent.instructions });
+    const runner = this.ctx.factory.create({
+      systemPrompt: agent.instructions,
+    });
     const input = `Document title: ${doc.title}\n\nDocument content:\n${doc.content}\n\nQuery: ${args.query}`;
     const result = await runner.run(agent, input);
     let parsed: { summary: string; excerpt: string };
     try {
-      parsed = JSON.parse(result.output) as { summary: string; excerpt: string };
+      parsed = JSON.parse(result.output) as {
+        summary: string;
+        excerpt: string;
+      };
     } catch {
       parsed = { summary: result.output, excerpt: "" };
     }
-    return JSON.stringify({ summary: parsed.summary, excerpt: parsed.excerpt ?? "" });
+    return JSON.stringify({
+      summary: parsed.summary,
+      excerpt: parsed.excerpt ?? "",
+    });
   }
 }

--- a/src/lib/agents/tools/workspace/read_workspace_doc.ts
+++ b/src/lib/agents/tools/workspace/read_workspace_doc.ts
@@ -8,7 +8,10 @@ interface ReadWorkspaceDocArgs {
   id: string;
 }
 
-export class ReadWorkspaceDocTool implements Tool<ReadWorkspaceDocArgs, string> {
+export class ReadWorkspaceDocTool implements Tool<
+  ReadWorkspaceDocArgs,
+  string
+> {
   constructor(private ctx: WorkspaceContext) {}
 
   definition(): ToolDefinition {

--- a/src/lib/agents/tools/workspace/rename_document.ts
+++ b/src/lib/agents/tools/workspace/rename_document.ts
@@ -40,7 +40,8 @@ export class RenameDocumentTool implements Tool<RenameDocumentArgs, string> {
   async call(args: RenameDocumentArgs, _ctx: ToolContext): Promise<string> {
     const doc = this.ctx.docsRef.current.find((d) => d.id === args.id);
     if (!doc) return JSON.stringify({ error: "Document not found" });
-    if (!args.title?.trim()) return JSON.stringify({ error: "title is required" });
+    if (!args.title?.trim())
+      return JSON.stringify({ error: "title is required" });
     return applyWorkspaceAction(
       `Rename document "${doc.title}" to "${args.title}"`,
       () => this.ctx.renameDocumentFn(args.id, args.title),

--- a/src/lib/agents/tools/workspace/switch_active_document.ts
+++ b/src/lib/agents/tools/workspace/switch_active_document.ts
@@ -8,7 +8,10 @@ interface SwitchActiveDocumentArgs {
   id: string;
 }
 
-export class SwitchActiveDocumentTool implements Tool<SwitchActiveDocumentArgs, string> {
+export class SwitchActiveDocumentTool implements Tool<
+  SwitchActiveDocumentArgs,
+  string
+> {
   constructor(private ctx: WorkspaceContext) {}
 
   definition(): ToolDefinition {
@@ -30,14 +33,18 @@ export class SwitchActiveDocumentTool implements Tool<SwitchActiveDocumentArgs, 
     };
   }
 
-  async call(args: SwitchActiveDocumentArgs, _ctx: ToolContext): Promise<string> {
+  async call(
+    args: SwitchActiveDocumentArgs,
+    _ctx: ToolContext,
+  ): Promise<string> {
     const doc = this.ctx.docsRef.current.find((d) => d.id === args.id);
     if (!doc) return JSON.stringify({ error: "Document not found" });
 
     const currentDoc = this.ctx.activeDocRef.current;
     if (currentDoc) {
       const content =
-        this.ctx.editorRef.current?.getValue() ?? this.ctx.editorContentRef.current;
+        this.ctx.editorRef.current?.getValue() ??
+        this.ctx.editorContentRef.current;
       this.ctx.saveDocContentFn(currentDoc.id, content);
     }
     this.ctx.setActiveDocumentIdFn(args.id);

--- a/src/lib/agents/tools/workspace/workspace.test.ts
+++ b/src/lib/agents/tools/workspace/workspace.test.ts
@@ -22,13 +22,23 @@ function makeStream(output: string): AsyncIterable<AgentEvent> {
   })();
 }
 
-function makeDoc(overrides: Partial<WorkspaceDocument> = {}): WorkspaceDocument {
-  return { id: "doc-1", title: "Test Doc", content: "Hello world", updatedAt: 1000, ...overrides };
+function makeDoc(
+  overrides: Partial<WorkspaceDocument> = {},
+): WorkspaceDocument {
+  return {
+    id: "doc-1",
+    title: "Test Doc",
+    content: "Hello world",
+    updatedAt: 1000,
+    ...overrides,
+  };
 }
 
 function makeCtx(overrides: Partial<WorkspaceContext> = {}): WorkspaceContext {
   const mockRun = vi.fn().mockResolvedValue({ output: "mock answer" });
-  const mockFactory: AgentRunnerFactory = { create: vi.fn().mockReturnValue({ run: mockRun }) };
+  const mockFactory: AgentRunnerFactory = {
+    create: vi.fn().mockReturnValue({ run: mockRun }),
+  };
   return {
     docsRef: { current: [] },
     activeDocRef: { current: null },
@@ -48,13 +58,17 @@ function makeCtx(overrides: Partial<WorkspaceContext> = {}): WorkspaceContext {
 
 describe("GetActiveDocInfoTool", () => {
   it("returns id and title of the active document", async () => {
-    const ctx = makeCtx({ activeDocRef: { current: { id: "x", title: "My Essay" } } });
+    const ctx = makeCtx({
+      activeDocRef: { current: { id: "x", title: "My Essay" } },
+    });
     const result = JSON.parse(await new GetActiveDocInfoTool(ctx).call({}, {}));
     expect(result).toEqual({ id: "x", title: "My Essay" });
   });
 
   it("returns error when no document is active", async () => {
-    const result = JSON.parse(await new GetActiveDocInfoTool(makeCtx()).call({}, {}));
+    const result = JSON.parse(
+      await new GetActiveDocInfoTool(makeCtx()).call({}, {}),
+    );
     expect(result).toEqual({ error: "No active document" });
   });
 });
@@ -66,12 +80,19 @@ describe("ListWorkspaceDocsTool", () => {
       makeDoc({ id: "b", title: "Beta", content: "also secret" }),
     ];
     const ctx = makeCtx({ docsRef: { current: docs } });
-    const result = JSON.parse(await new ListWorkspaceDocsTool(ctx).call({}, {}));
-    expect(result).toEqual([{ id: "a", title: "Alpha" }, { id: "b", title: "Beta" }]);
+    const result = JSON.parse(
+      await new ListWorkspaceDocsTool(ctx).call({}, {}),
+    );
+    expect(result).toEqual([
+      { id: "a", title: "Alpha" },
+      { id: "b", title: "Beta" },
+    ]);
   });
 
   it("returns empty array when workspace has no documents", async () => {
-    expect(JSON.parse(await new ListWorkspaceDocsTool(makeCtx()).call({}, {}))).toEqual([]);
+    expect(
+      JSON.parse(await new ListWorkspaceDocsTool(makeCtx()).call({}, {})),
+    ).toEqual([]);
   });
 });
 
@@ -79,31 +100,58 @@ describe("ReadWorkspaceDocTool", () => {
   it("returns title and content for a valid id", async () => {
     const doc = makeDoc({ id: "x", title: "My Doc", content: "content here" });
     const ctx = makeCtx({ docsRef: { current: [doc] } });
-    const result = JSON.parse(await new ReadWorkspaceDocTool(ctx).call({ id: "x" }, {}));
+    const result = JSON.parse(
+      await new ReadWorkspaceDocTool(ctx).call({ id: "x" }, {}),
+    );
     expect(result).toEqual({ title: "My Doc", content: "content here" });
   });
 
   it("returns error for an unknown id", async () => {
     const ctx = makeCtx({ docsRef: { current: [makeDoc()] } });
-    const result = JSON.parse(await new ReadWorkspaceDocTool(ctx).call({ id: "unknown" }, {}));
+    const result = JSON.parse(
+      await new ReadWorkspaceDocTool(ctx).call({ id: "unknown" }, {}),
+    );
     expect(result).toEqual({ error: "Document not found" });
   });
 });
 
 describe("QueryWorkspaceDocTool", () => {
   it("returns error for unknown doc id", async () => {
-    const result = JSON.parse(await new QueryWorkspaceDocTool(makeCtx()).call({ id: "nope", query: "anything" }, {}));
+    const result = JSON.parse(
+      await new QueryWorkspaceDocTool(makeCtx()).call(
+        { id: "nope", query: "anything" },
+        {},
+      ),
+    );
     expect(result).toEqual({ error: "Document not found" });
   });
 
   it("creates a sub-agent runner with doc content and query, returns summary and excerpt", async () => {
-    const mockRun = vi.fn().mockResolvedValue({ output: '{"summary":"A concise summary.","excerpt":"The sky is blue."}' });
-    const mockFactory: AgentRunnerFactory = { create: vi.fn().mockReturnValue({ run: mockRun }) };
-    const doc = makeDoc({ id: "d1", title: "Brief", content: "The sky is blue." });
+    const mockRun = vi
+      .fn()
+      .mockResolvedValue({
+        output: '{"summary":"A concise summary.","excerpt":"The sky is blue."}',
+      });
+    const mockFactory: AgentRunnerFactory = {
+      create: vi.fn().mockReturnValue({ run: mockRun }),
+    };
+    const doc = makeDoc({
+      id: "d1",
+      title: "Brief",
+      content: "The sky is blue.",
+    });
     const ctx = makeCtx({ docsRef: { current: [doc] }, factory: mockFactory });
 
-    const result = JSON.parse(await new QueryWorkspaceDocTool(ctx).call({ id: "d1", query: "What color is the sky?" }, {}));
-    expect(result).toEqual({ summary: "A concise summary.", excerpt: "The sky is blue." });
+    const result = JSON.parse(
+      await new QueryWorkspaceDocTool(ctx).call(
+        { id: "d1", query: "What color is the sky?" },
+        {},
+      ),
+    );
+    expect(result).toEqual({
+      summary: "A concise summary.",
+      excerpt: "The sky is blue.",
+    });
     expect(mockFactory.create).toHaveBeenCalledOnce();
 
     const [agentConfig, input] = mockRun.mock.calls[0];
@@ -123,17 +171,24 @@ describe("CreateDocumentTool", () => {
   beforeEach(() => {
     createDocumentFn = vi.fn().mockReturnValue("new-doc-id");
     setEditorValueFn = vi.fn();
-    mockEditorRef = { current: { getValue: vi.fn().mockReturnValue(""), setValue: setEditorValueFn } };
+    mockEditorRef = {
+      current: {
+        getValue: vi.fn().mockReturnValue(""),
+        setValue: setEditorValueFn,
+      },
+    };
     setPendingWorkspaceAction = vi.fn();
   });
 
   function makeTool(approveAll = false) {
-    return new CreateDocumentTool(makeCtx({
-      createDocumentFn,
-      editorRef: mockEditorRef,
-      setPendingWorkspaceAction,
-      approveAllRef: { current: approveAll },
-    }));
+    return new CreateDocumentTool(
+      makeCtx({
+        createDocumentFn,
+        editorRef: mockEditorRef,
+        setPendingWorkspaceAction,
+        approveAllRef: { current: approveAll },
+      }),
+    );
   }
 
   it("returns error when title is empty", async () => {
@@ -176,13 +231,15 @@ describe("CreateDocumentTool", () => {
 
   it("sets editor to provided content and saves it when approveAll is true", async () => {
     const saveDocContentFn = vi.fn();
-    const tool = new CreateDocumentTool(makeCtx({
-      createDocumentFn,
-      saveDocContentFn,
-      editorRef: mockEditorRef,
-      setPendingWorkspaceAction,
-      approveAllRef: { current: true },
-    }));
+    const tool = new CreateDocumentTool(
+      makeCtx({
+        createDocumentFn,
+        saveDocContentFn,
+        editorRef: mockEditorRef,
+        setPendingWorkspaceAction,
+        approveAllRef: { current: true },
+      }),
+    );
     await tool.call({ title: "My Doc", content: "Hello world" }, {});
     expect(setEditorValueFn).toHaveBeenCalledWith("Hello world");
     expect(saveDocContentFn).toHaveBeenCalledWith("new-doc-id", "Hello world");
@@ -190,16 +247,21 @@ describe("CreateDocumentTool", () => {
 
   it("uses empty string for editor when no content provided", async () => {
     const saveDocContentFn = vi.fn();
-    const tool = new CreateDocumentTool(makeCtx({
-      createDocumentFn,
-      saveDocContentFn,
-      editorRef: mockEditorRef,
-      setPendingWorkspaceAction,
-      approveAllRef: { current: true },
-    }));
+    const tool = new CreateDocumentTool(
+      makeCtx({
+        createDocumentFn,
+        saveDocContentFn,
+        editorRef: mockEditorRef,
+        setPendingWorkspaceAction,
+        approveAllRef: { current: true },
+      }),
+    );
     await tool.call({ title: "My Doc" }, {});
     expect(setEditorValueFn).toHaveBeenCalledWith("");
-    expect(saveDocContentFn).not.toHaveBeenCalledWith("new-doc-id", expect.anything());
+    expect(saveDocContentFn).not.toHaveBeenCalledWith(
+      "new-doc-id",
+      expect.anything(),
+    );
   });
 });
 
@@ -213,31 +275,43 @@ describe("RenameDocumentTool", () => {
   });
 
   function makeTool(docs: WorkspaceDocument[], approveAll = false) {
-    return new RenameDocumentTool(makeCtx({
-      docsRef: { current: docs },
-      renameDocumentFn,
-      setPendingWorkspaceAction,
-      approveAllRef: { current: approveAll },
-    }));
+    return new RenameDocumentTool(
+      makeCtx({
+        docsRef: { current: docs },
+        renameDocumentFn,
+        setPendingWorkspaceAction,
+        approveAllRef: { current: approveAll },
+      }),
+    );
   }
 
   it("returns error when document is not found", async () => {
-    const result = JSON.parse(await makeTool([]).call({ id: "nope", title: "New" }, {}));
+    const result = JSON.parse(
+      await makeTool([]).call({ id: "nope", title: "New" }, {}),
+    );
     expect(result).toEqual({ error: "Document not found" });
   });
 
   it("returns error when title is empty", async () => {
-    const result = JSON.parse(await makeTool([makeDoc({ id: "d1" })]).call({ id: "d1", title: "" }, {}));
+    const result = JSON.parse(
+      await makeTool([makeDoc({ id: "d1" })]).call({ id: "d1", title: "" }, {}),
+    );
     expect(result).toEqual({ error: "title is required" });
   });
 
   it("renames immediately when approveAll is true", async () => {
-    await makeTool([makeDoc({ id: "d1", title: "Old" })], true).call({ id: "d1", title: "New" }, {});
+    await makeTool([makeDoc({ id: "d1", title: "Old" })], true).call(
+      { id: "d1", title: "New" },
+      {},
+    );
     expect(renameDocumentFn).toHaveBeenCalledWith("d1", "New");
   });
 
   it("sets pending workspace action and renames on accept", async () => {
-    const promise = makeTool([makeDoc({ id: "d1", title: "Old" })]).call({ id: "d1", title: "New" }, {});
+    const promise = makeTool([makeDoc({ id: "d1", title: "Old" })]).call(
+      { id: "d1", title: "New" },
+      {},
+    );
     const request = setPendingWorkspaceAction.mock.calls[0][0];
     expect(request.description).toContain("Old");
     expect(request.description).toContain("New");
@@ -250,7 +324,10 @@ describe("RenameDocumentTool", () => {
   });
 
   it("does not rename on rejection", async () => {
-    const promise = makeTool([makeDoc({ id: "d1", title: "Old" })]).call({ id: "d1", title: "New" }, {});
+    const promise = makeTool([makeDoc({ id: "d1", title: "Old" })]).call(
+      { id: "d1", title: "New" },
+      {},
+    );
     const request = setPendingWorkspaceAction.mock.calls[0][0];
     request.resolve("Action rejected by user.");
     expect(await promise).toBe("Action rejected by user.");
@@ -268,12 +345,14 @@ describe("DeleteDocumentTool", () => {
   });
 
   function makeTool(docs: WorkspaceDocument[], approveAll = false) {
-    return new DeleteDocumentTool(makeCtx({
-      docsRef: { current: docs },
-      deleteDocumentFn,
-      setPendingWorkspaceAction,
-      approveAllRef: { current: approveAll },
-    }));
+    return new DeleteDocumentTool(
+      makeCtx({
+        docsRef: { current: docs },
+        deleteDocumentFn,
+        setPendingWorkspaceAction,
+        approveAllRef: { current: approveAll },
+      }),
+    );
   }
 
   it("returns error when document is not found", async () => {
@@ -287,7 +366,10 @@ describe("DeleteDocumentTool", () => {
   });
 
   it("sets pending workspace action and deletes on accept", async () => {
-    const promise = makeTool([makeDoc({ id: "d1", title: "My Essay" })]).call({ id: "d1" }, {});
+    const promise = makeTool([makeDoc({ id: "d1", title: "My Essay" })]).call(
+      { id: "d1" },
+      {},
+    );
     const request = setPendingWorkspaceAction.mock.calls[0][0];
     expect(request.description).toContain("My Essay");
 
@@ -317,17 +399,27 @@ describe("SwitchActiveDocumentTool", () => {
     setActiveDocumentIdFn = vi.fn();
     saveDocContentFn = vi.fn();
     setEditorValueFn = vi.fn();
-    mockEditorRef = { current: { getValue: vi.fn().mockReturnValue("editor content"), setValue: setEditorValueFn } };
+    mockEditorRef = {
+      current: {
+        getValue: vi.fn().mockReturnValue("editor content"),
+        setValue: setEditorValueFn,
+      },
+    };
   });
 
-  function makeTool(docs: WorkspaceDocument[], activeDoc: { id: string; title: string } | null = null) {
-    return new SwitchActiveDocumentTool(makeCtx({
-      docsRef: { current: docs },
-      activeDocRef: { current: activeDoc },
-      setActiveDocumentIdFn,
-      saveDocContentFn,
-      editorRef: mockEditorRef,
-    }));
+  function makeTool(
+    docs: WorkspaceDocument[],
+    activeDoc: { id: string; title: string } | null = null,
+  ) {
+    return new SwitchActiveDocumentTool(
+      makeCtx({
+        docsRef: { current: docs },
+        activeDocRef: { current: activeDoc },
+        setActiveDocumentIdFn,
+        saveDocContentFn,
+        editorRef: mockEditorRef,
+      }),
+    );
   }
 
   it("returns error when document is not found", async () => {
@@ -336,13 +428,21 @@ describe("SwitchActiveDocumentTool", () => {
   });
 
   it("switches document without authorization", async () => {
-    const result = JSON.parse(await makeTool([makeDoc({ id: "d1", title: "Doc 1" })]).call({ id: "d1" }, {}));
+    const result = JSON.parse(
+      await makeTool([makeDoc({ id: "d1", title: "Doc 1" })]).call(
+        { id: "d1" },
+        {},
+      ),
+    );
     expect(result).toEqual({ switched: true, id: "d1", title: "Doc 1" });
     expect(setActiveDocumentIdFn).toHaveBeenCalledWith("d1");
   });
 
   it("saves current document content before switching", async () => {
-    await makeTool([makeDoc({ id: "d2", title: "Target" })], { id: "d1", title: "Current" }).call({ id: "d2" }, {});
+    await makeTool([makeDoc({ id: "d2", title: "Target" })], {
+      id: "d1",
+      title: "Current",
+    }).call({ id: "d2" }, {});
     expect(saveDocContentFn).toHaveBeenCalledWith("d1", "editor content");
     expect(setActiveDocumentIdFn).toHaveBeenCalledWith("d2");
   });
@@ -353,7 +453,10 @@ describe("SwitchActiveDocumentTool", () => {
   });
 
   it("syncs editor value to new document content immediately", async () => {
-    await makeTool([makeDoc({ id: "d1", content: "new content" })]).call({ id: "d1" }, {});
+    await makeTool([makeDoc({ id: "d1", content: "new content" })]).call(
+      { id: "d1" },
+      {},
+    );
     expect(setEditorValueFn).toHaveBeenCalledWith("new content");
   });
 });
@@ -366,7 +469,9 @@ describe("QueryWorkspaceTool", () => {
   beforeEach(() => {
     mockRunStream = vi.fn();
     mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
-    streamFactory = { create: vi.fn().mockReturnValue({ runBuilder: mockRunBuilder }) };
+    streamFactory = {
+      create: vi.fn().mockReturnValue({ runBuilder: mockRunBuilder }),
+    };
   });
 
   it("synthesizes results from multiple docs and returns ResearchResult shape", async () => {
@@ -375,27 +480,51 @@ describe("QueryWorkspaceTool", () => {
       makeDoc({ id: "d2", title: "Doc 2", content: "content 2" }),
     ];
     mockRunStream
-      .mockReturnValueOnce(makeStream('{"summary":"Summary 1.","excerpt":"excerpt 1"}'))
-      .mockReturnValueOnce(makeStream('{"summary":"Summary 2.","excerpt":"excerpt 2"}'))
+      .mockReturnValueOnce(
+        makeStream('{"summary":"Summary 1.","excerpt":"excerpt 1"}'),
+      )
+      .mockReturnValueOnce(
+        makeStream('{"summary":"Summary 2.","excerpt":"excerpt 2"}'),
+      )
       .mockReturnValueOnce(makeStream('{"summary":"Combined answer."}'));
 
     const ctx = makeCtx({ docsRef: { current: docs }, factory: streamFactory });
-    const result = JSON.parse(await new QueryWorkspaceTool(ctx).call({ query: "What do the docs say?" }, {}));
+    const result = JSON.parse(
+      await new QueryWorkspaceTool(ctx).call(
+        { query: "What do the docs say?" },
+        {},
+      ),
+    );
 
     expect(result.summary).toBe("Combined answer.");
     expect(Array.isArray(result.sources)).toBe(true);
     expect(result.sources).toHaveLength(2);
-    expect(result.sources[0]).toMatchObject({ id: "d1", title: "Doc 1", excerpt: "excerpt 1" });
-    expect(result.sources[1]).toMatchObject({ id: "d2", title: "Doc 2", excerpt: "excerpt 2" });
+    expect(result.sources[0]).toMatchObject({
+      id: "d1",
+      title: "Doc 1",
+      excerpt: "excerpt 1",
+    });
+    expect(result.sources[1]).toMatchObject({
+      id: "d2",
+      title: "Doc 2",
+      excerpt: "excerpt 2",
+    });
   });
 
   it("returns a ResearchResult even with a single document", async () => {
     mockRunStream
-      .mockReturnValueOnce(makeStream('{"summary":"Single doc summary.","excerpt":"passage"}'))
+      .mockReturnValueOnce(
+        makeStream('{"summary":"Single doc summary.","excerpt":"passage"}'),
+      )
       .mockReturnValueOnce(makeStream('{"summary":"Final answer."}'));
 
-    const ctx = makeCtx({ docsRef: { current: [makeDoc()] }, factory: streamFactory });
-    const result = JSON.parse(await new QueryWorkspaceTool(ctx).call({ query: "q" }, {}));
+    const ctx = makeCtx({
+      docsRef: { current: [makeDoc()] },
+      factory: streamFactory,
+    });
+    const result = JSON.parse(
+      await new QueryWorkspaceTool(ctx).call({ query: "q" }, {}),
+    );
     expect(result.summary).toBe("Final answer.");
     expect(result.sources).toHaveLength(1);
   });
@@ -406,12 +535,18 @@ describe("QueryWorkspaceTool", () => {
       makeDoc({ id: "d2", title: "Empty", content: "" }),
     ];
     mockRunStream
-      .mockReturnValueOnce(makeStream('{"summary":"Useful info.","excerpt":"good passage"}'))
-      .mockReturnValueOnce(makeStream('{"summary":"No relevant content.","excerpt":""}'))
+      .mockReturnValueOnce(
+        makeStream('{"summary":"Useful info.","excerpt":"good passage"}'),
+      )
+      .mockReturnValueOnce(
+        makeStream('{"summary":"No relevant content.","excerpt":""}'),
+      )
       .mockReturnValueOnce(makeStream('{"summary":"Only useful info."}'));
 
     const ctx = makeCtx({ docsRef: { current: docs }, factory: streamFactory });
-    const result = JSON.parse(await new QueryWorkspaceTool(ctx).call({ query: "q" }, {}));
+    const result = JSON.parse(
+      await new QueryWorkspaceTool(ctx).call({ query: "q" }, {}),
+    );
     expect(result.sources).toHaveLength(1);
     expect(result.sources[0].id).toBe("d1");
   });

--- a/src/lib/agents/tools/workspace/workspace.test.ts
+++ b/src/lib/agents/tools/workspace/workspace.test.ts
@@ -127,11 +127,9 @@ describe("QueryWorkspaceDocTool", () => {
   });
 
   it("creates a sub-agent runner with doc content and query, returns summary and excerpt", async () => {
-    const mockRun = vi
-      .fn()
-      .mockResolvedValue({
-        output: '{"summary":"A concise summary.","excerpt":"The sky is blue."}',
-      });
+    const mockRun = vi.fn().mockResolvedValue({
+      output: '{"summary":"A concise summary.","excerpt":"The sky is blue."}',
+    });
     const mockFactory: AgentRunnerFactory = {
       create: vi.fn().mockReturnValue({ run: mockRun }),
     };


### PR DESCRIPTION
## Summary

Two related cleanups bundled because each is small on its own:

- **`.gitattributes`** — pin text files to LF in the repo (overriding any per-machine `core.autocrlf` setting), keep Windows scripts as CRLF, and mark common image/font formats as binary. Suppresses the recurring "LF will be replaced by CRLF" warnings on Windows checkouts and stops future drift before it starts. Template adapted from [bandarrame_rs](https://github.com/andreban/bandarrame_rs/blob/main/.gitattributes).
- **Prettier reformat** — 23 source/test files that were merged without `npm run format` being applied. Pure mechanical changes: line wrapping at 80 chars and trailing commas. No behavior changes.

After this lands, `npm run format` on a clean `main` is a no-op.

## Notes

- During investigation I found `git ls-files --eol` reports every tracked file as LF — there was no actual content-level line-ending drift, only the autocrlf warning noise. The `.gitattributes` is forward-looking hygiene, not a backfill.
- The pre-existing lint error in `src/lib/agents/tools/editor/editor.test.ts` (tracked in #85) is unaffected by this change.

## Test plan

- [x] `npm run build` — passes
- [x] `npm run test` — 293/293 passing across 28 files
- [x] `npm run format` produces no further modifications

Closes #84