### PR TITLE
feat: adopt collapsible ToolCallBlock from @mast-ai/react-ui 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mast-ai/built-in-ai": "^0.1.1",
         "@mast-ai/core": "^0.1.1",
         "@mast-ai/google-genai": "^0.1.1",
-        "@mast-ai/react-ui": "^0.1.1",
+        "@mast-ai/react-ui": "^0.1.2",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
@@ -868,9 +868,9 @@
       }
     },
     "node_modules/@mast-ai/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@mast-ai/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-CZgjowvXushugW8EtQby7AfB+/4G6y0V9nVmkq6jFTXk6m2dYaZiVTGR21LvhFqf1t7Rd4EZ3qhharh1xhhHDg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@mast-ai/core/-/core-0.1.2.tgz",
+      "integrity": "sha512-MY34w7YwwD6MamWZh1B+v8muK8TCkG2AZwvrJRgkqLthbUTnhrKNRIlFIkCfoMAfUTpIB17IlFSnfFhoOXVIKw==",
       "license": "Apache-2.0"
     },
     "node_modules/@mast-ai/google-genai": {
@@ -884,12 +884,12 @@
       }
     },
     "node_modules/@mast-ai/react-ui": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@mast-ai/react-ui/-/react-ui-0.1.1.tgz",
-      "integrity": "sha512-1ou9RpFVg8zQbpP58inA//9ZYx/kuDBE0XCnKCv4OPQKgEWsJ7oqMi/0OxXaO0qRICVmZnOeRNajAGOKLK/loQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@mast-ai/react-ui/-/react-ui-0.1.2.tgz",
+      "integrity": "sha512-LYPm2SKL4c1MnSwu82/jf8uuLauK9P3SJ9ce01ZSUDD/u6E/2a0HQ9One0bq82EeKdKnGToWIeRS+qTzdX5jHQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@mast-ai/core": "^0.1.1",
+        "@mast-ai/core": "^0.1.2",
         "@tanstack/react-virtual": ">=3.0.0",
         "react": ">=19.0.0",
         "react-dom": ">=19.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mast-ai/built-in-ai": "^0.1.1",
     "@mast-ai/core": "^0.1.1",
     "@mast-ai/google-genai": "^0.1.1",
-    "@mast-ai/react-ui": "^0.1.1",
+    "@mast-ai/react-ui": "^0.1.2",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",


### PR DESCRIPTION
## Summary

- Bumps `@mast-ai/react-ui` from `^0.1.1` → `^0.1.2`. The new release ships built-in collapsibility for `<ToolCallBlock>` (single header toggle hiding sub-output / nested events / args / result), defaulting to `defaultOpen='streaming'` — open while streaming, collapsed once complete.
- No code changes in `renderToolCall` / `renderToolCallWithDocs`: the existing `<ToolCallBlock>` call picks up the new behavior automatically. No local CSS overrides existed that needed removing.
- Restores the single outer toggle UX of the previous bespoke `ChatItem` (deleted in Phase 5 of the migration).

Closes #104

## Test plan

- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` passes
- [x] `npm run test` passes (257/257)
- [x] Manual: completed tool calls collapse to just the header; streaming tool calls stay open until done.