### PR TITLE
feat: swap chat list to @mast-ai/react-ui <MessageList> (Phase 2)

### DIFF
--- a/src/components/ChatSidebar.test.tsx
+++ b/src/components/ChatSidebar.test.tsx
@@ -7,10 +7,40 @@ import { ChatSidebar } from "./ChatSidebar";
 import { AppProvider } from "@/lib/store";
 import { ThemeProvider } from "@/lib/ThemeProvider";
 import { WorkspacesProvider } from "@/lib/WorkspacesContext";
-import { useAgentContext } from "@/context/AgentContext";
-import type { StreamItem } from "@/lib/agents";
+import { useAgent } from "@mast-ai/react-ui";
+import type { ConversationEntry } from "@mast-ai/react-ui";
 
-vi.mock("@/context/AgentContext");
+// Stub MessageList because the real one uses its own bundled useAgent binding
+// that vi.mock cannot reach. The stub renders enough of the entry shape for
+// the smoke tests below.
+vi.mock("@mast-ai/react-ui", async () => {
+  const actual =
+    await vi.importActual<typeof import("@mast-ai/react-ui")>(
+      "@mast-ai/react-ui",
+    );
+  const useAgent = vi.fn();
+  function MessageList() {
+    const { messages } = useAgent() as { messages: ConversationEntry[] };
+    return (
+      <div>
+        {messages.map((m) => (
+          <div key={m.id}>
+            {m.text && <div>{m.text}</div>}
+            {m.thinking && <div>Thinking Process</div>}
+            {m.toolEvents?.map((t) => (
+              <div key={t.id}>{t.name}</div>
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return {
+    ...actual,
+    useAgent,
+    MessageList,
+  };
+});
 
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: (opts: {
@@ -31,31 +61,29 @@ vi.mock("@tanstack/react-virtual", () => ({
   }),
 }));
 
-function makeContext(
-  overrides: {
-    items?: StreamItem[];
-    isLoading?: boolean;
-    sendMessage?: (prompt: string, displayText?: string) => Promise<void>;
-    cancel?: () => void;
-  } = {},
-) {
+interface AgentMockOverrides {
+  messages?: ConversationEntry[];
+  isRunning?: boolean;
+  sendMessage?: (text: string, displayText?: string) => void;
+  cancel?: () => void;
+}
+
+function makeAgent(overrides: AgentMockOverrides = {}) {
   return {
-    items: overrides.items ?? [],
-    isLoading: overrides.isLoading ?? false,
-    sendMessage:
-      overrides.sendMessage ??
-      (vi.fn() as unknown as (
-        prompt: string,
-        displayText?: string,
-      ) => Promise<void>),
+    messages: overrides.messages ?? [],
+    history: [],
+    isRunning: overrides.isRunning ?? false,
+    sendMessage: overrides.sendMessage ?? (vi.fn() as () => void),
     cancel: overrides.cancel ?? (vi.fn() as () => void),
+    reset: vi.fn(),
+    pendingApprovals: [],
   };
 }
 
-function renderSidebar(
-  context: ReturnType<typeof makeContext> = makeContext(),
-) {
-  vi.mocked(useAgentContext).mockReturnValue(context);
+function renderSidebar(agent: ReturnType<typeof makeAgent> = makeAgent()) {
+  vi.mocked(useAgent).mockReturnValue(agent);
+  // The chat input is gated on apiKey; seed it before mount so handleSend runs.
+  localStorage.setItem("gemini_api_key", "test-key");
   return render(
     <ThemeProvider>
       <WorkspacesProvider>
@@ -99,43 +127,51 @@ describe("ChatSidebar", () => {
   it("calls sendMessage with the typed text on send", async () => {
     const user = userEvent.setup();
     const sendMessage = vi.fn();
-    renderSidebar(makeContext({ sendMessage }));
+    renderSidebar(makeAgent({ sendMessage }));
     await user.type(getInput(), "Hello AI");
     await user.click(screen.getByRole("button", { name: "Send" }));
     expect(sendMessage).toHaveBeenCalledWith("Hello AI", "Hello AI");
   });
 
-  it("shows cancel button while loading", () => {
-    renderSidebar(makeContext({ isLoading: true }));
+  it("shows cancel button while running", () => {
+    renderSidebar(makeAgent({ isRunning: true }));
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
   it("calls cancel when cancel button is clicked", async () => {
     const user = userEvent.setup();
     const cancel = vi.fn();
-    renderSidebar(makeContext({ isLoading: true, cancel }));
+    renderSidebar(makeAgent({ isRunning: true, cancel }));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(cancel).toHaveBeenCalled();
   });
 
-  it("renders a user message from items", () => {
+  it("renders a user message from messages", () => {
     renderSidebar(
-      makeContext({
-        items: [{ kind: "user", id: "u1", text: "Hello from user" }],
+      makeAgent({
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            text: "Hello from user",
+            toolEvents: [],
+            isStreaming: false,
+          },
+        ],
       }),
     );
     expect(screen.getByText("Hello from user")).toBeInTheDocument();
   });
 
-  it("renders an assistant message from items", () => {
+  it("renders an assistant message from messages", () => {
     renderSidebar(
-      makeContext({
-        items: [
+      makeAgent({
+        messages: [
           {
-            kind: "assistant",
             id: "a1",
+            role: "assistant",
             text: "Hello from assistant",
-            thought: "",
+            toolEvents: [],
             isStreaming: false,
           },
         ],
@@ -144,15 +180,16 @@ describe("ChatSidebar", () => {
     expect(screen.getByText("Hello from assistant")).toBeInTheDocument();
   });
 
-  it("renders a thinking section when thought is present", () => {
+  it("renders a thinking section when entry.thinking is present", () => {
     renderSidebar(
-      makeContext({
-        items: [
+      makeAgent({
+        messages: [
           {
-            kind: "assistant",
             id: "a1",
+            role: "assistant",
             text: "",
-            thought: "Thinking hard...",
+            thinking: "Thinking hard...",
+            toolEvents: [],
             isStreaming: true,
           },
         ],
@@ -161,10 +198,26 @@ describe("ChatSidebar", () => {
     expect(screen.getByText("Thinking Process")).toBeInTheDocument();
   });
 
-  it("renders a tool item from items", () => {
+  it("renders a tool call from messages", () => {
     renderSidebar(
-      makeContext({
-        items: [{ kind: "tool", id: "t1", name: "read", pending: false }],
+      makeAgent({
+        messages: [
+          {
+            id: "a1",
+            role: "assistant",
+            text: "",
+            toolEvents: [
+              {
+                id: "t1",
+                type: "tool_call_completed",
+                name: "read",
+                isStreaming: false,
+                status: "success",
+              },
+            ],
+            isStreaming: false,
+          },
+        ],
       }),
     );
     expect(screen.getByText("read")).toBeInTheDocument();

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -1,17 +1,21 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useCallback, useRef, useEffect, Fragment } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useState, useCallback, useRef, Fragment } from "react";
+import {
+  MessageList,
+  ToolCallBlock,
+  useAgent,
+  type ToolEventEntry,
+} from "@mast-ai/react-ui";
 import { Button } from "./ui/button";
 import { Switch } from "./ui/switch";
 import { Label } from "./ui/label";
 import { Settings, Wand2, Sun, Moon, X } from "lucide-react";
-import { useEditorUI } from "@/lib/store";
+import { useAgentConfig, useEditorUI } from "@/lib/store";
 import { useTheme } from "@/lib/ThemeProvider";
 import { useWorkspaces } from "@/lib/WorkspacesContext";
 import { SettingsDialog } from "./SettingsDialog";
 import { SkillsDialog } from "./SkillsDialog";
-import { ChatItem } from "./ChatItem";
 import { PlanConfirmationWidget } from "./PlanConfirmationWidget";
 import {
   DocRef,
@@ -19,20 +23,25 @@ import {
   buildPromptWithMentions,
   extractMentionQuery,
 } from "@/lib/mentionUtils";
-import { useAgentContext } from "@/context/AgentContext";
-import type { StreamItem } from "@/lib/agents";
+
+function renderToolCall(entry: ToolEventEntry) {
+  if (entry.name === "delegate_to_skill") {
+    const args = entry.args as { skillName?: string } | undefined;
+    if (args?.skillName) {
+      return <ToolCallBlock entry={{ ...entry, name: args.skillName }} />;
+    }
+  }
+  return <ToolCallBlock entry={entry} />;
+}
 
 export function ChatSidebar() {
-  const { items, isLoading, sendMessage, cancel } = useAgentContext();
+  const { messages, isRunning, sendMessage, cancel } = useAgent();
+  const { apiKey } = useAgentConfig();
 
   const [trailingInput, setTrailingInput] = useState("");
   const [segments, setSegments] = useState<Segment[]>([]);
-  const [expandedThoughts, setExpandedThoughts] = useState<Set<string>>(
-    new Set(),
-  );
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [pickerIndex, setPickerIndex] = useState(0);
-  const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [skillsOpen, setSkillsOpen] = useState(false);
@@ -50,57 +59,6 @@ export function ChatSidebar() {
             d.title.toLowerCase().includes(mentionQuery.toLowerCase()),
         )
       : [];
-
-  // Sync expandedThoughts with streaming assistant items.
-  const prevItemsRef = useRef<readonly StreamItem[]>([]);
-  useEffect(() => {
-    const prevItems = prevItemsRef.current;
-    prevItemsRef.current = items;
-    setExpandedThoughts((prev) => {
-      const next = new Set(prev);
-      for (const item of items) {
-        if (item.kind !== "assistant") continue;
-        const prevItem = prevItems.find((p) => p.id === item.id);
-        if (!prevItem && item.isStreaming) {
-          next.add(item.id);
-        } else if (
-          prevItem &&
-          prevItem.kind === "assistant" &&
-          prevItem.isStreaming &&
-          !item.isStreaming
-        ) {
-          next.delete(item.id);
-        }
-      }
-      return next;
-    });
-  }, [items]);
-
-  const virtualizer = useVirtualizer({
-    count: items.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => 80,
-    overscan: 5,
-  });
-
-  const scrollToBottom = useCallback(() => {
-    if (items.length > 0) {
-      virtualizer.scrollToIndex(items.length - 1, { align: "end" });
-    }
-  }, [items.length, virtualizer]);
-
-  useEffect(() => {
-    scrollToBottom();
-  }, [items, scrollToBottom]);
-
-  const toggleThought = (id: string) => {
-    setExpandedThoughts((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
 
   const selectDoc = (doc: DocRef) => {
     if (segments.some((s) => s.doc.id === doc.id)) return;
@@ -176,7 +134,7 @@ export function ChatSidebar() {
   const handleSend = () => {
     const displayText =
       segments.map((s) => `${s.text}@${s.doc.title}`).join("") + trailingInput;
-    if (!displayText.trim() || isLoading) return;
+    if (!displayText.trim() || isRunning || !apiKey) return;
 
     const prompt = buildPromptWithMentions(segments, trailingInput);
 
@@ -189,10 +147,16 @@ export function ChatSidebar() {
   };
 
   const canSend =
-    (trailingInput.trim().length > 0 || segments.length > 0) && !isLoading;
+    (trailingInput.trim().length > 0 || segments.length > 0) &&
+    !isRunning &&
+    !!apiKey;
 
   return (
-    <div className="flex flex-col h-full bg-muted/20 border-l">
+    <div
+      data-mast-root
+      data-mast-theme={theme}
+      className="flex flex-col h-full bg-muted/20 border-l"
+    >
       <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
       <SkillsDialog open={skillsOpen} onOpenChange={setSkillsOpen} />
       <div className="p-4 border-b flex justify-between items-center gap-4">
@@ -246,39 +210,13 @@ export function ChatSidebar() {
         </div>
       </div>
 
-      <div ref={scrollRef} className="flex-1 overflow-y-auto">
-        {items.length === 0 ? (
+      <div className="flex-1 min-h-0 flex flex-col">
+        {messages.length === 0 ? (
           <div className="text-sm text-muted-foreground italic text-center mt-4 p-4">
             Start a conversation with the editor assistant.
           </div>
         ) : (
-          <div
-            style={{
-              height: `${virtualizer.getTotalSize()}px`,
-              position: "relative",
-            }}
-          >
-            {virtualizer.getVirtualItems().map((vItem) => (
-              <div
-                key={vItem.key}
-                data-index={vItem.index}
-                ref={virtualizer.measureElement}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  transform: `translateY(${vItem.start}px)`,
-                  width: "100%",
-                  padding: "8px 16px",
-                }}
-              >
-                <ChatItem
-                  item={items[vItem.index]}
-                  isExpanded={expandedThoughts.has(items[vItem.index].id)}
-                  onToggle={toggleThought}
-                />
-              </div>
-            ))}
-          </div>
+          <MessageList renderToolCall={renderToolCall} />
         )}
       </div>
 
@@ -343,13 +281,13 @@ export function ChatSidebar() {
               value={trailingInput}
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
-              disabled={isLoading}
+              disabled={isRunning}
               className="w-full min-w-0 bg-transparent outline-none text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 resize-none overflow-hidden"
               aria-label="Chat input"
             />
           </div>
         </div>
-        {isLoading ? (
+        {isRunning ? (
           <Button variant="outline" onClick={cancel} className="min-h-11">
             Cancel
           </Button>

--- a/src/context/AgentProviderShim.tsx
+++ b/src/context/AgentProviderShim.tsx
@@ -4,11 +4,11 @@
 import { useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
 import {
   AgentProvider,
-  INLINE_APPROVAL,
   type OnApprovalRequired,
   type IconMap,
 } from "@mast-ai/react-ui";
-import type { AgentConfig } from "@mast-ai/core";
+import { AgentRunner } from "@mast-ai/core";
+import type { AgentConfig, LlmAdapter } from "@mast-ai/core";
 import { addAllBuiltInAITools } from "@mast-ai/built-in-ai";
 import {
   Brain,
@@ -31,6 +31,15 @@ import { createToolRegistry } from "@/lib/agents/tools/registries";
 import { registerDelegationTools } from "@/lib/agents/tools/delegation";
 import { useAgentConfig, useEditorUI } from "@/lib/store";
 import { useWorkspaces } from "@/lib/WorkspacesContext";
+
+// Fallback runner used while the user has no API key configured. Keeps
+// `<AgentProvider>` mounted so consumers can call `useAgent()` unconditionally;
+// the input is gated separately and will not invoke this adapter.
+const STUB_ADAPTER: LlmAdapter = {
+  generate: () =>
+    Promise.reject(new Error("API key required to run the agent.")),
+};
+const STUB_RUNNER = new AgentRunner(STUB_ADAPTER);
 
 const ICONS: IconMap = {
   brain: <Brain className="w-4 h-4" />,
@@ -177,7 +186,7 @@ export function AgentProviderShim({ children }: { children: ReactNode }) {
   }, [apiKey, factory, editorCtx, workspaceCtx, setPendingPlanConfirmation]);
 
   const runner = useMemo(() => {
-    if (!factory || !registry) return null;
+    if (!factory || !registry) return STUB_RUNNER;
     return factory.create({ tools: registry });
   }, [factory, registry]);
 
@@ -189,14 +198,14 @@ export function AgentProviderShim({ children }: { children: ReactNode }) {
     [skills],
   );
 
+  // Always proceed: tools that need user confirmation (edit, write, etc.) own
+  // their own bespoke approval flow today (Monaco suggestions, plan
+  // confirmation modal, workspace action dialogs). Phase 4 reroutes those
+  // flows through the library's inline approval queue.
   const onApprovalRequired = useCallback<OnApprovalRequired>(
-    async () => (approveAllRef.current ? true : INLINE_APPROVAL),
+    async () => true,
     [],
   );
-
-  if (!runner) {
-    return <>{children}</>;
-  }
 
   return (
     <AgentProvider

--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,38 @@ SPDX-License-Identifier: Apache-2.0
   }
 }
 
+/*
+ * Map @mast-ai/react-ui CSS custom properties to this app's Tailwind tokens
+ * so library components (MessageList, ToolCallBlock, ThinkingBlock, etc.)
+ * inherit the app's theme — including dark mode toggled via the `.dark` class
+ * on <html>. The selector list matches the library's so source-order
+ * tie-breaks in our favour (index.css is imported after styles.css).
+ */
+[data-mast-root],
+[data-mast-root][data-mast-theme="dark"],
+[data-mast-root][data-mast-theme="light"] {
+  --mast-bg: hsl(var(--background));
+  --mast-bg-subtle: hsl(var(--muted) / 0.2);
+  --mast-fg: hsl(var(--foreground));
+  --mast-fg-muted: hsl(var(--muted-foreground));
+  --mast-border: hsl(var(--border));
+  --mast-accent: hsl(var(--primary));
+  --mast-accent-fg: hsl(var(--primary-foreground));
+  --mast-thinking-bg: hsl(var(--muted));
+  --mast-thinking-fg: hsl(var(--muted-foreground));
+  --mast-tool-bg: hsl(var(--muted) / 0.4);
+  --mast-tool-fg: hsl(var(--muted-foreground));
+  --mast-tool-pending: hsl(var(--primary));
+  --mast-tool-error-bg: hsl(var(--destructive) / 0.1);
+  --mast-tool-error-fg: hsl(var(--destructive));
+  --mast-tool-cancelled-bg: hsl(var(--muted));
+  --mast-tool-cancelled-fg: hsl(var(--muted-foreground));
+  --mast-user-bubble: hsl(var(--primary));
+  --mast-user-fg: hsl(var(--primary-foreground));
+  --mast-mention-chip-bg: hsl(var(--primary) / 0.1);
+  --mast-mention-chip-fg: hsl(var(--primary));
+}
+
 .suggestion-delete {
   color: #ef4444 !important;
   text-decoration: line-through !important;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import "@mast-ai/react-ui/styles.css";
 import "./index.css";
 import { AppProvider } from "./lib/store";
 import { ThemeProvider } from "./lib/ThemeProvider";


### PR DESCRIPTION
Phase 2 of the migration tracked by #82. ChatSidebar now consumes \`useAgent()\` from the library and renders \`<MessageList>\` in place of the bespoke \`@tanstack/react-virtual\` list.

## Summary

- \`ChatSidebar\`:
  - Reads \`messages\`, \`isRunning\`, \`sendMessage\`, \`cancel\` from \`useAgent()\`.
  - Renders \`<MessageList renderToolCall={...}>\`; drops the \`useVirtualizer\`, \`expandedThoughts\`, scroll-to-bottom logic, and the \`ChatItem\` import.
  - Wraps the panel in \`<div data-mast-root data-mast-theme={theme}>\` so the library's CSS variables resolve.
  - Send is gated on \`apiKey\` so the stub runner is never invoked (see below).
  - Chip-based input, mention picker, \`<PlanConfirmationWidget>\`, settings/skills dialogs, theme toggle, approve-all switch are unchanged. Phase 3 swaps the input.
- \`AgentProviderShim\`:
  - Always mounts \`<AgentProvider>\` now, falling back to a stub \`AgentRunner\` when \`apiKey\` is unset, so \`useAgent()\` works unconditionally inside the tree.
  - \`onApprovalRequired\` returns \`true\` so the library's approval proxy proceeds and lets the existing bespoke approval flows run (Monaco suggestions for \`edit\`/\`write\`, the plan-confirmation modal for \`invoke_planner\`, the workspace-action dialog). Phase 4 reroutes those through the library's \`INLINE_APPROVAL\` queue.
- \`renderToolCall\`: minimal mapping that swaps the \`delegate_to_skill\` label for the actual skill name (from \`args.skillName\`).
- Library theme integration: \`src/index.css\` maps \`[data-mast-root]\` CSS custom properties onto this app's Tailwind tokens (\`--primary\`, \`--secondary\`, \`--muted\`, etc.), so library components inherit the app theme — including dark mode via the \`.dark\` class on \`<html>\`.
- \`src/main.tsx\` imports \`@mast-ai/react-ui/styles.css\`.

## Test changes

- \`ChatSidebar.test.tsx\` mocks \`useAgent\` and stubs \`<MessageList>\` (the real one's bundled \`useAgent\` binding cannot be reached by \`vi.mock\`). Same assertion intent with the library's \`ConversationEntry\` shape.
- \`ChatItem.tsx\` and \`ChatItem.test.tsx\` are untouched — kept as the Phase 5 parity baseline per SPEC.

## Known follow-ups

- andreban/mast-ai#78 — make \`<ToolCallBlock>\` collapsible (single outer toggle instead of separate args/result \`<details>\`). Today the library shows args/result summaries inline, which is noisier than the previous bespoke single-toggle UX. Will pick up the new prop in a small follow-up once it ships.

## Test plan

- [x] \`npm run lint\` (0 errors, 8 warnings — one fewer than Phase 1 since \`useVirtualizer\` is no longer used here)
- [x] \`npm run build\`
- [x] \`npm run test\` (293 passed)
- [x] \`npm run format:check\`
- [x] Manual: streaming, thinking, tool calls (incl. delegate_to_skill / invoke_*), mention picker, approve-all path, plan confirmation modal, dark mode, scroll behaviour, edit/write Monaco suggestions

Closes #91.