### PR TITLE
feat: adopt renderApproval slot for workspace approval cards

### DIFF
--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -67,35 +67,33 @@ function WorkspaceApprovalCard({
   );
 }
 
-function renderToolCallWithDocs(docs: { id: string; title: string }[]) {
-  return (entry: ToolEventEntry, approval?: PendingApproval) => {
-    if (approval) {
-      const description = workspaceApprovalDescription(entry, docs);
-      if (description) {
-        return (
-          <WorkspaceApprovalCard
-            description={description}
-            approval={approval}
-          />
-        );
-      }
+function renderApprovalWithDocs(docs: { id: string; title: string }[]) {
+  return (entry: ToolEventEntry, approval: PendingApproval) => {
+    const description = workspaceApprovalDescription(entry, docs);
+    if (description) {
       return (
-        <InlineApproval
-          entry={entry}
-          approve={approval.approve}
-          reject={approval.reject}
-          respondWith={approval.respondWith}
-        />
+        <WorkspaceApprovalCard description={description} approval={approval} />
       );
     }
-    if (entry.name === "delegate_to_skill") {
-      const args = entry.args as { skillName?: string } | undefined;
-      if (args?.skillName) {
-        return <ToolCallBlock entry={{ ...entry, name: args.skillName }} />;
-      }
-    }
-    return <ToolCallBlock entry={entry} />;
+    return (
+      <InlineApproval
+        entry={entry}
+        approve={approval.approve}
+        reject={approval.reject}
+        respondWith={approval.respondWith}
+      />
+    );
   };
+}
+
+function renderToolCall(entry: ToolEventEntry) {
+  if (entry.name === "delegate_to_skill") {
+    const args = entry.args as { skillName?: string } | undefined;
+    if (args?.skillName) {
+      return <ToolCallBlock entry={{ ...entry, name: args.skillName }} />;
+    }
+  }
+  return <ToolCallBlock entry={entry} />;
 }
 
 // Prepend a "the user has referenced..." preamble so the LLM can use
@@ -128,9 +126,9 @@ export function ChatSidebar() {
     [activeWorkspace],
   );
 
-  const renderToolCall = useMemo(
+  const renderApproval = useMemo(
     () =>
-      renderToolCallWithDocs(
+      renderApprovalWithDocs(
         (activeWorkspace?.documents ?? []).map((d) => ({
           id: d.id,
           title: d.title,
@@ -204,7 +202,10 @@ export function ChatSidebar() {
             Start a conversation with the editor assistant.
           </div>
         ) : (
-          <MessageList renderToolCall={renderToolCall} />
+          <MessageList
+            renderToolCall={renderToolCall}
+            renderApproval={renderApproval}
+          />
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- Split workspace-approval rendering off the `renderToolCall` interception and into the dedicated `renderApproval` prop on `<MessageList>` (now exposed by `@mast-ai/react-ui` 0.2.0).
- `renderToolCall` is now focused on non-approval rendering — only the `delegate_to_skill` → skill name rewrite remains.
- Non-workspace approvals still fall through to the bundled `<InlineApproval>` from the new `renderApproval` slot, preserving existing behavior.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [x] Manual: workspace mutations (create / rename / delete document) show the friendly `WorkspaceApprovalCard` with Approve / Reject.
- [x] Manual: Approve All toggle still bypasses the prompt.
- [x] Manual: `delegate_to_skill` still renders with the skill name.
- [x] Manual: non-workspace tool calls falling through to `<InlineApproval>` still work.

Closes #101