### PR TITLE
fix: re-wire WebMCP and surface async-registered tools

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -215,7 +215,7 @@ Computes and applies inline diff decorations to the Monaco editor for a pending 
 
 ### `WebMCPTools.ts`
 
-Registers all editor and workspace tools with `navigator.modelContext` (WebMCP API), allowing external browser agents to drive the editor. Mirrors the `EditorTools` and `WorkspaceTools` registrations so both the built-in agent and external agents share the same capabilities.
+Bridges a `ToolRegistry` to `navigator.modelContext` (WebMCP API) so external browser agents can drive the editor. `registerWebMCPTools(registry)` subscribes to the registry's `tool-registered` / `tool-unregistered` events and registers each tool with WebMCP using a per-tool `AbortController` (the abort signal is how WebMCP unregisters). Tools that join the registry asynchronously (built-in AI tools after browser availability checks, delegation tools when an API key is configured) are picked up automatically; the returned cleanup aborts every controller and removes both listeners. If `registerTool` throws (e.g. an older WebMCP shape without `unregisterTool`), the bridge logs a warning and tears down without retrying.
 
 ### `EditorPanel.tsx`
 
@@ -253,8 +253,8 @@ A dialog for creating, editing, and deleting custom skills.
 The main entry point:
 
 - Manages global state (API key, selected model, active suggestions, "approve all" toggle, skills).
-- Wires `EditorTools` and `WorkspaceTools` into the `ToolRegistry`, passing the Monaco editor ref and a snapshot ref of `WorkspacesContext.activeWorkspace.documents` respectively.
-- Registers `WebMCPTools` for external browser agent access.
+- Wires editor and workspace tools into the `ToolRegistry` (via `AgentProviderShim`), passing the Monaco editor ref and a snapshot ref of `WorkspacesContext.activeWorkspace.documents` respectively.
+- `AgentProviderShim` exposes the live registry to external browser agents via `registerWebMCPTools` (see `WebMCPTools.ts`), independent of API-key configuration.
 - Dynamically constructs `AgentConfig.systemInstructions`: appends skill names/descriptions and workspace tool guidance.
 - Renders `WorkspacePicker` when no workspace is active, or the editor layout (`WorkspacePanel` + `EditorPanel` + `ChatSidebar`) when a workspace is open.
 - Handles responsive layout (desktop collapsible split-pane vs. mobile bottom-sheet).

--- a/src/context/AgentProviderShim.tsx
+++ b/src/context/AgentProviderShim.tsx
@@ -29,6 +29,7 @@ import type { WorkspaceContext } from "@/lib/agents/tools/workspace/context";
 import { DelegateToSkillTool } from "@/lib/agents/tools/delegation/delegate_to_skill";
 import { createToolRegistry } from "@/lib/agents/tools/registries";
 import { registerDelegationTools } from "@/lib/agents/tools/delegation";
+import { registerWebMCPTools } from "@/lib/WebMCPTools";
 import { useAgentConfig, useEditorUI } from "@/lib/store";
 import { useWorkspaces } from "@/lib/WorkspacesContext";
 
@@ -155,25 +156,45 @@ export function AgentProviderShim({ children }: { children: ReactNode }) {
     ],
   );
 
-  const registry = useMemo(() => {
-    if (!apiKey || !factory) return null;
+  const registry = useMemo(
     // eslint-disable-next-line react-hooks/refs
-    const r = createToolRegistry(editorCtx, workspaceCtx);
-    addAllBuiltInAITools(r).catch(() => {});
-    r.register(new DelegateToSkillTool(factory, r.readOnly()));
+    () => createToolRegistry(editorCtx, workspaceCtx),
+    [editorCtx, workspaceCtx],
+  );
+
+  // Built-ins resolve asynchronously based on browser availability, so they
+  // land in the registry after the initial render. The listener-based WebMCP
+  // bridge picks them up via `tool-registered` events.
+  useEffect(() => {
+    addAllBuiltInAITools(registry).catch(() => {});
+  }, [registry]);
+
+  // Mirror the live registry into navigator.modelContext so external WebMCP
+  // agents can drive the editor regardless of internal-agent configuration.
+  useEffect(() => registerWebMCPTools(registry), [registry]);
+
+  useEffect(() => {
+    if (!factory) return;
+    registry.register(new DelegateToSkillTool(factory, registry.readOnly()));
     registerDelegationTools(
-      r,
+      registry,
       factory,
-      r.readOnly(),
-      // eslint-disable-next-line react-hooks/refs
+      registry.readOnly(),
       workspaceCtx.docsRef,
       setPendingPlanConfirmation,
     );
-    return r;
-  }, [apiKey, factory, editorCtx, workspaceCtx, setPendingPlanConfirmation]);
+    return () => {
+      registry.unregister("delegate_to_skill");
+      registry.unregister("invoke_agent");
+      registry.unregister("invoke_planner");
+      registry.unregister("invoke_researcher");
+      registry.unregister("invoke_writer");
+      registry.unregister("invoke_reviewer");
+    };
+  }, [registry, factory, workspaceCtx, setPendingPlanConfirmation]);
 
   const runner = useMemo(() => {
-    if (!factory || !registry) return null;
+    if (!factory) return null;
     return factory.create({ tools: registry });
   }, [factory, registry]);
 

--- a/src/lib/WebMCPTools.test.ts
+++ b/src/lib/WebMCPTools.test.ts
@@ -103,6 +103,23 @@ describe("registerWebMCPTools", () => {
     warnSpy.mockRestore();
   });
 
+  it("stops registering after the first registerTool throw", () => {
+    let calls = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (navigator as any).modelContext = {
+      registerTool: vi.fn(() => {
+        calls += 1;
+        throw new TypeError("broken");
+      }),
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerWebMCPTools(
+      createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()),
+    );
+    expect(calls).toBe(1);
+    warnSpy.mockRestore();
+  });
+
   it("returns a no-op cleanup when navigator.modelContext is undefined", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (navigator as any).modelContext;
@@ -150,14 +167,43 @@ describe("registerWebMCPTools", () => {
     }
   });
 
-  it("cleanup aborts the shared signal", () => {
+  it("cleanup aborts every registered signal", () => {
     const cleanup = registerWebMCPTools(
       createToolRegistry(makeEditorCtx(), makeWorkspaceCtx()),
     );
-    const signal = registeredTools.get("read")!.signal!;
-    expect(signal.aborted).toBe(false);
+    const signals = [...registeredTools.values()].map((e) => e.signal!);
+    expect(signals.length).toBeGreaterThan(0);
+    expect(signals.every((s) => !s.aborted)).toBe(true);
     cleanup();
-    expect(signal.aborted).toBe(true);
+    expect(signals.every((s) => s.aborted)).toBe(true);
+  });
+
+  it("registers tools added to the registry after subscription", () => {
+    const registry = createToolRegistry(makeEditorCtx(), makeWorkspaceCtx());
+    registerWebMCPTools(registry);
+    const initialCount = registeredTools.size;
+    const lateTool = {
+      definition: () => ({
+        name: "late_tool",
+        description: "registered after subscription",
+        parameters: { type: "object", properties: {} },
+        scope: "read" as const,
+      }),
+      call: vi.fn().mockResolvedValue("late result"),
+    };
+    registry.register(lateTool);
+    expect(registeredTools.size).toBe(initialCount + 1);
+    expect(registeredTools.has("late_tool")).toBe(true);
+  });
+
+  it("unregistering from the registry aborts only that tool's signal", () => {
+    const registry = createToolRegistry(makeEditorCtx(), makeWorkspaceCtx());
+    registerWebMCPTools(registry);
+    const readSignal = registeredTools.get("read")!.signal!;
+    const editSignal = registeredTools.get("edit")!.signal!;
+    registry.unregister("edit");
+    expect(editSignal.aborted).toBe(true);
+    expect(readSignal.aborted).toBe(false);
   });
 
   it("read execute returns editor content", async () => {

--- a/src/lib/WebMCPTools.ts
+++ b/src/lib/WebMCPTools.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ToolProvider } from "@mast-ai/core";
+import type { Tool, ToolDefinition, ToolRegistry } from "@mast-ai/core";
 
 interface WebMCPTool {
   name: string;
@@ -20,19 +20,27 @@ declare global {
   }
 }
 
-export function registerWebMCPTools(provider: ToolProvider): () => void {
+// We need the listener API on top of ToolProvider.
+type ListenableRegistry = Pick<ToolRegistry, "getTools" | "getTool"> &
+  Pick<ToolRegistry, "addEventListener" | "removeEventListener">;
+
+export function registerWebMCPTools(registry: ListenableRegistry): () => void {
   if (!navigator.modelContext) {
     console.warn("WebMCP not detected in this browser.");
     return () => {};
   }
 
-  const controller = new AbortController();
-  const { signal } = controller;
   const mc = navigator.modelContext;
+  const controllers = new Map<string, AbortController>();
+  let teardown = false;
 
-  try {
-    for (const def of provider.getTools()) {
-      const tool = provider.getTool(def.name)!;
+  const registerOne = (def: ToolDefinition): boolean => {
+    if (teardown) return true;
+    if (controllers.has(def.name)) return true;
+    const tool = registry.getTool(def.name);
+    if (!tool) return true;
+    const ac = new AbortController();
+    try {
       mc.registerTool(
         {
           name: def.name,
@@ -40,13 +48,44 @@ export function registerWebMCPTools(provider: ToolProvider): () => void {
           inputSchema: def.parameters,
           execute: (args) => tool.call(args as never, {}) as Promise<string>,
         },
-        { signal },
+        { signal: ac.signal },
       );
+      controllers.set(def.name, ac);
+      return true;
+    } catch (err) {
+      console.warn("WebMCP tool registration failed:", err);
+      cleanup();
+      return false;
     }
-  } catch (err) {
-    console.warn("WebMCP tool registration failed:", err);
-    return () => {};
+  };
+
+  const onRegistered = ({ tool }: { tool: Tool }) => {
+    registerOne(tool.definition());
+  };
+
+  const onUnregistered = ({ name }: { name: string }) => {
+    const ac = controllers.get(name);
+    if (ac) {
+      ac.abort();
+      controllers.delete(name);
+    }
+  };
+
+  const cleanup = () => {
+    if (teardown) return;
+    teardown = true;
+    registry.removeEventListener("tool-registered", onRegistered);
+    registry.removeEventListener("tool-unregistered", onUnregistered);
+    for (const ac of controllers.values()) ac.abort();
+    controllers.clear();
+  };
+
+  registry.addEventListener("tool-registered", onRegistered);
+  registry.addEventListener("tool-unregistered", onUnregistered);
+
+  for (const def of registry.getTools()) {
+    if (!registerOne(def)) break;
   }
 
-  return () => controller.abort();
+  return cleanup;
 }


### PR DESCRIPTION
## Summary

- `registerWebMCPTools` was orphaned in d3a2b23 (the `AgentContext` delete) — nothing has called it since, so `navigator.modelContext` has been empty. Even before that, the one-shot `getTools()` snapshot missed `addAllBuiltInAITools` (async) and the delegation tools (registered behind the API-key gate).
- Switched the bridge to the `ToolRegistry` listener API: subscribe to `tool-registered` / `tool-unregistered` and register each tool with WebMCP using a per-tool `AbortController`, so the full live tool surface — editor, workspace, async built-ins, delegation when an API key is configured — is mirrored automatically.
- Restructured `AgentProviderShim` so a single registry is built up over time instead of being gated behind the API key: registry creation is unconditional, `addAllBuiltInAITools` runs in a `useEffect`, `registerWebMCPTools` runs in a `useEffect`, and `DelegateToSkillTool` + `registerDelegationTools` register in a factory-keyed effect with cleanup that `unregister`s each by name when the key goes away.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (252 passing, including new coverage for late registration, per-tool unregistration abort, cleanup aborting every signal, and early-bail on `registerTool` throw)
- [x] Manual: confirmed `navigator.modelContext.registerTool` is called for editor + workspace tools at startup, again for built-ins as they resolve, and again for delegation tools when an API key is set