### PR TITLE
refactor: adopt @mast-ai/core forwardTo() across delegation tools and role helpers

### DIFF
--- a/src/lib/agents/roles/researcher.ts
+++ b/src/lib/agents/roles/researcher.ts
@@ -3,8 +3,8 @@
 
 import {
   AgentConfig,
-  AgentEvent,
   AgentRunner,
+  ToolContext,
   ToolRegistry,
 } from "@mast-ai/core";
 import type { AgentRunnerFactory } from "./factory";
@@ -57,7 +57,7 @@ export async function runResearch(
   docs: WorkspaceDocument[],
   factory: AgentRunnerFactory,
   docIds?: string[],
-  onEvent?: (event: AgentEvent) => void,
+  parentContext?: ToolContext,
 ): Promise<ResearchResult> {
   const filteredDocs = docIds
     ? docs.filter((d) => docIds.includes(d.id))
@@ -81,7 +81,10 @@ export async function runResearch(
     let summary = "No relevant content.";
     let excerpt = "";
 
-    for await (const event of runner.runBuilder(agentConfig).runStream(input)) {
+    const builder = runner.runBuilder(agentConfig);
+    if (parentContext) builder.forwardTo(parentContext);
+
+    for await (const event of builder.runStream(input)) {
       if (event.type === "done") {
         try {
           const parsed = JSON.parse(event.output) as {
@@ -95,7 +98,6 @@ export async function runResearch(
         }
         break;
       }
-      onEvent?.(event);
     }
 
     docResults.push({ doc, summary, excerpt });
@@ -128,9 +130,10 @@ export async function runResearch(
 
   let finalSummary = "No relevant content found in workspace.";
 
-  for await (const event of synth
-    .runBuilder(synthConfig)
-    .runStream(synthInput)) {
+  const synthBuilder = synth.runBuilder(synthConfig);
+  if (parentContext) synthBuilder.forwardTo(parentContext);
+
+  for await (const event of synthBuilder.runStream(synthInput)) {
     if (event.type === "done") {
       try {
         const parsed = JSON.parse(event.output) as { summary: string };
@@ -141,7 +144,6 @@ export async function runResearch(
       }
       break;
     }
-    onEvent?.(event);
   }
 
   return { summary: finalSummary, sources };

--- a/src/lib/agents/roles/reviewer.test.ts
+++ b/src/lib/agents/roles/reviewer.test.ts
@@ -23,7 +23,11 @@ function makeFactory(output: string): {
     capturedPrompts.push(prompt);
     yield { type: "done" as const, output, history: [] };
   });
-  const mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
+  const mockRunBuilder = vi.fn().mockImplementation(() => {
+    const builder = { runStream: mockRunStream, forwardTo: vi.fn() };
+    builder.forwardTo.mockReturnValue(builder);
+    return builder;
+  });
   const mockCreate = vi.fn().mockReturnValue({ runBuilder: mockRunBuilder });
   return { factory: { create: mockCreate }, mockCreate, capturedPrompts };
 }

--- a/src/lib/agents/roles/reviewer.ts
+++ b/src/lib/agents/roles/reviewer.ts
@@ -3,8 +3,8 @@
 
 import {
   AgentConfig,
-  AgentEvent,
   AgentRunner,
+  ToolContext,
   ToolRegistry,
 } from "@mast-ai/core";
 import type { AgentRunnerFactory } from "./factory";
@@ -51,7 +51,7 @@ export async function runReview(
   text: string,
   criteria: string[],
   factory: AgentRunnerFactory,
-  onEvent?: (event: AgentEvent) => void,
+  parentContext?: ToolContext,
 ): Promise<ReviewResult> {
   const runner = createReviewerAgent(factory);
   const agentConfig: AgentConfig = {
@@ -62,7 +62,10 @@ export async function runReview(
 
   const prompt = buildReviewerPrompt(text, criteria);
 
-  for await (const event of runner.runBuilder(agentConfig).runStream(prompt)) {
+  const builder = runner.runBuilder(agentConfig);
+  if (parentContext) builder.forwardTo(parentContext);
+
+  for await (const event of builder.runStream(prompt)) {
     if (event.type === "done") {
       let result: ReviewResult;
       try {
@@ -83,7 +86,6 @@ export async function runReview(
       }
       return result;
     }
-    onEvent?.(event);
   }
 
   throw new Error("runReview: reviewer agent ended without a done event");

--- a/src/lib/agents/roles/writer.test.ts
+++ b/src/lib/agents/roles/writer.test.ts
@@ -19,7 +19,11 @@ function makeFactory(output: string = "draft output"): {
     capturedPrompts.push(prompt);
     yield { type: "done" as const, output, history: [] };
   });
-  const mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
+  const mockRunBuilder = vi.fn().mockImplementation(() => {
+    const builder = { runStream: mockRunStream, forwardTo: vi.fn() };
+    builder.forwardTo.mockReturnValue(builder);
+    return builder;
+  });
   const mockCreate = vi.fn().mockReturnValue({ runBuilder: mockRunBuilder });
   return { factory: { create: mockCreate }, mockCreate, capturedPrompts };
 }

--- a/src/lib/agents/roles/writer.ts
+++ b/src/lib/agents/roles/writer.ts
@@ -3,8 +3,8 @@
 
 import {
   AgentConfig,
-  AgentEvent,
   AgentRunner,
+  ToolContext,
   ToolRegistry,
 } from "@mast-ai/core";
 import type { AgentRunnerFactory } from "./factory";
@@ -52,7 +52,7 @@ export async function runWriter(
   factory: AgentRunnerFactory,
   researchContext?: ResearchResult,
   styleContext?: string,
-  onEvent?: (event: AgentEvent) => void,
+  parentContext?: ToolContext,
 ): Promise<string> {
   const runner = createWriterAgent(factory);
   const agentConfig: AgentConfig = {
@@ -63,11 +63,13 @@ export async function runWriter(
 
   const prompt = buildWriterPrompt(instruction, researchContext, styleContext);
 
-  for await (const event of runner.runBuilder(agentConfig).runStream(prompt)) {
+  const builder = runner.runBuilder(agentConfig);
+  if (parentContext) builder.forwardTo(parentContext);
+
+  for await (const event of builder.runStream(prompt)) {
     if (event.type === "done") {
       return event.output;
     }
-    onEvent?.(event);
   }
 
   throw new Error("runWriter: writer agent ended without a done event");

--- a/src/lib/agents/tools/delegation/delegate_to_skill.test.ts
+++ b/src/lib/agents/tools/delegation/delegate_to_skill.test.ts
@@ -8,6 +8,7 @@ import type { WorkspaceContext } from "../workspace/context";
 import { createToolRegistry } from "../registries";
 import { saveSkills } from "../../../skills";
 import type { AgentRunnerFactory } from "../../";
+import type { AgentEvent, ToolContext } from "@mast-ai/core";
 
 describe("DelegateToSkillTool", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,7 +38,25 @@ describe("DelegateToSkillTool", () => {
       getSelection: vi.fn().mockReturnValue(null),
     };
     mockRunStream = vi.fn().mockReturnValue(makeMockStream("done"));
-    mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
+    const callStream = mockRunStream as unknown as (
+      input: string,
+    ) => AsyncIterable<AgentEvent>;
+    mockRunBuilder = vi.fn().mockImplementation(() => {
+      let ctx: ToolContext | undefined;
+      const builder = {
+        forwardTo: vi.fn().mockImplementation((c: ToolContext) => {
+          ctx = c;
+          return builder;
+        }),
+        runStream: vi.fn().mockImplementation(async function* (input: string) {
+          for await (const event of callStream(input)) {
+            if (event.type !== "done") ctx?.onEvent?.(event);
+            yield event;
+          }
+        }),
+      };
+      return builder;
+    });
     mockFactory = {
       create: vi.fn().mockReturnValue({ runBuilder: mockRunBuilder }),
     };

--- a/src/lib/agents/tools/delegation/delegate_to_skill.ts
+++ b/src/lib/agents/tools/delegation/delegate_to_skill.ts
@@ -12,10 +12,13 @@ import type {
 import type { AgentRunnerFactory } from "../../";
 import { loadSkills } from "../../../skills";
 
+type RunBuilderLike = {
+  forwardTo(parentContext: ToolContext): RunBuilderLike;
+  runStream(input: string): AsyncIterable<AgentEvent>;
+};
+
 type RunnerLike = {
-  runBuilder: (agent: AgentConfig) => {
-    runStream: (input: string) => AsyncIterable<AgentEvent>;
-  };
+  runBuilder: (agent: AgentConfig) => RunBuilderLike;
 };
 
 interface DelegateToSkillArgs {
@@ -83,11 +86,11 @@ export class DelegateToSkillTool implements Tool<DelegateToSkillArgs, string> {
 
     for await (const event of childRunner
       .runBuilder(agentConfig)
+      .forwardTo(context)
       .runStream(task)) {
       if (event.type === "done") {
         return event.output;
       }
-      context.onEvent?.(event);
     }
     throw new Error("Child runner ended without a done event");
   }

--- a/src/lib/agents/tools/delegation/delegation.test.ts
+++ b/src/lib/agents/tools/delegation/delegation.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { registerDelegationTools } from "./index";
 import { ToolRegistry } from "@mast-ai/core";
 import type { AgentRunnerFactory } from "../../";
-import type { AgentEvent } from "@mast-ai/core";
+import type { AgentEvent, ToolContext } from "@mast-ai/core";
 import type { EditorContext } from "../editor/context";
 import type { WorkspaceContext } from "../workspace/context";
 import { createToolRegistry } from "../registries";
@@ -26,7 +26,25 @@ function makeFactory(mockRunStream: ReturnType<typeof vi.fn>): {
   mockCreate: ReturnType<typeof vi.fn>;
   mockRunBuilder: ReturnType<typeof vi.fn>;
 } {
-  const mockRunBuilder = vi.fn().mockReturnValue({ runStream: mockRunStream });
+  const callStream = mockRunStream as unknown as (
+    input: string,
+  ) => AsyncIterable<AgentEvent>;
+  const mockRunBuilder = vi.fn().mockImplementation(() => {
+    let ctx: ToolContext | undefined;
+    const builder = {
+      forwardTo: vi.fn().mockImplementation((c: ToolContext) => {
+        ctx = c;
+        return builder;
+      }),
+      runStream: vi.fn().mockImplementation(async function* (input: string) {
+        for await (const event of callStream(input)) {
+          if (event.type !== "done") ctx?.onEvent?.(event);
+          yield event;
+        }
+      }),
+    };
+    return builder;
+  });
   const mockCreate = vi.fn().mockReturnValue({ runBuilder: mockRunBuilder });
   return { factory: { create: mockCreate }, mockCreate, mockRunBuilder };
 }

--- a/src/lib/agents/tools/delegation/invoke_agent.ts
+++ b/src/lib/agents/tools/delegation/invoke_agent.ts
@@ -72,11 +72,11 @@ export class InvokeAgentTool implements Tool<InvokeAgentArgs, string> {
 
     for await (const event of runner
       .runBuilder(agentConfig)
+      .forwardTo(context)
       .runStream(args.task)) {
       if (event.type === "done") {
         return JSON.stringify({ result: event.output });
       }
-      context.onEvent?.(event);
     }
 
     throw new Error("invoke_agent: sub-agent ended without a done event");

--- a/src/lib/agents/tools/delegation/invoke_planner.ts
+++ b/src/lib/agents/tools/delegation/invoke_planner.ts
@@ -59,11 +59,9 @@ export class InvokePlannerTool implements Tool<InvokePlannerArgs, string> {
 
     for await (const event of runner
       .runBuilder(agentConfig)
+      .forwardTo(context)
       .runStream(prompt)) {
-      if (event.type !== "done") {
-        context.onEvent?.(event);
-        continue;
-      }
+      if (event.type !== "done") continue;
       let plan: Plan;
       try {
         plan = JSON.parse(event.output) as Plan;

--- a/src/lib/agents/tools/delegation/invoke_researcher.ts
+++ b/src/lib/agents/tools/delegation/invoke_researcher.ts
@@ -54,7 +54,7 @@ export class InvokeResearcherTool implements Tool<
       this.docsRef.current,
       this.factory,
       args.docIds,
-      context.onEvent,
+      context,
     );
     return JSON.stringify(result);
   }

--- a/src/lib/agents/tools/delegation/invoke_reviewer.ts
+++ b/src/lib/agents/tools/delegation/invoke_reviewer.ts
@@ -47,7 +47,7 @@ export class InvokeReviewerTool implements Tool<InvokeReviewerArgs, string> {
       args.text,
       args.criteria,
       this.factory,
-      context.onEvent,
+      context,
     );
     return JSON.stringify(result);
   }

--- a/src/lib/agents/tools/delegation/invoke_writer.ts
+++ b/src/lib/agents/tools/delegation/invoke_writer.ts
@@ -62,7 +62,7 @@ export class InvokeWriterTool implements Tool<InvokeWriterArgs, string> {
       this.factory,
       parsedResearch,
       args.styleContext,
-      context.onEvent,
+      context,
     );
     return JSON.stringify({ draft });
   }


### PR DESCRIPTION
## Summary

- Replaces hand-written sub-agent event forwarding (`for await … if (event.type !== "done") context.onEvent?.(event)`) with a single chained `forwardTo(context)` call across all six delegation tools and three role helpers. The library helper landed in `@mast-ai/core@0.2.0` (andreban/mast-ai#80).
- Role helpers (`runWriter`, `runResearch`, `runReview`) now accept an optional `ToolContext` instead of an `onEvent` callback, so they compose directly with `forwardTo`. Callers pass `context` through unchanged.
- Eliminates a class of silent-failure bug where omitting the manual forward broke sub-agent streaming without tripping any tests (caught only by manual UI testing during the original migration).

Closes #102

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run test` — 257 pass
- [x] `npm run format` — no changes
- [x] Manual: ran a multi-step task that triggers `invoke_writer` / `invoke_reviewer`; sub-thinking, sub-text, and nested tool calls still stream into the parent tool block.