### PR TITLE
chore: refresh model list with current Gemini IDs

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -79,7 +79,7 @@ This document outlines the phased implementation strategy for the AI Agent Text 
 
 **Goal:** Make the application usable across sessions and transparent about usage.
 
-- [x] Update state management to sync the API key and selected model (default: `gemini-2.5-flash`) with `localStorage`.
+- [x] Update state management to sync the API key and selected model (default: `gemini-3.1-flash-lite`) with `localStorage`.
 - [x] Create a "Settings" UI (modal or sidebar tab) to manage credentials and model selection.
 - [x] Update `GoogleGenAIAdapter` to capture `usageMetadata`.
 - [x] Add a UI element to display cumulative session token usage.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -169,7 +169,7 @@ Implements `LlmAdapter` interface:
 - Handles tool calls and streaming text/thought deltas from the model.
 - Captures `thoughtSignature` from function call parts for correct turn attribution.
 - Enables thinking mode (`ThinkingLevel.HIGH`) by default.
-- Instantiated with the user's selected model name (e.g., `gemini-3.1-flash-lite-preview`).
+- Instantiated with the user's selected model name (e.g., `gemini-3.1-flash-lite`).
 
 ### `EditorTools.ts`
 

--- a/docs/multi-agent/PHASE-E.md
+++ b/docs/multi-agent/PHASE-E.md
@@ -147,7 +147,7 @@ The planning quality eval suite. Runs with `npm run evals`.
 **Setup:**
 
 - Reads `GEMINI_API_KEY` and `GEMINI_MODEL` from `process.env` in a `beforeAll`. Calls `vi.skipAllTests()` with a message if the key is absent — keeps the suite skipped rather than failing when no key is available.
-- Creates a `GoogleGenAIAdapter` with the API key and the resolved model (`GEMINI_MODEL ?? "gemini-3.1-flash-lite-preview"`). This single adapter instance is shared: passed to `judge()` for scoring and used directly to construct `new AgentRunner(adapter, new ToolRegistry())` for running the planner. No factory needed.
+- Creates a `GoogleGenAIAdapter` with the API key and the resolved model (`GEMINI_MODEL ?? "gemini-3.1-flash-lite"`). This single adapter instance is shared: passed to `judge()` for scoring and used directly to construct `new AgentRunner(adapter, new ToolRegistry())` for running the planner. No factory needed.
 
 **Per-fixture tests (parameterized with `it.each`):**
 

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -40,7 +40,7 @@ describe("SettingsDialog", () => {
   });
 
   it("renders API key input and model selector when open", () => {
-    mockStore("test-key", "gemini-2.5-flash");
+    mockStore("test-key", "gemini-3.1-flash-lite");
     renderDialog(true);
 
     expect(screen.getByLabelText("Gemini API Key")).toBeInTheDocument();
@@ -48,7 +48,7 @@ describe("SettingsDialog", () => {
   });
 
   it("does not render content when closed", () => {
-    mockStore("test-key", "gemini-2.5-flash");
+    mockStore("test-key", "gemini-3.1-flash-lite");
     renderDialog(false);
 
     expect(screen.queryByLabelText("Gemini API Key")).not.toBeInTheDocument();
@@ -57,7 +57,7 @@ describe("SettingsDialog", () => {
   it("saves API key and model when Save is clicked", async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
-    mockStore("old-key", "gemini-2.5-flash");
+    mockStore("old-key", "gemini-3.1-flash-lite");
 
     renderDialog(true, onOpenChange);
 
@@ -66,19 +66,19 @@ describe("SettingsDialog", () => {
     await user.type(keyInput, "new-key");
 
     const modelSelect = screen.getByLabelText("Model");
-    await user.selectOptions(modelSelect, "gemini-2.5-pro");
+    await user.selectOptions(modelSelect, "gemini-3.5-flash");
 
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(mockSetApiKey).toHaveBeenCalledWith("new-key");
-    expect(mockSetModelName).toHaveBeenCalledWith("gemini-2.5-pro");
+    expect(mockSetModelName).toHaveBeenCalledWith("gemini-3.5-flash");
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("does not update store when Cancel is clicked", async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
-    mockStore("old-key", "gemini-2.5-flash");
+    mockStore("old-key", "gemini-3.1-flash-lite");
 
     renderDialog(true, onOpenChange);
 
@@ -91,7 +91,7 @@ describe("SettingsDialog", () => {
 
   it("toggles API key visibility when eye button is clicked", async () => {
     const user = userEvent.setup();
-    mockStore("test-key", "gemini-2.5-flash");
+    mockStore("test-key", "gemini-3.1-flash-lite");
 
     renderDialog(true);
 
@@ -107,7 +107,7 @@ describe("SettingsDialog", () => {
 
   it("resets draft values to current store values when reopened", () => {
     const onOpenChange = vi.fn();
-    mockStore("stored-key", "gemini-2.5-pro");
+    mockStore("stored-key", "gemini-3.5-flash");
 
     const { rerender } = render(
       <ThemeProvider>
@@ -127,13 +127,13 @@ describe("SettingsDialog", () => {
     const modelSelect = screen.getByLabelText("Model") as HTMLSelectElement;
 
     expect(keyInput.value).toBe("stored-key");
-    expect(modelSelect.value).toBe("gemini-2.5-pro");
+    expect(modelSelect.value).toBe("gemini-3.5-flash");
   });
 
   it("sets API key to null when saved with empty input", async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
-    mockStore("old-key", "gemini-2.5-flash");
+    mockStore("old-key", "gemini-3.1-flash-lite");
 
     renderDialog(true, onOpenChange);
 

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -17,14 +17,8 @@ import { Label } from "@/components/ui/label";
 import { useAgentConfig } from "@/lib/store";
 
 const MODELS = [
-  { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
-  { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
-  {
-    id: "gemini-3.1-flash-lite-preview",
-    label: "Gemini 3.1 Flash Lite (Preview)",
-  },
-  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro (Preview)" },
-  { id: "gemini-3-flash-preview", label: "Gemini 3 Flash (Preview)" },
+  { id: "gemini-3.1-flash-lite", label: "Gemini 3.1 Flash Lite" },
+  { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash" },
   { id: "gemma-4-26b-a4b-it", label: "Gemma 4 26B A4B IT" },
   { id: "gemma-4-31b-it", label: "Gemma 4 31B IT" },
 ];

--- a/src/components/SkillsDialog.test.tsx
+++ b/src/components/SkillsDialog.test.tsx
@@ -24,7 +24,7 @@ function mockStore(skills: Skill[]) {
   vi.spyOn(storeModule, "useAgentConfig").mockReturnValue({
     apiKey: "test-key",
     setApiKey: vi.fn(),
-    modelName: "gemini-2.5-flash",
+    modelName: "gemini-3.1-flash-lite",
     setModelName: vi.fn(),
     totalTokens: 0,
     setTotalTokens: vi.fn(),

--- a/src/lib/agents/evals/planning.eval.ts
+++ b/src/lib/agents/evals/planning.eval.ts
@@ -14,7 +14,7 @@ const PLANNING_CRITERIA =
   "dependsOn: []. Redundant or empty steps are absent.";
 
 const apiKey = process.env.GEMINI_API_KEY;
-const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite-preview";
+const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite";
 
 describe.skipIf(!apiKey)("planning quality", () => {
   let adapter: GoogleGenAIAdapter;

--- a/src/lib/agents/evals/reviewing.eval.ts
+++ b/src/lib/agents/evals/reviewing.eval.ts
@@ -15,7 +15,7 @@ const REVIEWING_CRITERIA =
   "clear overall verdict. Output is valid ReviewResult JSON with no prose outside it.";
 
 const apiKey = process.env.GEMINI_API_KEY;
-const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite-preview";
+const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite";
 
 describe.skipIf(!apiKey)("reviewing quality", () => {
   let adapter: GoogleGenAIAdapter;

--- a/src/lib/agents/evals/routing.eval.ts
+++ b/src/lib/agents/evals/routing.eval.ts
@@ -8,7 +8,7 @@ import { buildOrchestratorPrompt } from "./roles/orchestrator";
 import fixtures from "./fixtures/routing.json";
 
 const apiKey = process.env.GEMINI_API_KEY;
-const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite-preview";
+const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite";
 
 describe.skipIf(!apiKey)("orchestrator routing", () => {
   let adapter: GoogleGenAIAdapter;

--- a/src/lib/agents/evals/writing.eval.ts
+++ b/src/lib/agents/evals/writing.eval.ts
@@ -16,7 +16,7 @@ const WRITING_CRITERIA =
   "formatting match it. Markdown fences are absent unless the content itself is markdown.";
 
 const apiKey = process.env.GEMINI_API_KEY;
-const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite-preview";
+const modelName = process.env.GEMINI_MODEL ?? "gemini-3.1-flash-lite";
 
 describe.skipIf(!apiKey)("writing quality", () => {
   let adapter: GoogleGenAIAdapter;

--- a/src/lib/agents/tools/delegation/delegate_to_skill.test.ts
+++ b/src/lib/agents/tools/delegation/delegate_to_skill.test.ts
@@ -193,7 +193,7 @@ describe("DelegateToSkillTool", () => {
         name: "Proofreader",
         description: "d",
         instructions: "i",
-        model: "gemini-2.5-pro",
+        model: "gemini-3.5-flash",
       },
     ]);
     const customRunnerFactory = vi
@@ -207,7 +207,7 @@ describe("DelegateToSkillTool", () => {
     await tool.call({ skillName: "Proofreader", task: "t" }, {});
     expect(customRunnerFactory).toHaveBeenCalledWith(
       expect.anything(),
-      "gemini-2.5-pro",
+      "gemini-3.5-flash",
     );
   });
 

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -67,7 +67,7 @@ describe("skills storage", () => {
       name: "A",
       description: "d",
       instructions: "i",
-      model: "gemini-2.5-pro",
+      model: "gemini-3.5-flash",
     };
     const withoutModel: Skill = {
       id: "b",
@@ -77,7 +77,7 @@ describe("skills storage", () => {
     };
     saveSkills([withModel, withoutModel]);
     const loaded = loadSkills();
-    expect(loaded[0].model).toBe("gemini-2.5-pro");
+    expect(loaded[0].model).toBe("gemini-3.5-flash");
     expect(loaded[1].model).toBeUndefined();
   });
 });

--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -93,9 +93,14 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
     localStorage.getItem("gemini_api_key"),
   );
   const [modelName, setModelName] = useState<string>(() => {
-    const saved = localStorage.getItem("gemini_model_name");
-    if (saved === "gemini-2.0-flash") return "gemini-3.1-flash-lite-preview";
-    return saved || "gemini-3.1-flash-lite-preview";
+    let saved = localStorage.getItem("gemini_model_name");
+    if (
+      saved === "gemini-2.0-flash" ||
+      saved === "gemini-3.1-flash-lite-preview"
+    ) {
+      saved = null;
+    }
+    return saved || "gemini-3.1-flash-lite";
   });
   const [totalTokens, setTotalTokens] = useState<number>(0);
   const [skills, setSkillsState] = useState<Skill[]>(() => initializeSkills());


### PR DESCRIPTION
## Summary

- Replace deprecated Gemini IDs in the Settings dropdown with `gemini-3.1-flash-lite` and `gemini-3.5-flash`; keep both Gemma entries.
- Migrate legacy `gemini-3.1-flash-lite-preview` (and the existing `gemini-2.0-flash`) values out of `localStorage` on load so returning users land on the new default.
- Align eval defaults (`planning`, `reviewing`, `routing`, `writing`) and docs (`SPEC.md`, `IMPLEMENTATION_PLAN.md`, `multi-agent/PHASE-E.md`) with the new IDs.
- Update test fixtures in `SettingsDialog.test.tsx`, `SkillsDialog.test.tsx`, `skills.test.ts`, and `delegate_to_skill.test.ts` that still referenced retired IDs — `SettingsDialog.test.tsx` would otherwise fail because the selected option no longer exists in the dropdown.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run format\`
- [x] \`npm run build\`
- [x] \`npm run test\` (252 passed)
- [x] Manual: Settings dropdown shows the new four-model list; selecting each value persists; legacy \`gemini-3.1-flash-lite-preview\` value in localStorage is migrated to the new default on load.