### PR TITLE
refactor: drop STUB_RUNNER now that AgentProvider accepts nullable runner

### DIFF
--- a/src/context/AgentProviderShim.tsx
+++ b/src/context/AgentProviderShim.tsx
@@ -8,8 +8,7 @@ import {
   type OnApprovalRequired,
   type IconMap,
 } from "@mast-ai/react-ui";
-import { AgentRunner } from "@mast-ai/core";
-import type { AgentConfig, LlmAdapter } from "@mast-ai/core";
+import type { AgentConfig } from "@mast-ai/core";
 import { addAllBuiltInAITools } from "@mast-ai/built-in-ai";
 import {
   Brain,
@@ -32,15 +31,6 @@ import { createToolRegistry } from "@/lib/agents/tools/registries";
 import { registerDelegationTools } from "@/lib/agents/tools/delegation";
 import { useAgentConfig, useEditorUI } from "@/lib/store";
 import { useWorkspaces } from "@/lib/WorkspacesContext";
-
-// Fallback runner used while the user has no API key configured. Keeps
-// `<AgentProvider>` mounted so consumers can call `useAgent()` unconditionally;
-// the input is gated separately and will not invoke this adapter.
-const STUB_ADAPTER: LlmAdapter = {
-  generate: () =>
-    Promise.reject(new Error("API key required to run the agent.")),
-};
-const STUB_RUNNER = new AgentRunner(STUB_ADAPTER);
 
 const ICONS: IconMap = {
   brain: <Brain className="w-4 h-4" />,
@@ -183,7 +173,7 @@ export function AgentProviderShim({ children }: { children: ReactNode }) {
   }, [apiKey, factory, editorCtx, workspaceCtx, setPendingPlanConfirmation]);
 
   const runner = useMemo(() => {
-    if (!factory || !registry) return STUB_RUNNER;
+    if (!factory || !registry) return null;
     return factory.create({ tools: registry });
   }, [factory, registry]);
 


### PR DESCRIPTION
## Summary

- `@mast-ai/react-ui` 0.2.0 (andreban/mast-ai#84) lets `<AgentProvider>` accept `runner: AgentRunner | null`. The provider mounts cleanly with `runner={null}`, `useAgent()` returns disabled-state defaults, and `<ChatInput>` greys out automatically.
- Drop the local `STUB_ADAPTER` / `STUB_RUNNER` and the `AgentRunner` / `LlmAdapter` imports — they existed only to keep the provider mounted before an API key was set, and the stub was never actually invoked.
- The `runner` memo now returns `null` when `factory` or `registry` is missing.

Closes #107

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (257 passed)
- [x] `npm run format`
- [x] Manual: launched the app with no API key — chat sidebar mounts cleanly, `<ChatInput>` is greyed out, no console errors. Entered a key — chat activates without remount and the agent responds end-to-end.