### PR TITLE
refactor: adopt @mast-ai/react-ui Tailwind/shadcn theme preset

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -62,38 +62,6 @@ SPDX-License-Identifier: Apache-2.0
   }
 }
 
-/*
- * Map @mast-ai/react-ui CSS custom properties to this app's Tailwind tokens
- * so library components (MessageList, ToolCallBlock, ThinkingBlock, etc.)
- * inherit the app's theme — including dark mode toggled via the `.dark` class
- * on <html>. The selector list matches the library's so source-order
- * tie-breaks in our favour (index.css is imported after styles.css).
- */
-[data-mast-root],
-[data-mast-root][data-mast-theme="dark"],
-[data-mast-root][data-mast-theme="light"] {
-  --mast-bg: hsl(var(--background));
-  --mast-bg-subtle: hsl(var(--muted) / 0.2);
-  --mast-fg: hsl(var(--foreground));
-  --mast-fg-muted: hsl(var(--muted-foreground));
-  --mast-border: hsl(var(--border));
-  --mast-accent: hsl(var(--primary));
-  --mast-accent-fg: hsl(var(--primary-foreground));
-  --mast-thinking-bg: hsl(var(--muted));
-  --mast-thinking-fg: hsl(var(--muted-foreground));
-  --mast-tool-bg: hsl(var(--muted) / 0.4);
-  --mast-tool-fg: hsl(var(--muted-foreground));
-  --mast-tool-pending: hsl(var(--primary));
-  --mast-tool-error-bg: hsl(var(--destructive) / 0.1);
-  --mast-tool-error-fg: hsl(var(--destructive));
-  --mast-tool-cancelled-bg: hsl(var(--muted));
-  --mast-tool-cancelled-fg: hsl(var(--muted-foreground));
-  --mast-user-bubble: hsl(var(--primary));
-  --mast-user-fg: hsl(var(--primary-foreground));
-  --mast-mention-chip-bg: hsl(var(--primary) / 0.1);
-  --mast-mention-chip-fg: hsl(var(--primary));
-}
-
 .suggestion-delete {
   color: #ef4444 !important;
   text-decoration: line-through !important;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "@mast-ai/react-ui/styles.css";
+import "@mast-ai/react-ui/themes/tailwind-shadcn.css";
 import "./index.css";
 import { AppProvider } from "./lib/store";
 import { ThemeProvider } from "./lib/ThemeProvider";


### PR DESCRIPTION
## Summary

- Replace the ~30-line hand-rolled `[data-mast-root]` token mapping in `src/index.css` with the upstream `@mast-ai/react-ui/themes/tailwind-shadcn.css` preset shipped in 0.2.0 (andreban/mast-ai#82).
- The preset is byte-equivalent to the previous local block — same tokens, same triple-selector specificity trick — so visuals are unchanged.
- Imported in `src/main.tsx` between the library's base `styles.css` and our app's `index.css` so source-order ordering still lets app-level overrides win if we ever add deltas.

Closes #105

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (257 passed)
- [x] `npm run format`
- [x] Manual: every library component (user bubble, assistant bubble, thinking block, tool call block, mention chip, mention picker, send/cancel buttons) matches the previous theme in both light and dark mode; the in-app dark/light toggle swap is clean (no FOUC, no leftover light-mode tokens).