### PR TITLE
feat: wire @mast-ai/react-ui <AgentProvider> at app root (Phase 1)

### DIFF
--- a/docs/react-ui-migration/SPEC.md
+++ b/docs/react-ui-migration/SPEC.md
@@ -4,14 +4,14 @@ Companion to [PRD.md](./PRD.md). Tracking issue: [#82](https://github.com/andreb
 
 ## Current state (what we're replacing)
 
-| File | Lines | Role |
-| --- | ---: | --- |
-| `src/components/ChatSidebar.tsx` | 364 | Sidebar chrome (header, theme toggle, settings/skills buttons, approve-all switch) **plus** virtualised message list, mention picker, chip-based input, streaming state machine, scroll-to-bottom, `expandedThoughts` set. |
-| `src/components/ChatItem.tsx` | 300 | Renders one user/assistant message: streaming text, collapsible thinking chunks, tool call/result events. |
-| `src/lib/mentionUtils.ts` | 48 | `Segment`, `DocRef`, `extractMentionQuery`, `buildPromptWithMentions`. |
-| `src/context/AgentContext.tsx` | 228 | Custom React context: builds `AgentRunnerFactory`, `EditorContext`, `WorkspaceContext`, `ToolRegistry` (with `DelegateToSkillTool`, delegation tools, web MCP, built-in AI tools), constructs `AgentModel`, exposes `items`, `isLoading`, `sendMessage(prompt, displayText?)`, `cancel`. |
-| `src/components/ChatSidebar.test.tsx` | 172 | Tests for the bespoke sidebar. |
-| `src/components/ChatItem.test.tsx` | 88 | Tests for the bespoke message renderer. |
+| File                                  | Lines | Role                                                                                                                                                                                                                                                                                     |
+| ------------------------------------- | ----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/components/ChatSidebar.tsx`      |   364 | Sidebar chrome (header, theme toggle, settings/skills buttons, approve-all switch) **plus** virtualised message list, mention picker, chip-based input, streaming state machine, scroll-to-bottom, `expandedThoughts` set.                                                               |
+| `src/components/ChatItem.tsx`         |   300 | Renders one user/assistant message: streaming text, collapsible thinking chunks, tool call/result events.                                                                                                                                                                                |
+| `src/lib/mentionUtils.ts`             |    48 | `Segment`, `DocRef`, `extractMentionQuery`, `buildPromptWithMentions`.                                                                                                                                                                                                                   |
+| `src/context/AgentContext.tsx`        |   228 | Custom React context: builds `AgentRunnerFactory`, `EditorContext`, `WorkspaceContext`, `ToolRegistry` (with `DelegateToSkillTool`, delegation tools, web MCP, built-in AI tools), constructs `AgentModel`, exposes `items`, `isLoading`, `sendMessage(prompt, displayText?)`, `cancel`. |
+| `src/components/ChatSidebar.test.tsx` |   172 | Tests for the bespoke sidebar.                                                                                                                                                                                                                                                           |
+| `src/components/ChatItem.test.tsx`    |    88 | Tests for the bespoke message renderer.                                                                                                                                                                                                                                                  |
 
 Other affected entry points:
 
@@ -20,14 +20,14 @@ Other affected entry points:
 
 ## Target state (what it becomes)
 
-| Today | Replacement (`@mast-ai/react-ui`) |
-| --- | --- |
-| `<ChatSidebar>` (compound: header + list + plan widget + input) | A thin sidebar component in this repo containing the existing header chrome, `<MessageList>`, `<PlanConfirmationWidget>`, and `<ChatInput>`. |
-| `ChatItem` (user/assistant rendering, thinking, tool calls) | Library's `<UserMessage>`, `<AssistantMessage>`, `<ThinkingBlock>`, `<ToolCallBlock>` (consumed by `<MessageList>`'s default renderer; override via `renderToolCall` for our bespoke tools). |
-| Virtualiser + `expandedThoughts` + scroll-to-bottom in `ChatSidebar` | `<MessageList>` + `useAgent()`. |
-| `mentionUtils.ts` + segment/picker state | `<ChatInput mentions={{ items, buildPrompt }}>` from the library. |
-| `AgentContext` + `useAgentContext()` | `<AgentProvider runner={...} agent={...} icons={...} onApprovalRequired={...} mentions={...}>` + `useAgent()`. |
-| Skill / approve-all + plan confirmation + custom approval routing | `onApprovalRequired` callback returning `INLINE_APPROVAL` for inline cases; falling through to existing `<PlanConfirmationWidget>` modal for plan approvals. |
+| Today                                                                | Replacement (`@mast-ai/react-ui`)                                                                                                                                                            |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<ChatSidebar>` (compound: header + list + plan widget + input)      | A thin sidebar component in this repo containing the existing header chrome, `<MessageList>`, `<PlanConfirmationWidget>`, and `<ChatInput>`.                                                 |
+| `ChatItem` (user/assistant rendering, thinking, tool calls)          | Library's `<UserMessage>`, `<AssistantMessage>`, `<ThinkingBlock>`, `<ToolCallBlock>` (consumed by `<MessageList>`'s default renderer; override via `renderToolCall` for our bespoke tools). |
+| Virtualiser + `expandedThoughts` + scroll-to-bottom in `ChatSidebar` | `<MessageList>` + `useAgent()`.                                                                                                                                                              |
+| `mentionUtils.ts` + segment/picker state                             | `<ChatInput mentions={{ items, buildPrompt }}>` from the library.                                                                                                                            |
+| `AgentContext` + `useAgentContext()`                                 | `<AgentProvider runner={...} agent={...} icons={...} onApprovalRequired={...}>` + `useAgent()`.                                                                                              |
+| Skill / approve-all + plan confirmation + custom approval routing    | `onApprovalRequired` callback returning `INLINE_APPROVAL` for inline cases; falling through to existing `<PlanConfirmationWidget>` modal for plan approvals.                                 |
 
 ## Implementation phases
 
@@ -36,7 +36,7 @@ Each phase is one issue, one PR against `feat/react-ui-migration`. They are sequ
 ### Phase 1 — Add deps + wire `<AgentProvider>` (replaces step 1+2 in #82)
 
 - Add `@mast-ai/react-ui` to `dependencies`.
-- Mount `<AgentProvider>` at the app root (`src/App.tsx` or a new `src/context/AgentProvider.tsx` shim) wired with: the existing `runner`/`agent` constructed from `DefaultAgentRunnerFactory`, the existing `usageCallback`, lucide icon overrides to keep current visuals, an `onApprovalRequired` that delegates to existing approve-all + plan-confirmation logic, and a `mentions` config built from `activeWorkspace.documents`.
+- Mount `<AgentProvider>` at the app root via a new `src/context/AgentProviderShim.tsx` wired with: the existing `runner`/`agent` constructed from `DefaultAgentRunnerFactory`, the existing `usageCallback`, lucide icon overrides to keep current visuals, and an `onApprovalRequired` that delegates to existing approve-all + plan-confirmation logic. The `mentions` config is a `<ChatInput>` prop and is wired in Phase 3, not here.
 - Keep `AgentContext` in place behind the new provider so the bespoke `ChatSidebar` continues to work. No UI change in this phase.
 - Acceptance: app builds, chat works exactly as before, `useAgent()` is callable from inside the provider.
 
@@ -68,7 +68,7 @@ Each phase is one issue, one PR against `feat/react-ui-migration`. They are sequ
 
 ## Non-obvious decisions
 
-- **`<AgentProvider>` first.** Phase 1 adds the new provider *underneath* the existing `AgentContext` so that subsequent phases can swap UI piecewise without ever leaving the app in a broken state. The two contexts coexist for phases 1–4.
+- **`<AgentProvider>` first.** Phase 1 adds the new provider _underneath_ the existing `AgentContext` so that subsequent phases can swap UI piecewise without ever leaving the app in a broken state. The two contexts coexist for phases 1–4.
 - **`PlanConfirmationWidget` stays.** It's a modal owned by this app's domain (plan-mode delegations) and is explicitly out of scope for `@mast-ai/react-ui`. Only the trigger path moves into `onApprovalRequired`.
 - **Tests as parity baseline.** `ChatSidebar.test.tsx` and `ChatItem.test.tsx` are kept until Phase 5. They exist to catch regressions during phases 2–4; they are deleted (not ported) in Phase 5 because the library has its own coverage for the equivalent behaviour.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mast-ai/built-in-ai": "^0.1.1",
         "@mast-ai/core": "^0.1.1",
         "@mast-ai/google-genai": "^0.1.1",
+        "@mast-ai/react-ui": "^0.1.1",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
@@ -880,6 +881,29 @@
       "dependencies": {
         "@google/genai": "^1.50.1",
         "@mast-ai/core": "^0.1.1"
+      }
+    },
+    "node_modules/@mast-ai/react-ui": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@mast-ai/react-ui/-/react-ui-0.1.1.tgz",
+      "integrity": "sha512-1ou9RpFVg8zQbpP58inA//9ZYx/kuDBE0XCnKCv4OPQKgEWsJ7oqMi/0OxXaO0qRICVmZnOeRNajAGOKLK/loQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@mast-ai/core": "^0.1.1",
+        "@tanstack/react-virtual": ">=3.0.0",
+        "react": ">=19.0.0",
+        "react-dom": ">=19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-markdown": {
+          "optional": true
+        },
+        "rehype-sanitize": {
+          "optional": true
+        },
+        "remark-gfm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@monaco-editor/loader": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mast-ai/built-in-ai": "^0.1.1",
     "@mast-ai/core": "^0.1.1",
     "@mast-ai/google-genai": "^0.1.1",
+    "@mast-ai/react-ui": "^0.1.1",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { AgentContextProvider } from "@/context/AgentContext";
+import { AgentProviderShim } from "@/context/AgentProviderShim";
 import { useEffect, useRef } from "react";
 
 function useIsMobile() {
@@ -332,8 +333,10 @@ function AppContent() {
 
 export default function App() {
   return (
-    <AgentContextProvider>
-      <AppContent />
-    </AgentContextProvider>
+    <AgentProviderShim>
+      <AgentContextProvider>
+        <AppContent />
+      </AgentContextProvider>
+    </AgentProviderShim>
   );
 }

--- a/src/context/AgentProviderShim.tsx
+++ b/src/context/AgentProviderShim.tsx
@@ -1,0 +1,211 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
+import {
+  AgentProvider,
+  INLINE_APPROVAL,
+  type OnApprovalRequired,
+  type IconMap,
+} from "@mast-ai/react-ui";
+import type { AgentConfig } from "@mast-ai/core";
+import { addAllBuiltInAITools } from "@mast-ai/built-in-ai";
+import {
+  Brain,
+  Wrench,
+  CircleCheck,
+  CircleX,
+  Ban,
+  Loader2,
+  Send,
+  Square,
+} from "lucide-react";
+import {
+  DefaultAgentRunnerFactory,
+  buildOrchestratorPrompt,
+} from "@/lib/agents";
+import type { EditorContext } from "@/lib/agents/tools/editor/context";
+import type { WorkspaceContext } from "@/lib/agents/tools/workspace/context";
+import { DelegateToSkillTool } from "@/lib/agents/tools/delegation/delegate_to_skill";
+import { createToolRegistry } from "@/lib/agents/tools/registries";
+import { registerDelegationTools } from "@/lib/agents/tools/delegation";
+import { useAgentConfig, useEditorUI } from "@/lib/store";
+import { useWorkspaces } from "@/lib/WorkspacesContext";
+
+const ICONS: IconMap = {
+  brain: <Brain className="w-4 h-4" />,
+  wrench: <Wrench className="w-4 h-4" />,
+  check: <CircleCheck className="w-4 h-4" />,
+  error: <CircleX className="w-4 h-4" />,
+  cancelled: <Ban className="w-4 h-4" />,
+  loader: <Loader2 className="w-4 h-4 animate-spin" />,
+  send: <Send className="w-4 h-4" />,
+  stop: <Square className="w-4 h-4" />,
+};
+
+export function AgentProviderShim({ children }: { children: ReactNode }) {
+  const { apiKey, modelName, skills, setTotalTokens } = useAgentConfig();
+  const {
+    setSuggestions,
+    approveAll,
+    activeTab,
+    editorContent,
+    editorInstance,
+    setPendingTabSwitchRequest,
+    setPendingWorkspaceAction,
+    setPendingPlanConfirmation,
+  } = useEditorUI();
+  const {
+    activeWorkspace,
+    activeDocument,
+    createDocumentWithTitle,
+    updateDocument,
+    deleteDocument,
+    setActiveDocumentId,
+  } = useWorkspaces();
+
+  const docsRef = useRef(activeWorkspace?.documents ?? []);
+  useEffect(() => {
+    docsRef.current = activeWorkspace?.documents ?? [];
+  }, [activeWorkspace]);
+
+  const activeDocRef = useRef<{ id: string; title: string } | null>(
+    activeDocument
+      ? { id: activeDocument.id, title: activeDocument.title }
+      : null,
+  );
+  useEffect(() => {
+    activeDocRef.current = activeDocument
+      ? { id: activeDocument.id, title: activeDocument.title }
+      : null;
+  }, [activeDocument]);
+
+  const editorInstanceRef = useRef(editorInstance);
+  useEffect(() => {
+    editorInstanceRef.current = editorInstance;
+  }, [editorInstance]);
+
+  const editorContentRef = useRef(editorContent);
+  useEffect(() => {
+    editorContentRef.current = editorContent;
+  }, [editorContent]);
+
+  const activeTabRef = useRef(activeTab);
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab]);
+
+  const approveAllRef = useRef(approveAll);
+  useEffect(() => {
+    approveAllRef.current = approveAll;
+  }, [approveAll]);
+
+  const requestTabSwitch = useCallback(
+    () =>
+      new Promise<boolean>((resolve) => {
+        setPendingTabSwitchRequest({ resolve });
+      }),
+    [setPendingTabSwitchRequest],
+  );
+
+  const editorCtx = useMemo<EditorContext>(
+    () => ({
+      editorRef: editorInstanceRef,
+      editorContentRef,
+      activeTabRef,
+      requestTabSwitch,
+      setSuggestions,
+      approveAllRef,
+    }),
+    [setSuggestions, requestTabSwitch],
+  );
+
+  const usageCallback = useCallback(
+    (usage: { totalTokenCount?: number }) =>
+      setTotalTokens((prev) => prev + (usage.totalTokenCount || 0)),
+    [setTotalTokens],
+  );
+
+  const factory = useMemo(
+    () =>
+      apiKey
+        ? new DefaultAgentRunnerFactory(apiKey, modelName, usageCallback)
+        : null,
+    [apiKey, modelName, usageCallback],
+  );
+
+  const workspaceCtx = useMemo<WorkspaceContext>(
+    () => ({
+      docsRef,
+      activeDocRef,
+      factory: factory ?? new DefaultAgentRunnerFactory("", ""),
+      createDocumentFn: (title) => createDocumentWithTitle(title),
+      renameDocumentFn: (id, title) => updateDocument(id, { title }),
+      deleteDocumentFn: (id) => deleteDocument(id),
+      setActiveDocumentIdFn: (id) => setActiveDocumentId(id),
+      saveDocContentFn: (id, content) => updateDocument(id, { content }),
+      editorRef: editorInstanceRef,
+      editorContentRef,
+      setPendingWorkspaceAction,
+      approveAllRef,
+    }),
+    [
+      factory,
+      createDocumentWithTitle,
+      updateDocument,
+      deleteDocument,
+      setActiveDocumentId,
+      setPendingWorkspaceAction,
+    ],
+  );
+
+  const registry = useMemo(() => {
+    if (!apiKey || !factory) return null;
+    // eslint-disable-next-line react-hooks/refs
+    const r = createToolRegistry(editorCtx, workspaceCtx);
+    addAllBuiltInAITools(r).catch(() => {});
+    r.register(new DelegateToSkillTool(factory, r.readOnly()));
+    registerDelegationTools(
+      r,
+      factory,
+      r.readOnly(),
+      // eslint-disable-next-line react-hooks/refs
+      workspaceCtx.docsRef,
+      setPendingPlanConfirmation,
+    );
+    return r;
+  }, [apiKey, factory, editorCtx, workspaceCtx, setPendingPlanConfirmation]);
+
+  const runner = useMemo(() => {
+    if (!factory || !registry) return null;
+    return factory.create({ tools: registry });
+  }, [factory, registry]);
+
+  const agent = useMemo<AgentConfig>(
+    () => ({
+      name: "EditorAssistant",
+      instructions: buildOrchestratorPrompt(skills),
+    }),
+    [skills],
+  );
+
+  const onApprovalRequired = useCallback<OnApprovalRequired>(
+    async () => (approveAllRef.current ? true : INLINE_APPROVAL),
+    [],
+  );
+
+  if (!runner) {
+    return <>{children}</>;
+  }
+
+  return (
+    <AgentProvider
+      runner={runner}
+      agent={agent}
+      icons={ICONS}
+      onApprovalRequired={onApprovalRequired}
+    >
+      {children}
+    </AgentProvider>
+  );
+}


### PR DESCRIPTION
Phase 1 of the migration tracked by #82. Adds `@mast-ai/react-ui` and mounts `<AgentProvider>` at the app root behind the existing bespoke `AgentContext`, with no UI change.

## Summary

- Add `@mast-ai/react-ui@^0.1.1` to `dependencies`.
- New `src/context/AgentProviderShim.tsx` mounts `<AgentProvider>` wired with:
  - a `runner` built from `DefaultAgentRunnerFactory` + the same tool registry the bespoke `AgentContext` builds (editor + workspace tools, built-in AI tools, `DelegateToSkillTool`, delegation tools);
  - an `agent` config (`{ name: 'EditorAssistant', instructions: buildOrchestratorPrompt(skills) }`);
  - lucide icon overrides for `brain`/`wrench`/`check`/`error`/`cancelled`/`loader`/`send`/`stop`;
  - an `onApprovalRequired` placeholder that returns `true` when approve-all is on, otherwise `INLINE_APPROVAL` (no UI consumes this in Phase 1; Phase 4 wires the real plan-confirmation routing).
  - When `apiKey` is unset, the shim falls through to plain `{children}` so `useAgent()` is unavailable but the rest of the app (API key dialog, workspace picker) still renders.
- `src/App.tsx` wraps `<AgentContextProvider>` (untouched) with `<AgentProviderShim>`.
- `docs/react-ui-migration/SPEC.md`: dropped the inaccurate `mentions={...}` prop on `<AgentProvider>` from the target-state row and Phase 1 description. `mentions` is a `<ChatInput>` prop and gets wired in Phase 3, not here.

## Notes

- The new wrapper is the long-term home for `<AgentProvider>` configuration. Phase 5 deletes the bespoke `AgentContext` and roughly halves the wrapper's contents.
- Both providers currently build their own runners (waste, but safe — only the bespoke side drives chat in Phase 1). This goes away in Phase 5.

## Test plan

- [x] `npm run lint` (0 errors, 9 pre-existing warnings)
- [x] `npm run build`
- [x] `npm run test` (293 passed)
- [x] `npm run format:check`
- [x] Manual: chat works exactly as before (streaming, thinking, tool calls, mentions, approve-all, plan confirmation, dark mode)

Closes #90.