### PR TITLE
chore: install @mast-ai/* from npm registry + lint fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-An AI-powered collaborative text editor: a React SPA where an LLM agent assists with editing text in a Monaco editor. The agent runs in the browser via [`@mast-ai/core`](../mast-ai/packages/core), reads and edits the active document through tools, and routes mutating operations through a user-approval workflow before they touch the editor buffer.
+An AI-powered collaborative text editor: a React SPA where an LLM agent assists with editing text in a Monaco editor. The agent runs in the browser via [`@mast-ai/core`](https://www.npmjs.com/package/@mast-ai/core), reads and edits the active document through tools, and routes mutating operations through a user-approval workflow before they touch the editor buffer.
 
 ## Commands
 
@@ -38,7 +38,7 @@ This is an AI-powered collaborative text editor: a React SPA where an LLM agent 
 - `src/components/ChatSidebar.tsx` — streaming chat UI that renders thinking chunks (collapsible), text deltas, and tool call/result events
 - `src/App.tsx` — assembles the agent runner, sets the system prompt ("helpful senior editorial assistant"), and manages API key/model localStorage persistence
 
-**MAST dependency:** `@mast-ai/core` is resolved from a local sibling path (`../mast-ai/packages/core`) via `vite.config.ts` alias. If that path is missing the dev server will fail.
+**MAST dependency:** `@mast-ai/core`, `@mast-ai/built-in-ai`, and `@mast-ai/google-genai` are installed from the npm registry.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Agent Text Editor is a React SPA that lets you write and edit text with the help
 
 - Node.js 18+
 - A [Google AI Studio](https://aistudio.google.com/) API key
-- The [`@mast-ai/core`](../mast-ai/packages/core) package checked out as a sibling directory at `../mast-ai`
 
 ## Getting Started
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -25,7 +25,7 @@ The application is a single-page React application bundled with Vite. It consist
 - **UI Components:** `shadcn/ui` (built on Radix UI).
 - **Editor:** `@monaco-editor/react`.
 - **LLM SDK:** `@google/genai`.
-- **Agent Framework:** `@mast-ai/core` (Installed via `npm install github:andreban/mast-ai#packages/core`).
+- **Agent Framework:** `@mast-ai/core` (installed from npm).
 - **Testing:** `vitest`, `@testing-library/react`.
 - **Quality:** `eslint`, `prettier`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@google/genai": "^1.50.1",
-        "@mast-ai/built-in-ai": "file:../mast-ai/packages/built-in-ai",
-        "@mast-ai/core": "file:../mast-ai/packages/core",
-        "@mast-ai/google-genai": "file:../mast-ai/packages/google-genai",
+        "@mast-ai/built-in-ai": "^0.1.1",
+        "@mast-ai/core": "^0.1.1",
+        "@mast-ai/google-genai": "^0.1.1",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
@@ -60,42 +60,6 @@
       "optionalDependencies": {
         "@rollup/rollup-win32-arm64-msvc": "^4.60.2",
         "@rollup/rollup-win32-x64-msvc": "^4.60.2"
-      }
-    },
-    "../mast-ai/packages/built-in-ai": {
-      "name": "@mast-ai/built-in-ai",
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mast-ai/core": "*"
-      },
-      "devDependencies": {
-        "tsup": "^8.0.0",
-        "typescript": "~6.0.2",
-        "vitest": "^4.1.4"
-      }
-    },
-    "../mast-ai/packages/core": {
-      "name": "@mast-ai/core",
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "devDependencies": {
-        "tsup": "^8.0.0",
-        "typescript": "~6.0.2"
-      }
-    },
-    "../mast-ai/packages/google-genai": {
-      "name": "@mast-ai/google-genai",
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@google/genai": "^1.50.1",
-        "@mast-ai/core": "*"
-      },
-      "devDependencies": {
-        "tsup": "^8.0.0",
-        "typescript": "~6.0.2",
-        "vitest": "^4.1.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -200,7 +164,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -521,7 +484,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -570,9 +532,33 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -872,16 +858,29 @@
       }
     },
     "node_modules/@mast-ai/built-in-ai": {
-      "resolved": "../mast-ai/packages/built-in-ai",
-      "link": true
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@mast-ai/built-in-ai/-/built-in-ai-0.1.1.tgz",
+      "integrity": "sha512-679xP8iotLuZ5cyZxkZpW9ztgzCm6bMu2ZNCg8fFX5IWsPgknOqvN/p4IOPMl0PbUj5+TGCFzE4SsNl0exdkGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mast-ai/core": "^0.1.1"
+      }
     },
     "node_modules/@mast-ai/core": {
-      "resolved": "../mast-ai/packages/core",
-      "link": true
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@mast-ai/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-CZgjowvXushugW8EtQby7AfB+/4G6y0V9nVmkq6jFTXk6m2dYaZiVTGR21LvhFqf1t7Rd4EZ3qhharh1xhhHDg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@mast-ai/google-genai": {
-      "resolved": "../mast-ai/packages/google-genai",
-      "link": true
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@mast-ai/google-genai/-/google-genai-0.1.1.tgz",
+      "integrity": "sha512-Rbw1zvlLQvWCzzNmaRhfJjnh55ImML1nObHMRZmR7ZVM+Q84Kep+d9BP05s+M4PgwLmiFpSXODl7FDcfkiMe6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google/genai": "^1.50.1",
+        "@mast-ai/core": "^0.1.1"
+      }
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
@@ -2085,7 +2084,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2188,7 +2188,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2199,7 +2198,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2215,7 +2213,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2275,7 +2274,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -2625,7 +2623,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2675,6 +2672,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2685,6 +2683,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2920,7 +2919,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3303,13 +3301,15 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -3388,7 +3388,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4310,7 +4309,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4812,6 +4810,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4841,6 +4840,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -6086,7 +6086,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6262,6 +6261,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6341,7 +6341,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6351,7 +6350,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6364,7 +6362,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7047,7 +7046,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7189,7 +7187,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7477,7 +7474,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7840,7 +7836,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/built-in-ai": "file:../mast-ai/packages/built-in-ai",
-    "@mast-ai/core": "file:../mast-ai/packages/core",
-    "@mast-ai/google-genai": "file:../mast-ai/packages/google-genai",
+    "@mast-ai/built-in-ai": "^0.1.1",
+    "@mast-ai/core": "^0.1.1",
+    "@mast-ai/google-genai": "^0.1.1",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,10 +9,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
-      "@mast-ai/google-genai": path.resolve(
-        __dirname,
-        "../mast-ai/packages/google-genai/dist/index.js",
-      ),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Migrate `@mast-ai/{core,built-in-ai,google-genai}` from local `file:../mast-ai/...` sibling deps to `^0.1.1` published on npm. Drops the requirement to check out `mast-ai` as a sibling directory.
- Remove the now-unnecessary `@mast-ai/google-genai` alias from `vite.config.ts` (it was pointing at the local `dist/index.js`).
- Update `CLAUDE.md`, `README.md`, and `docs/SPEC.md` to drop the sibling-checkout prerequisite and reference the npm packages.
- Bundles a small earlier commit (`f0e5d01`) replacing `any` in `editor.test.ts`'s `makeCtx` helper.

### Note on the upstream fix

The initially-published `@mast-ai/core@0.1.0` had a Node ESM resolution bug — its compiled `dist/*.js` used extensionless relative imports (`export * from './types'`), which Vite's bundler tolerates but Node's strict ESM loader rejects. This surfaced as `ERR_MODULE_NOT_FOUND` once vitest started resolving the package via `node_modules` rather than via a symlinked file: dep. The mast-ai `core` package was updated to add explicit `.js` extensions and republished as `0.1.1`; this PR pins to `^0.1.1` accordingly.

## Test plan

- [x] `npm run lint` — 0 errors (9 preexisting warnings)
- [x] `npm run build` — passes
- [x] `npm run test` — 293/293 passing
- [x] Manual smoke test (`npm run dev`) — chat, edits, suggestions still work end-to-end