### PR TITLE
ci: add GitHub Actions workflow for PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run format:check
+
+      - run: npm run build
+
+      - run: npm test -- --run

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc && vite build",
     "lint": "eslint .",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "preview": "vite preview",
     "test": "vitest",
     "evals": "vitest run --config vitest.evals.config.ts"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml`: runs lint, format check, build, and tests on every pull request and on pushes to `main`. Single Ubuntu job on Node 22 with npm cache; concurrency group cancels stale runs when new commits land.
- Add `format:check` script (`prettier --check .`) so CI can verify formatting without mutating files.

Lint warnings (currently 9, all preexisting) are not treated as failures — `eslint .` exits 0 on warnings. If we later want to gate PRs on warnings, that's a one-flag change (`--max-warnings 0`).

## Test plan

- [x] `npm run format:check` — passes
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — passes
- [x] `npm test -- --run` — 293/293 passing
- [x] CI run on this PR — verify the workflow itself is green