### PR TITLE
fix: replace 'any' in editor.test.ts makeCtx helper

### DIFF
--- a/src/lib/agents/tools/editor/editor.test.ts
+++ b/src/lib/agents/tools/editor/editor.test.ts
@@ -1,6 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as monaco from "monaco-editor";
 import type { EditorContext } from "./context";
 import { ReadTool } from "./read";
 import { ReadSelectionTool } from "./read_selection";
@@ -11,15 +12,12 @@ import { RequestSwitchToEditorTool } from "./request_switch_to_editor";
 import { EditTool } from "./edit";
 import { WriteTool } from "./write";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeCtx(
   overrides: Partial<EditorContext> = {},
-  mockEditor?: any,
+  mockEditor?: monaco.editor.IStandaloneCodeEditor,
 ): EditorContext {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const editor = mockEditor ?? (null as any);
   return {
-    editorRef: { current: editor },
+    editorRef: { current: mockEditor ?? null },
     editorContentRef: { current: "" },
     activeTabRef: { current: "editor" },
     requestTabSwitch: () => Promise.resolve(false),


### PR DESCRIPTION
## Summary

- Type the optional `mockEditor` parameter in `makeCtx` as `monaco.editor.IStandaloneCodeEditor` so `editorRef.current` accepts the value (or `null`) directly, eliminating the `any` cast that was triggering the lint error.
- Drop the two now-unused `eslint-disable @typescript-eslint/no-explicit-any` directives.

`npm run lint` now exits 0 on this branch.

Closes #85

## Test plan

- [x] `npm run lint` exits with 0 errors
- [x] `npm run build` succeeds
- [x] `npm run test` — all 293 tests pass
- [x] `npm run format` clean