### PR TITLE
refactor: adopt @mast-ai/react-ui getToolLabel slot for delegate_to_skill

### DIFF
--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -5,7 +5,6 @@ import {
   ChatInput,
   InlineApproval,
   MessageList,
-  ToolCallBlock,
   useAgent,
   type MentionItem,
   type MentionSegment,
@@ -86,14 +85,11 @@ function renderApprovalWithDocs(docs: { id: string; title: string }[]) {
   };
 }
 
-function renderToolCall(entry: ToolEventEntry) {
+function getToolLabel(entry: ToolEventEntry) {
   if (entry.name === "delegate_to_skill") {
-    const args = entry.args as { skillName?: string } | undefined;
-    if (args?.skillName) {
-      return <ToolCallBlock entry={{ ...entry, name: args.skillName }} />;
-    }
+    return (entry.args as { skillName?: string } | undefined)?.skillName;
   }
-  return <ToolCallBlock entry={entry} />;
+  return undefined;
 }
 
 // Prepend a "the user has referenced..." preamble so the LLM can use
@@ -203,7 +199,7 @@ export function ChatSidebar() {
           </div>
         ) : (
           <MessageList
-            renderToolCall={renderToolCall}
+            getToolLabel={getToolLabel}
             renderApproval={renderApproval}
           />
         )}


### PR DESCRIPTION
## Summary

- Replace the bespoke `renderToolCall` that spread/cloned `entry` to override its `name` with the new `<MessageList getToolLabel>` slot shipped in `@mast-ai/react-ui` 0.2.0 (upstream andreban/mast-ai#81).
- The relabel logic for `delegate_to_skill` collapses to a small resolver returning `args.skillName`; the `ToolCallBlock` import is no longer needed in `ChatSidebar.tsx`.
- `renderToolCall` only existed for this label rewrite (the `renderApproval` migration in #110 already split approvals out), so dropping it leaves `ChatSidebar` leaning fully on library primitives.

Closes #103

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (257 passed)
- [x] `npm run format`
- [x] Manual: `delegate_to_skill` calls in the chat sidebar render the target skill's name in the tool-call header rather than the literal `delegate_to_skill`; other tool calls (`read`, `edit`, etc.) continue to show their own names.